### PR TITLE
OSGi support #4

### DIFF
--- a/chronicle/pom.xml
+++ b/chronicle/pom.xml
@@ -23,6 +23,7 @@
     <groupId>net.openhft</groupId>
     <artifactId>chronicle</artifactId>
     <version>2.0.2-SNAPSHOT</version>
+    <packaging>bundle</packaging>
 
     <name>OpenHTF/Java-Chronicle</name>
     <description>Java library for persisted low latency messaging (Java 6+)</description>


### PR DESCRIPTION
Added  `<packaging>bundle</packaging>` to chronicle/pom.xml

Results:

```
chronicle (346)
---------------
Manifest-Version = 1.0
Bnd-LastModified = 1380264407470
Tool = Bnd-1.50.0
Built-By = c300125
Build-Jdk = 1.7.0_40
Created-By = Apache Maven Bundle Plugin

Bundle-Name = chronicle
Bundle-Description = Java library for persisted low latency messaging (Java 6+)
Bundle-SymbolicName = net.openhft.chronicle
Bundle-Version = 2.0.2.SNAPSHOT
Bundle-License = http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion = 2

Import-Package = 
    net.openhft.lang;version="[6.0,7)",
    net.openhft.lang.io;version="[6.0,7)",
    net.openhft.lang.thread;version="[6.0,7)",
    sun.misc,
    sun.nio.ch
Export-Package = 
    net.openhft.chronicle;uses:="net.openhft.lang.io,sun.nio.ch,sun.misc,net.openhft.lang,net.openhft.lang.thread";version=2.0.2.SNAPSHOT,
    net.openhft.chronicle.tcp;uses:="net.openhft.chronicle,net.openhft.chronicle.tools,net.openhft.lang.thread";version=2.0.2.SNAPSHOT,
    net.openhft.chronicle.tools;uses:="net.openhft.chronicle,net.openhft.lang.io";version=2.0.2.SNAPSHOT
```
