### PR TITLE
"Damaged" CQ file.

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/FsFullReadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/FsFullReadTest.java
@@ -1,0 +1,89 @@
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.MappedBytes;
+import net.openhft.chronicle.queue.impl.WireStore;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireDumper;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
+
+import static java.lang.System.err;
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by AM on 3/20/17. The specimen cq file was created when it hit the filesystem full.
+ * The standard DC present code can read only 1 entry, while the dumper can read 31k entries.
+ * It would be great if the normal code could read most of the entries also.
+ */
+public class FsFullReadTest {
+
+
+    private static  String basePath = "src/test/resources/tr2";
+
+    @Test
+    public void testFullReadFs() throws Exception {
+
+        SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(basePath)
+                .blockSize(256 << 1000)
+                .rollCycle(RollCycles.DAILY)
+                .build();
+        ExcerptTailer tailer = queue.createTailer();
+        DocumentContext dc = tailer.readingDocument();
+        boolean doExit = false;
+        int entries = 0;
+        while(!doExit) {
+            try {
+                if (dc.isPresent()) {
+                    entries++;
+                    Wire w = dc.wire();
+                    LocalDateTime dt = w.read().dateTime();
+                    assertNotNull(dt);
+                    byte[] b = w.read().bytes();
+                    assertEquals(1024, b.length);
+                } else {
+                    System.out.println("Exiting");
+                    doExit = true;
+                }
+            } finally {
+                dc.close();
+            }
+        }
+        System.out.println(String.format("Read %d entries.",entries));
+        WireStore wireStore = queue.storeForCycle(queue.cycle(), 0, false);
+        File file  = wireStore.file();
+        queue.close();
+        int dumpEntries = 0;
+        try {
+            MappedBytes bytes = MappedBytes.mappedBytes(file, 4 << 20);
+            bytes.readLimit(bytes.realCapacity());
+
+            WireDumper dumper = WireDumper.of(bytes);
+            Bytes<ByteBuffer> buffer = Bytes.elasticByteBuffer();
+            while (bytes.readRemaining() >= 4) {
+                StringBuilder sb = new StringBuilder();
+                boolean last = dumper.dumpOne(sb, buffer);
+                assertTrue(sb.length()>0);
+
+                if (last)
+                    break;
+                dumpEntries++;
+            }
+        } catch (IOException ioe) {
+            err.println("Failed to read " + file + " " + ioe);
+        }
+
+        assertEquals(dumpEntries,entries);
+    }
+
+
+}

--- a/src/test/java/net/openhft/chronicle/queue/FsFullWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/FsFullWriteTest.java
@@ -1,0 +1,68 @@
+package net.openhft.chronicle.queue;
+
+
+
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.Wire;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Random;
+
+/**
+ * Created by AM on 3/20/17. Mainly for documentation: Write counterpart for FsFullRestTest.
+ * Fails on Linux with a JVM SIGBUS unfortunately. Would be great if it's a "normal" runtime
+ * exception.
+ */
+@Ignore
+public class FsFullWriteTest {
+
+    private static  String basePath = "/mnt/tmpfs/cq/testqueue";
+
+    //@Before
+    public void before() throws Exception {
+        Path rootPath = Paths.get(basePath);
+        Files.walk(rootPath, FileVisitOption.FOLLOW_LINKS)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .peek(System.out::println)
+                .forEach(File::delete);
+    }
+
+    @Test
+    public void testAppenderFullFs() throws Exception {
+
+
+        ChronicleQueue queue = SingleChronicleQueueBuilder.binary(basePath)
+                .blockSize(256 << 1000)
+                .rollCycle(RollCycles.DAILY)
+                .build();
+        ExcerptAppender appender = queue.acquireAppender();
+        byte[] payload = new byte[1024];
+        Random r = new Random();
+        r.nextBytes(payload);
+        final LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
+        for (int i = 0; i < 1024*1024; i++) {
+            DocumentContext dc = appender.writingDocument();
+            try {
+
+                Wire w = dc.wire();
+                w.write().dateTime(now);
+                w.write().bytes(payload);
+            } finally {
+                dc.close();
+            }
+        }
+    }
+
+}

--- a/src/test/java/net/openhft/chronicle/queue/FsFullWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/FsFullWriteTest.java
@@ -27,6 +27,13 @@ import java.util.Random;
 @Ignore
 public class FsFullWriteTest {
 
+
+    /*
+      as root:
+       mount -o size=100M -t tmpfs none /mnt/tmpfs
+       mkdir /mnt/tmpfs/cq && chown <user>:<group> /mnt/tmpfs/cq
+       dd if=/dev/zero of=/mnt/tmpfs/fillspace bs=1M count=90
+      */
     private static  String basePath = "/mnt/tmpfs/cq/testqueue";
 
     //@Before
@@ -52,7 +59,7 @@ public class FsFullWriteTest {
         Random r = new Random();
         r.nextBytes(payload);
         final LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
-        for (int i = 0; i < 1024*1024; i++) {
+        for (int i = 0; i < 1024*200; i++) {
             DocumentContext dc = appender.writingDocument();
             try {
 


### PR DESCRIPTION
Test for a damaged CQ file. It would be great if CQ could extract more
entries from such a "damaged" file and fail more gracefully.