### PR TITLE
Corrected support for ChronicleReader from-index argument

### DIFF
--- a/chronicle/src/main/java/net/openhft/chronicle/tools/ChronicleReader.java
+++ b/chronicle/src/main/java/net/openhft/chronicle/tools/ChronicleReader.java
@@ -42,8 +42,7 @@ enum ChronicleReader {
         ExcerptTailer excerpt = ic.createTailer();
         //noinspection InfiniteLoopStatement
         while (true) {
-            while (!excerpt.nextIndex())
-                //noinspection BusyWait
+            while (!excerpt.index(index))
                 Thread.sleep(50);
             System.out.print(index + ": ");
             int nullCount = 0;


### PR DESCRIPTION
Unsure if support was intentionally broken at SHA: b131e630a48abf8da6750532c0fd6ba14f2f8774
