### PR TITLE
tailer.toEnd() before write

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
@@ -2,6 +2,7 @@ package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.impl.RollingChronicleQueue;
@@ -65,44 +66,32 @@ public class ToEndTest {
 
     @Test
     public void toEndBeforeWriteTest() {
-        String baseDir = OS.TARGET + "/toEndTest";
-        System.out.println(baseDir);
+        String baseDir = OS.TARGET + "/toEndBeforeWriteTest";
         IOTools.shallowDeleteDirWithFiles(baseDir);
-        List<Integer> results = new ArrayList<>();
-        RollingChronicleQueue queue = new SingleChronicleQueueBuilder(baseDir)
-                .wireType(WireType.BINARY)
-                .blockSize(4 << 20)
-                .indexCount(8)
-                .indexSpacing(1)
-                .build();
 
+        ChronicleQueue queue = new SingleChronicleQueueBuilder(baseDir).build();
         checkOneFile(baseDir);
+
+        // if this appender isn't created, the tailer toEnd doesn't cause a roll.
         ExcerptAppender appender = queue.createAppender();
         checkOneFile(baseDir);
 
         ExcerptTailer tailer = queue.createTailer();
         checkOneFile(baseDir);
 
-        tailer.toEnd();
+        ExcerptTailer tailer2 = queue.createTailer();
+        checkOneFile(baseDir);
 
-        for (int i = 0; i < 10; i++) {
+        tailer.toEnd();
+        //checkOneFile(baseDir);
+
+        tailer2.toEnd();
+        checkOneFile(baseDir);
+
+        /*for (int i = 0; i < 10; i++) {
             final int j = i;
             appender.writeDocument(wire -> wire.write(() -> "msg").int32(j));
-        }
-
-        checkOneFile(baseDir);
-
-        assertEquals(10, queue.rollCycle().toSequenceNumber(tailer.index()));
-        checkOneFile(baseDir);
-        fillResults(tailer, results);
-        checkOneFile(baseDir);
-        assertEquals(0, results.size());
-
-        tailer.toStart();
-        checkOneFile(baseDir);
-        fillResults(tailer, results);
-        assertEquals(10, results.size());
-        checkOneFile(baseDir);
+        }*/
     }
 
     private void checkOneFile(String baseDir) {


### PR DESCRIPTION
tailer.toEnd() on a queue that has an appender that has not wrote causes the tailer to roll, and not receive any messages.