### PR TITLE
CHRON-92 - ExcerptAppender.lastWrittenIndex is wrong when index file rolls

### DIFF
--- a/chronicle/src/main/java/net/openhft/chronicle/VanillaDataCache.java
+++ b/chronicle/src/main/java/net/openhft/chronicle/VanillaDataCache.java
@@ -27,23 +27,13 @@ import java.io.File;
 import java.io.IOException;
 
 public class VanillaDataCache implements Closeable {
-    private static final String FILE_NAME_PREFIX = "data-";
+    public static final String FILE_NAME_PREFIX = "data-";
 
     private final String basePath;
     private final DataKey key = new DataKey();
     private final int blockBits;
     private final VanillaDateCache dateCache;
     private final VanillaMappedCache<DataKey> cache;
-
-    /*
-    public VanillaDataCache(@NotNull String basePath, int blockBits, @NotNull VanillaDateCache dateCache, @NotNull ChronicleQueueBuilder.VanillaChronicleQueueBuilder builder) {
-        this(basePath, blockBits, dateCache, builder.dataCacheCapacity(), builder.cleanupOnClose());
-    }
-
-    public VanillaDataCache(@NotNull String basePath, int blockBits, @NotNull VanillaDateCache dateCache, int capacity) {
-        this(basePath, blockBits, dateCache, capacity, false);
-    }
-    */
 
     VanillaDataCache(@NotNull String basePath, int blockBits, @NotNull VanillaDateCache dateCache, int capacity, boolean cleanupOnClose) {
         this.basePath = basePath;

--- a/chronicle/src/main/java/net/openhft/chronicle/VanillaIndexCache.java
+++ b/chronicle/src/main/java/net/openhft/chronicle/VanillaIndexCache.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.text.ParseException;
 
 public class VanillaIndexCache implements Closeable {
-    private static final String FILE_NAME_PREFIX = "index-";
+    public static final String FILE_NAME_PREFIX = "index-";
 
     private final String basePath;
     private final File baseFile;

--- a/chronicle/src/test/java/net/openhft/chronicle/VanillaChronicleTestBase.java
+++ b/chronicle/src/test/java/net/openhft/chronicle/VanillaChronicleTestBase.java
@@ -30,6 +30,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 public class VanillaChronicleTestBase {
@@ -103,5 +105,25 @@ public class VanillaChronicleTestBase {
            br.close();
            proc.destroy();
         }
+    }
+
+    protected int findLastIndexCacheNumber(final File cyclePath) {
+        int maxIndex = -1;
+
+        final File[] files = cyclePath.listFiles();
+
+        if (files != null) {
+            for (final File file : files) {
+                String name = file.getName();
+                if (name.startsWith(VanillaIndexCache.FILE_NAME_PREFIX)) {
+                    int index = Integer.parseInt(name.substring(VanillaIndexCache.FILE_NAME_PREFIX.length()));
+                    if (maxIndex < index) {
+                        maxIndex = index;
+                    }
+                }
+            }
+        }
+
+        return maxIndex;
     }
 }


### PR DESCRIPTION
See https://github.com/OpenHFT/Chronicle-Queue/pull/116
