### PR TITLE
Remove thread id from VanillaChronicle

### DIFF
--- a/chronicle/src/main/java/net/openhft/chronicle/VanillaChronicleConfig.java
+++ b/chronicle/src/main/java/net/openhft/chronicle/VanillaChronicleConfig.java
@@ -23,6 +23,28 @@ public class VanillaChronicleConfig {
 
     public static final long MIN_CYCLE_LENGTH = TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS);
 
+    /**
+     * Number of most-significant bits used to hold the appender id in index entries.
+     * The remaining least-significant bits of the index entry are used for the data offset info.
+     */
+    public static final int APPENDER_ID_BITS = 24;
+
+    /**
+     * Mask used to validate that the appender id does not exceed the allocated number of bits.
+     */
+    public static final long APPENDER_ID_MASK = -1L >>> -APPENDER_ID_BITS;
+
+    /**
+     * Number of least-significant bits used to hold the data offset info in index entries.
+     */
+    public static final int INDEX_DATA_OFFSET_BITS = 64 - APPENDER_ID_BITS;
+
+    /**
+     * Mask used to extract the data offset info from an index entry.
+     */
+    public static final long INDEX_DATA_OFFSET_MASK = -1L >>> -INDEX_DATA_OFFSET_BITS;
+
+
     private String cycleFormat = "yyyyMMdd";
     private int cycleLength = 24 * 60 * 60 * 1000; // MILLIS_PER_DAY
     private long indexBlockSize = 16L << 20; // 16 MB

--- a/chronicle/src/main/java/net/openhft/chronicle/VanillaDataCache.java
+++ b/chronicle/src/main/java/net/openhft/chronicle/VanillaDataCache.java
@@ -44,14 +44,14 @@ public class VanillaDataCache implements Closeable {
         this.dateCache = dateCache;
     }
 
-    public synchronized VanillaFile dataFor(int cycle, int threadId, int dataCount, boolean forWrite) throws IOException {
+    public synchronized VanillaFile dataFor(int cycle, int appenderId, int dataCount, boolean forWrite) throws IOException {
         key.cycle = cycle;
-        key.threadId = threadId;
+        key.appenderId = appenderId;
         key.dataCount = dataCount;
         VanillaFile vanillaFile = dataKeyVanillaFileMap.get(key);
         if (vanillaFile == null) {
             String cycleStr = dateCache.formatFor(cycle);
-            dataKeyVanillaFileMap.put(key.clone(), vanillaFile = new VanillaFile(basePath, cycleStr, "data-" + threadId + "-" + dataCount, dataCount, 1L << blockBits, forWrite));
+            dataKeyVanillaFileMap.put(key.clone(), vanillaFile = new VanillaFile(basePath, cycleStr, "data-" + appenderId + "-" + dataCount, dataCount, 1L << blockBits, forWrite));
             findEndOfData(vanillaFile);
         }
         vanillaFile.incrementUsage();
@@ -89,10 +89,10 @@ public class VanillaDataCache implements Closeable {
     private int lastCycle = -1;
     private int lastCount = -1;
 
-    public VanillaFile dataForLast(int cycle, int threadId) throws IOException {
+    public VanillaFile dataForLast(int cycle, int appenderId) throws IOException {
         String cycleStr = dateCache.formatFor(cycle);
         String cyclePath = basePath + "/" + cycleStr;
-        String dataPrefix = "data-" + threadId + "-";
+        String dataPrefix = "data-" + appenderId + "-";
         if (lastCycle != cycle) {
             int maxCount = 0;
             File[] files = new File(cyclePath).listFiles();
@@ -108,7 +108,7 @@ public class VanillaDataCache implements Closeable {
             lastCount = maxCount;
         }
 
-        return dataFor(cycle, threadId, lastCount, true);
+        return dataFor(cycle, appenderId, lastCount, true);
     }
 
     public void incrementLastCount() {
@@ -125,19 +125,19 @@ public class VanillaDataCache implements Closeable {
 
     static class DataKey implements Cloneable {
         int cycle;
-        int threadId;
+        int appenderId;
         int dataCount;
 
         @Override
         public int hashCode() {
-            return threadId * 10191 + cycle * 17 + dataCount;
+            return appenderId * 10191 + cycle * 17 + dataCount;
         }
 
         @Override
         public boolean equals(Object obj) {
             if (!(obj instanceof DataKey)) return false;
             DataKey key = (DataKey) obj;
-            return dataCount == key.dataCount && threadId == key.threadId && cycle == key.cycle;
+            return dataCount == key.dataCount && appenderId == key.appenderId && cycle == key.cycle;
         }
 
         @Override

--- a/chronicle/src/test/java/net/openhft/chronicle/TestTaskExecutionUtil.java
+++ b/chronicle/src/test/java/net/openhft/chronicle/TestTaskExecutionUtil.java
@@ -37,10 +37,10 @@ public final class TestTaskExecutionUtil {
     public static void executeConcurrentTasks(final List<? extends Callable<Void>> tasks, final long taskTimeoutMillis) {
 
         // Create and start a thread per task
-        final List<TaskRunner> taskRunners = new ArrayList<TaskRunner>();
+        final List<TestTaskRunner> taskRunners = new ArrayList<TestTaskRunner>();
         final List<Thread> threads = new ArrayList<Thread>();
         for (Callable<Void> task : tasks) {
-            final TaskRunner taskRunner = new TaskRunner(task);
+            final TestTaskRunner taskRunner = new TestTaskRunner(task);
             taskRunners.add(taskRunner);
             final Thread thread = new Thread(taskRunner, task.toString());
             threads.add(thread);
@@ -58,16 +58,19 @@ public final class TestTaskExecutionUtil {
         }
 
         // Fail if any tasks failed
-        for (TaskRunner taskRunner : taskRunners) {
+        for (TestTaskRunner taskRunner : taskRunners) {
             taskRunner.assertIfFailed();
         }
     }
 
-    private static class TaskRunner implements Runnable {
+    /**
+     * Wraps a task so that failures in another thread can be reported.
+     */
+    public static class TestTaskRunner implements Runnable {
         private final Callable<?> task;
         private volatile AssertionError failure;
 
-        public TaskRunner(final Callable<?> task) {
+        public TestTaskRunner(final Callable<?> task) {
             this.task = task;
         }
 


### PR DESCRIPTION
VanillaChronicle was using thread id in the name of data files
written by the Appender.  Max thread id can be configured
under Linux (/proc/sys/kernel/pid_max) to be an arbitrary size,
which may not fit within the size allocated in the index entries.
To eliminate this possibility, this change replaces use of
thread id with an integer allocated at creation of an Appender.
- Thread id was replaced by an incrementing integer that is
  assigned to each VanillaAppender on creation
- 24 bits was allowed for the Appender id
- All thread aware code was removed from the VanillaChronicle
  so that client code is now responsible for ensuring that
  an Appender is only ever used by a single thread.

NOTE:  This introduces an incompatible behaviour change to VanillaAppender.
Previously each call to VanillaChronicle.createAppender() by the same thread
would return the same Appender instance.  Now each call to createAppender()
creates a new instance.  It is the responsibility of the caller to ensure
that an Appender instance is only ever used by a single thread.
