### PR TITLE
SCQS.writePosition padding

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
@@ -73,8 +73,6 @@ public class SingleChronicleQueueStore implements WireStore {
         try {
             this.wireType = wire.read(MetaDataField.wireType).object(WireType.class);
             assert wireType != null;
-            this.writePosition = wire.newLongReference();
-            wire.read(MetaDataField.writePosition).int64(writePosition);
             this.roll = wire.read(MetaDataField.roll).typedMarshallable();
 
             this.mappedBytes = (MappedBytes) (wire.bytes());
@@ -82,7 +80,6 @@ public class SingleChronicleQueueStore implements WireStore {
             this.refCount = ReferenceCounter.onReleased(this::onCleanup);
             this.indexing = wire.read(MetaDataField.indexing).typedMarshallable();
             assert indexing != null;
-            this.indexing.writePosition = writePosition;
 
             if (wire.bytes().readRemaining() > 0) {
                 this.lastAcknowledgedIndexReplicated = wire.read(MetaDataField.lastAcknowledgedIndexReplicated)
@@ -103,6 +100,10 @@ public class SingleChronicleQueueStore implements WireStore {
             } else {
                 this.deltaCheckpointInterval = -1; // disabled.
             }
+
+            this.writePosition = wire.newLongReference();
+            wire.read(MetaDataField.writePosition).int64(writePosition);
+            this.indexing.writePosition = writePosition;
 
         } finally {
             assert wire.endUse();
@@ -300,13 +301,16 @@ public class SingleChronicleQueueStore implements WireStore {
             lastAcknowledgedIndexReplicated = wire.newLongReference();
 
         wire.write(MetaDataField.wireType).object(wireType)
-                .write(MetaDataField.writePosition).int64forBinding(0L, writePosition)
                 .write(MetaDataField.roll).typedMarshallable(this.roll)
                 .write(MetaDataField.indexing).typedMarshallable(this.indexing)
                 .write(MetaDataField.lastAcknowledgedIndexReplicated)
                 .int64forBinding(-1L, lastAcknowledgedIndexReplicated);
         wire.write(MetaDataField.recovery).typedMarshallable(recovery);
         wire.write(MetaDataField.deltaCheckpointInterval).int32(this.deltaCheckpointInterval);
+
+        // contended
+        wire.padToCacheAlign()
+            .write(MetaDataField.writePosition).int64forBinding(0L, writePosition);
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
@@ -73,6 +73,8 @@ public class SingleChronicleQueueStore implements WireStore {
         try {
             this.wireType = wire.read(MetaDataField.wireType).object(WireType.class);
             assert wireType != null;
+            this.writePosition = wire.newLongReference();
+            wire.read(MetaDataField.writePosition).int64(writePosition);
             this.roll = wire.read(MetaDataField.roll).typedMarshallable();
 
             this.mappedBytes = (MappedBytes) (wire.bytes());
@@ -80,6 +82,7 @@ public class SingleChronicleQueueStore implements WireStore {
             this.refCount = ReferenceCounter.onReleased(this::onCleanup);
             this.indexing = wire.read(MetaDataField.indexing).typedMarshallable();
             assert indexing != null;
+            this.indexing.writePosition = writePosition;
 
             if (wire.bytes().readRemaining() > 0) {
                 this.lastAcknowledgedIndexReplicated = wire.read(MetaDataField.lastAcknowledgedIndexReplicated)
@@ -100,10 +103,6 @@ public class SingleChronicleQueueStore implements WireStore {
             } else {
                 this.deltaCheckpointInterval = -1; // disabled.
             }
-
-            this.writePosition = wire.newLongReference();
-            wire.read(MetaDataField.writePosition).int64(writePosition);
-            this.indexing.writePosition = writePosition;
 
         } finally {
             assert wire.endUse();
@@ -301,16 +300,13 @@ public class SingleChronicleQueueStore implements WireStore {
             lastAcknowledgedIndexReplicated = wire.newLongReference();
 
         wire.write(MetaDataField.wireType).object(wireType)
+                .padToCacheAlign().write(MetaDataField.writePosition).int64forBinding(0L, writePosition)
                 .write(MetaDataField.roll).typedMarshallable(this.roll)
                 .write(MetaDataField.indexing).typedMarshallable(this.indexing)
                 .write(MetaDataField.lastAcknowledgedIndexReplicated)
                 .int64forBinding(-1L, lastAcknowledgedIndexReplicated);
         wire.write(MetaDataField.recovery).typedMarshallable(recovery);
         wire.write(MetaDataField.deltaCheckpointInterval).int32(this.deltaCheckpointInterval);
-
-        // contended
-        wire.padToCacheAlign()
-            .write(MetaDataField.writePosition).int64forBinding(0L, writePosition);
     }
 
     @Override


### PR DESCRIPTION
Reads of SCQS.writePosition were causing 'WARN: add padding for concurrent appenders...' message. After padding the warning is gone.