### PR TITLE
fixed store reference leaks

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -168,8 +168,12 @@ public class SingleChronicleQueue implements RollingChronicleQueue {
         for (int i = firstCycle(), max = lastCycle(); i <= max; i++) {
             WireStore wireStore = storeForCycle(i, epoch, false);
             if (wireStore != null) {
-//                sb.append("# ").append(wireStore.bytes().mappedFile().file()).append("\n");
-                sb.append(wireStore.dump());
+                try {
+//                    sb.append("# ").append(wireStore.bytes().mappedFile().file()).append("\n");
+                    sb.append(wireStore.dump());
+                } finally {
+                    release(wireStore);
+                }
             }
         }
         return sb.toString();
@@ -305,6 +309,9 @@ public class SingleChronicleQueue implements RollingChronicleQueue {
                     true) + 1;
         } catch (Exception e) {
             throw new IllegalStateException(e);
+        } finally {
+            if (wireStore != null)
+                release(wireStore);
         }
 
     }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
@@ -141,6 +141,9 @@ public class SingleChronicleQueueExcerpts {
             wire = null;
             if (w != null)
                 w.bytes().release();
+            if (store != null)
+                queue.release(store);
+            store = null;
         }
 
         @Override


### PR DESCRIPTION
This is another step in solving #306 : some store usages never call release, thus preventing the reference count from reaching zero and the resources from being freed.