### PR TITLE
InProcessChronicleSource can now exit accept() loop #35

### DIFF
--- a/chronicle/src/main/java/net/openhft/chronicle/tcp/InProcessChronicleSource.java
+++ b/chronicle/src/main/java/net/openhft/chronicle/tcp/InProcessChronicleSource.java
@@ -29,10 +29,14 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Set;
+import java.util.Iterator;
 
 /**
  * A Chronicle as a service to be replicated to any number of clients.  Clients can restart from where ever they are up
@@ -51,6 +55,7 @@ public class InProcessChronicleSource implements Chronicle {
     @NotNull
     private final Chronicle chronicle;
     private final ServerSocketChannel server;
+    private final Selector selector;
     @NotNull
     private final String name;
     @NotNull
@@ -66,6 +71,9 @@ public class InProcessChronicleSource implements Chronicle {
         server = ServerSocketChannel.open();
         server.socket().setReuseAddress(true);
         server.socket().bind(new InetSocketAddress(port));
+	server.configureBlocking(false);
+        selector = Selector.open();
+	server.register(selector, SelectionKey.OP_ACCEPT);
         name = chronicle.name() + "@" + port;
         logger = Logger.getLogger(getClass().getName() + "." + name);
         service = Executors.newCachedThreadPool(new NamedThreadFactory(name, true));
@@ -75,7 +83,6 @@ public class InProcessChronicleSource implements Chronicle {
     private void pauseReset() {
         lastUnpausedNS = System.nanoTime();
     }
-
     protected void pause() {
         if (lastUnpausedNS + busyWaitTimeNS > System.nanoTime())
             return;
@@ -133,9 +140,13 @@ public class InProcessChronicleSource implements Chronicle {
         try {
             chronicle.close();
             server.close();
+            service.shutdownNow();
+	    service.awaitTermination(10000, java.util.concurrent.TimeUnit.MILLISECONDS);
         } catch (IOException e) {
             logger.warning("Error closing server port " + e);
-        }
+        } catch (InterruptedException ie) {
+            logger.warning("Error shutting down service threads " + ie);
+	}
     }
 
     public ChronicleConfig config() {
@@ -148,14 +159,23 @@ public class InProcessChronicleSource implements Chronicle {
             Thread.currentThread().setName(name + "-acceptor");
             try {
                 while (!closed) {
-                    SocketChannel socket = server.accept();
-                    service.execute(new Handler(socket));
+		    selector.select();
+		    Set<SelectionKey> keys = selector.keys();
+		    for(Iterator<SelectionKey> i = keys.iterator(); i.hasNext(); ) {
+			SelectionKey key = i.next();
+			if (key.isAcceptable()) {
+			    SocketChannel socket = server.accept();
+			    socket.configureBlocking(true);
+			    service.execute(new Handler(socket));
+			}
+		    }
                 }
             } catch (IOException e) {
                 if (!closed)
                     logger.log(Level.SEVERE, "Acceptor dying", e);
             } finally {
                 service.shutdown();
+		logger.log(Level.INFO, "Acceptor loop ended");
             }
         }
     }


### PR DESCRIPTION
Fixes #35

Acceptor is now modified to use non-blocking IO to avoid leaked threads and sockets.
