### PR TITLE
VanillaChronicle fixes

### DIFF
--- a/chronicle-sandbox/src/main/java/net/openhft/chronicle/sandbox/VanillaDataCache.java
+++ b/chronicle-sandbox/src/main/java/net/openhft/chronicle/sandbox/VanillaDataCache.java
@@ -91,10 +91,11 @@ public class VanillaDataCache implements Closeable {
 
     public VanillaFile dataForLast(int cycle, int threadId) throws IOException {
         String cycleStr = dateCache.formatFor(cycle);
-        String dataPrefix = basePath + "/" + cycleStr + "/data-" + threadId + "-";
+        String cyclePath = basePath + "/" + cycleStr;
+        String dataPrefix = "data-" + threadId + "-";
         if (lastCycle != cycle) {
             int maxCount = 0;
-            File[] files = new File(dataPrefix).listFiles();
+            File[] files = new File(cyclePath).listFiles();
             if (files != null)
                 for (File file : files) {
                     if (file.getName().startsWith(dataPrefix)) {

--- a/chronicle-sandbox/src/main/java/net/openhft/chronicle/sandbox/VanillaIndexCache.java
+++ b/chronicle-sandbox/src/main/java/net/openhft/chronicle/sandbox/VanillaIndexCache.java
@@ -79,9 +79,10 @@ public class VanillaIndexCache implements Closeable {
         return lastIndexFile(cycle,0);
     }
 
-    int lastIndexFile(int cycle,int defaultCycle) {
+    int lastIndexFile(int cycle, int defaultCycle) {
         int maxIndex = -1;
-        File[] files = new File(basePath,dateCache.formatFor(cycle)).listFiles();
+        File cyclePath = new File(baseFile, dateCache.formatFor(cycle));
+        File[] files = cyclePath.listFiles();
         if (files != null) {
             for (File file : files) {
                 String name = file.getName();
@@ -99,18 +100,35 @@ public class VanillaIndexCache implements Closeable {
     public VanillaFile append(int cycle, long indexValue, boolean synchronous) throws IOException {
         for (int indexCount = lastIndexFile(cycle,0); indexCount < 10000; indexCount++) {
             VanillaFile file = indexFor(cycle, indexCount, true);
-            NativeBytes bytes = file.bytes();
-            while (bytes.remaining() >= 8) {
-                if (bytes.compareAndSwapLong(bytes.position(), 0L, indexValue)) {
-                    if (synchronous)
-                        file.force();
-                    return file;
-                }
-                bytes.position(bytes.position() + 8);
-            }
+            if (append(file, indexValue, synchronous))
+                return file;
             file.decrementUsage();
         }
         throw new AssertionError();
+    }
+
+    public static boolean append(final VanillaFile vanillaFile, final long indexValue, final boolean synchronous) {
+
+        // Position can be changed by another thread, so take a snapshot each loop so that
+        // buffer overflows are not generated when advancing to the next position.
+        // As a result, the position could step backwards when this method is called concurrently,
+        // but the compareAndSwapLong call ensures that data is never overwritten.
+
+        final NativeBytes bytes = vanillaFile.bytes();
+        boolean endOfFile = false;
+        while (!endOfFile) {
+            final long position = bytes.position();
+            endOfFile = (bytes.limit() - position) < 8;
+            if (!endOfFile) {
+                if (bytes.compareAndSwapLong(position, 0L, indexValue)) {
+                    if (synchronous)
+                        vanillaFile.force();
+                    return true;
+                }
+                bytes.position(position + 8);
+            }
+        }
+        return false;
     }
 
     public long firstIndex() {

--- a/chronicle-sandbox/src/test/java/net/openhft/chronicle/sandbox/TestTaskExecutionUtil.java
+++ b/chronicle-sandbox/src/test/java/net/openhft/chronicle/sandbox/TestTaskExecutionUtil.java
@@ -1,0 +1,73 @@
+package net.openhft.chronicle.sandbox;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Utility methods for executing tests using threads.
+ */
+public final class TestTaskExecutionUtil {
+
+    /**
+     * Ensure no instances of this utility class.
+     */
+    private TestTaskExecutionUtil() {
+    }
+
+    /**
+     * Execute specified tasks in independent threads.
+     */
+    public static void executeConcurrentTasks(final List<? extends Callable<Void>> tasks, final long taskTimeoutMillis) {
+
+        // Create and start a thread per task
+        final List<TaskRunner> taskRunners = new ArrayList<TaskRunner>();
+        final List<Thread> threads = new ArrayList<Thread>();
+        for (Callable<Void> task : tasks) {
+            final TaskRunner taskRunner = new TaskRunner(task);
+            taskRunners.add(taskRunner);
+            final Thread thread = new Thread(taskRunner, task.toString());
+            threads.add(thread);
+
+            thread.start();
+        }
+
+        // Wait for all tasks to finish
+        try {
+            for (Thread thread : threads) {
+                thread.join(taskTimeoutMillis);
+            }
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+
+        // Fail if any tasks failed
+        for (TaskRunner taskRunner : taskRunners) {
+            taskRunner.assertIfFailed();
+        }
+    }
+
+    private static class TaskRunner implements Runnable {
+        private final Callable<?> task;
+        private volatile AssertionError failure;
+
+        public TaskRunner(final Callable<?> task) {
+            this.task = task;
+        }
+
+        @Override
+        public void run() {
+            try {
+                task.call();
+            } catch (Throwable e) {
+                failure = new AssertionError("Task failed", e);
+            }
+        }
+
+        public void assertIfFailed() {
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+}

--- a/chronicle-sandbox/src/test/java/net/openhft/chronicle/sandbox/VanillaIndexCacheTest.java
+++ b/chronicle-sandbox/src/test/java/net/openhft/chronicle/sandbox/VanillaIndexCacheTest.java
@@ -17,8 +17,16 @@
 package net.openhft.chronicle.sandbox;
 
 import org.junit.Test;
-
 import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+
+import net.openhft.lang.io.IOTools;
+import net.openhft.lang.io.NativeBytes;
 
 import static org.junit.Assert.*;
 
@@ -61,4 +69,112 @@ public class VanillaIndexCacheTest {
         assertTrue(file0.getParentFile().delete());
         file0.getParentFile().getParentFile().delete();
     }
+
+    @Test
+    public void testLastIndexFile() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "testLastIndexFile");
+        IOTools.deleteDir(dir.getAbsolutePath());
+
+        DateCache dateCache = new DateCache("yyyyMMddHHmmss", 1000);
+        VanillaIndexCache cache = new VanillaIndexCache(dir.getAbsolutePath(), 10 + 3, dateCache);
+
+        int cycle = (int) (System.currentTimeMillis() / 1000);
+
+        // Check that the index file count starts at 0 when the data directory is empty
+        assertEquals(0, cache.lastIndexFile(cycle));
+
+        VanillaFile vanillaFile0 = cache.indexFor(cycle, 0, true);
+        assertEquals("index-0", vanillaFile0.file().getName());
+        vanillaFile0.decrementUsage();
+        assertEquals(0, cache.lastIndexFile(cycle));
+
+        VanillaFile vanillaFile1 = cache.indexFor(cycle, 1, true);
+        assertEquals("index-1", vanillaFile1.file().getName());
+        assertEquals(1, cache.lastIndexFile(cycle));
+
+        VanillaFile vanillaFile3 = cache.indexFor(cycle, 3, true);
+        assertEquals("index-3", vanillaFile3.file().getName());
+        assertEquals(3, cache.lastIndexFile(cycle));
+
+        IOTools.deleteDir(dir.getAbsolutePath());
+    }
+
+    @Test
+    public void testConcurrentAppend() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "testConcurrentAppend");
+        IOTools.deleteDir(dir.getAbsolutePath());
+
+        DateCache dateCache = new DateCache("yyyyMMddHHmmss", 1000);
+
+        // Use a small index file size so that the test frequently generates new index files
+        VanillaIndexCache cache = new VanillaIndexCache(dir.getAbsolutePath(), 5, dateCache);
+
+        int cycle = (int) (System.currentTimeMillis() / 1000);
+        final int numberOfTasks = 2;
+        final int countPerTask = 1000;
+
+        // Create tasks that append to the index
+        final List<Callable<Void>> tasks = new ArrayList<Callable<Void>>();
+        long nextValue = countPerTask;
+        for (int i = 0; i < numberOfTasks; i++) {
+            final long endValue = nextValue + countPerTask;
+            tasks.add(createAppendTask(cache, cycle, nextValue, endValue));
+            nextValue = endValue;
+        }
+
+        // Execute tasks using a thread per task
+        TestTaskExecutionUtil.executeConcurrentTasks(tasks, 30000L);
+
+        // Verify that all values can be read back from the index
+        final Set<Long> indexValues = readAllIndexValues(cache, cycle);
+        assertEquals(createRangeSet(countPerTask, nextValue), indexValues);
+
+        cache.close();
+        IOTools.deleteDir(dir.getAbsolutePath());
+    }
+
+    private Set<Long> readAllIndexValues(final VanillaIndexCache cache, final int cycle) throws IOException {
+        final Set<Long> indexValues = new TreeSet<Long>();
+        for (int i = 0; i <= cache.lastIndexFile(cycle); i++) {
+            final VanillaFile vanillaFile = cache.indexFor(cycle, i, false);
+            indexValues.addAll(readAllIndexValues(vanillaFile));
+            vanillaFile.decrementUsage();
+        }
+        return indexValues;
+    }
+
+    private Set<Long> readAllIndexValues(final VanillaFile vanillaFile) {
+        final Set<Long> indexValues = new TreeSet<Long>();
+        final NativeBytes bytes = vanillaFile.bytes();
+        bytes.position(0);
+        while (bytes.remaining() >= 8) {
+            indexValues.add(bytes.readLong());
+        }
+        return indexValues;
+    }
+
+    private static Set<Long> createRangeSet(final long start, final long end) {
+        final Set<Long> values = new TreeSet<Long>();
+        long counter = start;
+        while (counter < end) {
+            values.add(counter);
+            counter++;
+        }
+        return values;
+    }
+
+    private Callable<Void> createAppendTask(final VanillaIndexCache cache, final int cycle, final long startValue, final long endValue) {
+        return new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                long counter = startValue;
+                while (counter < endValue) {
+                    cache.append(cycle, counter, false);
+                    counter++;
+                }
+                return null;
+            }
+        };
+    }
+
 }


### PR DESCRIPTION
- Fix for concurrent append in VanillaIndexCache
  Concurrent access to the append method was causing
  a buffer overflow failure because the position was being
  incremented by another thread after the check for end of file.
- Fix for VanillaIndexCache.lastIndexFile
  lastIndexFile method was not listing existing index files
- Fix for VanillaDataCacheTest.testDataForLast
  VanillaDataCache was not listing existing files
- Unit tests for VanillaTailer reading across cycles
