### PR TITLE
Failing read only test: tailer can't get toEnd()

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
@@ -77,4 +77,15 @@ public class ReadWriteTest {
             out.acquireAppender();
         }
     }
+    @Test
+    public void testToEndOnReadOnly() {
+
+        try (SingleChronicleQueue out = SingleChronicleQueueBuilder.binary(chroniclePath).readOnly(true).build()) {
+            ExcerptTailer tailer = out.createTailer();
+            tailer.toEnd();
+            long index = tailer.index();
+            assertTrue(index != 0);
+        }
+    }
+
 }


### PR DESCRIPTION
If I switch a queue to read-only, tailers can't go to the end anymore. I have difficulties understanding the read-only mode.