### PR TITLE
Fix resource leaks caused by WireStore refCounting errors

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/WireStorePool.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/WireStorePool.java
@@ -27,8 +27,11 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WireStorePool {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WireStorePool.class);
     @NotNull
     private final WireStoreSupplier supplier;
     @NotNull
@@ -100,9 +103,10 @@ public class WireStorePool {
                 if (ref != null && ref.get() == store) {
                     stores.remove(entry.getKey());
                     storeFileListener.onReleased(entry.getKey().cycle(), store.file());
-                    break;
+                    return;
                 }
             }
+            LOGGER.warn("Store was not registered {}", store.file().getName());
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -315,7 +315,7 @@ public class SingleChronicleQueue implements RollingChronicleQueue {
         try {
             long index = rollCycle.toIndex(cycle, 0);
             if (tailer.moveToIndex(index)) {
-                assert tailer.store.refCount() > 1;
+                assert tailer.store.refCount() > 0;
                 return tailer.store.lastSequenceNumber(tailer) + 1;
             } else {
                 return -1;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
@@ -1462,7 +1462,6 @@ public class SingleChronicleQueueExcerpts {
         void release() {
             if (store != null) {
                 queue.release(store);
-                //store.release();
                 store = null;
             }
             state = UNINITIALISED;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
@@ -1449,7 +1449,6 @@ public class SingleChronicleQueueExcerpts {
                 return true;
 
             context.wire(null);
-            nextStore.reserve();
             this.store = nextStore;
             this.state = FOUND_CYCLE;
             this.setCycle(cycle);

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
@@ -1462,7 +1462,8 @@ public class SingleChronicleQueueExcerpts {
 
         void release() {
             if (store != null) {
-                store.release();
+                queue.release(store);
+                //store.release();
                 store = null;
             }
             state = UNINITIALISED;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
@@ -174,7 +174,7 @@ public class ToEndTest {
         SingleChronicleQueueStore store2 = (SingleChronicleQueueStore) storeF2.get(tailer);
 
         // the reference count here is 2, one of the reference is the appender, one the tailer, once in the queue itself
-        assertEquals(3, store2.refCount());
+        assertEquals(2, store2.refCount());
     }
 
     @Test


### PR DESCRIPTION
To find leaks I run some simple scenario and then check open file descriptors using linux "lsof" command. At first I suspected that leaks were caused by the direct call "store.release()". But the actual problem is "reserve" after "acquire".