### PR TITLE
Allow 24bit thread id in VanillaChronicle

### DIFF
--- a/chronicle/src/main/java/net/openhft/chronicle/VanillaChronicle.java
+++ b/chronicle/src/main/java/net/openhft/chronicle/VanillaChronicle.java
@@ -16,6 +16,10 @@
 
 package net.openhft.chronicle;
 
+import static net.openhft.chronicle.VanillaChronicleConfig.INDEX_DATA_OFFSET_BITS;
+import static net.openhft.chronicle.VanillaChronicleConfig.INDEX_DATA_OFFSET_MASK;
+import static net.openhft.chronicle.VanillaChronicleConfig.THREAD_ID_MASK;
+
 import net.openhft.affinity.AffinitySupport;
 import net.openhft.lang.Maths;
 import net.openhft.lang.io.IOTools;
@@ -274,8 +278,8 @@ public class VanillaChronicle implements Chronicle {
                 if (indexValue == 0) {
                     return false;
                 }
-                int threadId = (int) (indexValue >>> 48);
-                long dataOffset0 = indexValue & (-1L >>> -48);
+                int threadId = (int) (indexValue >>> INDEX_DATA_OFFSET_BITS);
+                long dataOffset0 = indexValue & INDEX_DATA_OFFSET_MASK;
                 int dataCount = (int) (dataOffset0 >>> dataBlockSizeBits);
                 int dataOffset = (int) (dataOffset0 & dataBlockSizeMask);
                 if (lastThreadId != threadId || lastDataCount != dataCount || indexFileChange) {
@@ -478,7 +482,7 @@ public class VanillaChronicle implements Chronicle {
             try {
                 appenderCycle = cycle;
                 appenderThreadId = AffinitySupport.getThreadId();
-                assert (appenderThreadId & 0xFFFF) == appenderThreadId : "appenderThreadId: " + appenderThreadId;
+                assert (appenderThreadId & THREAD_ID_MASK) == appenderThreadId : "appenderThreadId: " + appenderThreadId;
                 if (appenderCycle != lastCycle || appenderThreadId != lastThreadId) {
                     if (appenderFile != null) {
                         appenderFile.decrementUsage();
@@ -532,7 +536,7 @@ public class VanillaChronicle implements Chronicle {
             // position of the start not the end.
             int offset = (int) (startAddr - appenderFile.baseAddr());
             long dataOffset = appenderFile.indexCount() * config.dataBlockSize() + offset;
-            long indexValue = ((long) appenderThreadId << 48) + dataOffset;
+            long indexValue = ((long) appenderThreadId << INDEX_DATA_OFFSET_BITS) + dataOffset;
             lastWrittenIndex = indexValue;
             try {
                 final boolean appendDone = (lastIndexFile != null) && VanillaIndexCache.append(lastIndexFile, indexValue, nextSynchronous);

--- a/chronicle/src/main/java/net/openhft/chronicle/VanillaChronicleConfig.java
+++ b/chronicle/src/main/java/net/openhft/chronicle/VanillaChronicleConfig.java
@@ -23,6 +23,28 @@ public class VanillaChronicleConfig {
 
     public static final long MIN_CYCLE_LENGTH = TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS);
 
+    /**
+     * Number of most-significant bits used to hold the thread id in index entries.
+     * The remaining least-significant bits of the index entry are used for the data offset info.
+     */
+    public static final int THREAD_ID_BITS = 24;
+
+    /**
+     * Mask used to validate that the thread id does not exceed the allocated number of bits.
+     */
+    public static final long THREAD_ID_MASK = -1L >>> -THREAD_ID_BITS;
+
+    /**
+     * Number of least-significant bits used to hold the data offset info in index entries.
+     */
+    public static final int INDEX_DATA_OFFSET_BITS = 64 - THREAD_ID_BITS;
+
+    /**
+     * Mask used to extract the data offset info from an index entry.
+     */
+    public static final long INDEX_DATA_OFFSET_MASK = -1L >>> -INDEX_DATA_OFFSET_BITS;
+
+
     private String cycleFormat = "yyyyMMdd";
     private int cycleLength = 24 * 60 * 60 * 1000; // MILLIS_PER_DAY
     private long indexBlockSize = 16L << 20; // 16 MB


### PR DESCRIPTION
Thread id was previously restricted to 16 bits which
caused failures in some environments.
Under linux the max pid can be set using the setting
/proc/sys/kernel/pid_max
