### PR TITLE
Failing Test for Negative Epoch

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
@@ -20,7 +20,6 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -132,7 +131,6 @@ public class TailerDirectionTest extends ChronicleQueueTestBase {
     }
 
     @Test
-    @Ignore("failing")
     public void testTailerBackwardsReadBeyondCycle() throws Exception {
         String basePath = OS.TARGET + "/tailerForwardBackwardBeyondCycle-" + System.nanoTime();
         ChronicleQueue queue = SingleChronicleQueueBuilder.binary(basePath).rollCycle(RollCycles.TEST_SECONDLY)

--- a/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
@@ -20,6 +20,7 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -131,6 +132,7 @@ public class TailerDirectionTest extends ChronicleQueueTestBase {
     }
 
     @Test
+    @Ignore("fails")
     public void testTailerBackwardsReadBeyondCycle() throws Exception {
         String basePath = OS.TARGET + "/tailerForwardBackwardBeyondCycle-" + System.nanoTime();
         ChronicleQueue queue = SingleChronicleQueueBuilder.binary(basePath).rollCycle(RollCycles.TEST_SECONDLY)

--- a/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
@@ -20,6 +20,7 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -131,6 +132,7 @@ public class TailerDirectionTest extends ChronicleQueueTestBase {
     }
 
     @Test
+    @Ignore("failing")
     public void testTailerBackwardsReadBeyondCycle() throws Exception {
         String basePath = OS.TARGET + "/tailerForwardBackwardBeyondCycle-" + System.nanoTime();
         ChronicleQueue queue = SingleChronicleQueueBuilder.binary(basePath).rollCycle(RollCycles.TEST_SECONDLY)

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -1105,6 +1105,7 @@ public class SingleChronicleQueueTest extends ChronicleQueueTestBase {
     }
 
     @Test
+    @Ignore("fails")
     public void testNegativeEPOC() {
         try (final ChronicleQueue chronicle = SingleChronicleQueueBuilder.binary(getTmpDir())
                 .wireType(wireType)

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -1105,6 +1105,20 @@ public class SingleChronicleQueueTest extends ChronicleQueueTestBase {
     }
 
     @Test
+    public void testNegativeEPOC() {
+        try (final ChronicleQueue chronicle = SingleChronicleQueueBuilder.binary(getTmpDir())
+                .wireType(wireType)
+                .epoch(-TimeUnit.HOURS.toMillis(12))
+                .build()) {
+
+            final ExcerptAppender appender = chronicle.acquireAppender();
+            appender.writeDocument(wire -> wire.write(() -> "key").text("value=v"));
+
+            chronicle.createTailer().readingDocument();
+        }
+    }
+
+    @Test
     public void testIndex() throws TimeoutException {
         try (final RollingChronicleQueue queue = SingleChronicleQueueBuilder.binary(getTmpDir())
                 .wireType(this.wireType)


### PR DESCRIPTION
Fails with:
```
java.lang.NullPointerException
	at net.openhft.chronicle.queue.impl.single.SingleChronicleQueueExcerpts$StoreTailer.inACycle(SingleChronicleQueueExcerpts.java:988)
	at net.openhft.chronicle.queue.impl.single.SingleChronicleQueueExcerpts$StoreTailer.next(SingleChronicleQueueExcerpts.java:878)
	at net.openhft.chronicle.queue.impl.single.SingleChronicleQueueExcerpts$StoreTailer.readingDocument(SingleChronicleQueueExcerpts.java:856)
	at net.openhft.chronicle.queue.ExcerptTailer.readingDocument(ExcerptTailer.java:41)
	at net.openhft.chronicle.queue.impl.single.SingleChronicleQueueTest.testNegativeEPOC(SingleChronicleQueueTest.java:1117)
```