### PR TITLE
Vanilla latency

### DIFF
--- a/chronicle/pom.xml
+++ b/chronicle/pom.xml
@@ -102,6 +102,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+            <version>2.1.4</version>
+        </dependency>
+
         <!-- on linux install with sudo apt-get install libjna-java -->
         <dependency>
             <groupId>net.java.dev.jna</groupId>

--- a/chronicle/src/test/java/net/openhft/chronicle/VanillaBlockSizeTest.java
+++ b/chronicle/src/test/java/net/openhft/chronicle/VanillaBlockSizeTest.java
@@ -1,0 +1,70 @@
+package net.openhft.chronicle;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Random;
+
+/**
+ * @author luke
+ *         Date: 4/7/15
+ */
+public class VanillaBlockSizeTest {
+    @Test
+    public void testMaxSize() throws IOException {
+        final int SAMPLE = 10000000;
+        final int ITEM_SIZE = 256;
+        byte[][] byteArrays;
+        Random random = new Random();
+
+        Chronicle chronicle = ChronicleQueueBuilder.vanilla("blocksizetest")
+                .dataBlockSize(Integer.MAX_VALUE)
+                .indexBlockSize(Integer.MAX_VALUE)
+                .build();
+        ExcerptAppender appender = chronicle.createAppender();
+
+        System.out.println("Allocating...");
+        byteArrays = new byte[SAMPLE][ITEM_SIZE];
+
+        // Randomize
+        System.out.println("Randomize...");
+        for (int i=0;i<SAMPLE;i++) {
+            random.nextBytes(byteArrays[0]);
+        }
+
+        System.out.println("GC...");
+        System.gc();
+
+        // Warmup
+        System.out.println("Warmup...");
+        for (int i=0;i<SAMPLE;i++) {
+            appender.startExcerpt(ITEM_SIZE);
+            appender.write(byteArrays[i], 0, ITEM_SIZE);
+            appender.finish();
+        }
+
+        System.out.println("Test...");
+        int index = 0;
+        int count = 0;
+        while (true) {
+            if (index >= SAMPLE) {
+                index = 0;
+            }
+            long start = System.nanoTime();
+            appender.startExcerpt(ITEM_SIZE);
+            appender.write(byteArrays[index], 0, ITEM_SIZE);
+            appender.finish();
+
+            if (count % 100000000 == 0) {
+                System.out.println(count+" written");
+            }
+
+            index++;
+            count++;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        new VanillaBlockSizeTest().testMaxSize();
+    }
+}

--- a/chronicle/src/test/java/net/openhft/chronicle/VanillaBlockSizeTest.java
+++ b/chronicle/src/test/java/net/openhft/chronicle/VanillaBlockSizeTest.java
@@ -18,8 +18,8 @@ public class VanillaBlockSizeTest {
         Random random = new Random();
 
         Chronicle chronicle = ChronicleQueueBuilder.vanilla("blocksizetest")
-                .dataBlockSize(Integer.MAX_VALUE)
-                .indexBlockSize(Integer.MAX_VALUE)
+                .dataBlockSize(1073741824)
+                .indexBlockSize(1073741824)
                 .build();
         ExcerptAppender appender = chronicle.createAppender();
 

--- a/chronicle/src/test/java/net/openhft/chronicle/VanillaLatencyTest.java
+++ b/chronicle/src/test/java/net/openhft/chronicle/VanillaLatencyTest.java
@@ -1,0 +1,83 @@
+package net.openhft.chronicle;
+
+import org.HdrHistogram.Histogram;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Random;
+
+/**
+ * @author luke
+ *         Date: 4/7/15
+ */
+public class VanillaLatencyTest {
+
+    final int COUNT = 100000000;
+    final int SAMPLE = 10000000;
+    final int ITEM_SIZE = 256;
+
+    @Test
+    public void testIndexedVsVanilla() throws IOException {
+        Random random = new Random();
+
+        System.out.println("Allocating...");
+        byte[][] byteArrays = new byte[SAMPLE][ITEM_SIZE];
+
+        // Randomize
+        System.out.println("Randomize...");
+        for (int i=0;i<SAMPLE;i++) {
+            random.nextBytes(byteArrays[0]);
+        }
+
+        Chronicle indexedChronicle = ChronicleQueueBuilder.indexed("indexedlatency").build();
+        System.out.println("----------------------- INDEXED -----------------------");
+        latencyTest(indexedChronicle, COUNT, byteArrays);
+        indexedChronicle.close();
+
+        Chronicle vanillaChronicle = ChronicleQueueBuilder.vanilla("vanillalatency").build();
+        System.out.println("----------------------- VANILLA -----------------------");
+        latencyTest(vanillaChronicle, COUNT, byteArrays);
+        vanillaChronicle.close();
+    }
+
+    private void latencyTest(Chronicle chronicle, long count, final byte[][] byteArrays) throws IOException {
+        Histogram histogram = new Histogram(10000000000L, 3);
+        ExcerptAppender appender = chronicle.createAppender();
+
+        System.out.println("GC...");
+        System.gc();
+
+        // Warmup
+        System.out.println("Warmup...");
+        for (int i=0;i<SAMPLE;i++) {
+            appender.startExcerpt(ITEM_SIZE);
+            appender.write(byteArrays[i], 0, ITEM_SIZE);
+            appender.finish();
+        }
+
+        System.out.println("Test...");
+        int index = 0;
+        for (int i=0; i<count; i++) {
+            if (index >= SAMPLE) {
+                index = 0;
+            }
+            long start = System.nanoTime();
+            appender.startExcerpt(ITEM_SIZE);
+            appender.write(byteArrays[index], 0, ITEM_SIZE);
+            appender.finish();
+            long end = System.nanoTime();
+            histogram.recordValue(end - start);
+
+            if (i > 0 && i % 10000000 == 0) {
+                System.out.println("Total: "+i+" Mean: "+histogram.getMean()+" Max: "+histogram.getMaxValue()+
+                        " StdDev: "+histogram.getStdDeviation());
+            }
+
+            index++;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        new VanillaLatencyTest().testIndexedVsVanilla();
+    }
+}


### PR DESCRIPTION
This is an infinite running test, but after 500,000,000 excerpts written I get the following error:

Exception in thread "main" java.lang.AssertionError
	at net.openhft.chronicle.VanillaIndexCache.append(VanillaIndexCache.java:203)
	at net.openhft.chronicle.VanillaChronicle$VanillaAppenderImpl.finish(VanillaChronicle.java:625)
	at net.openhft.chronicle.VanillaBlockSizeTest.testMaxSize(VanillaBlockSizeTest.java:56)
	at net.openhft.chronicle.VanillaBlockSizeTest.main(VanillaBlockSizeTest.java:68)

I only get this error when I set dataBlockSize and indexBlockSize.