### PR TITLE
Added custom queue handling.

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
@@ -49,7 +49,8 @@ public enum ChronicleReaderMain {
 
         final ChronicleReader chronicleReader = new ChronicleReader().
                 withMessageSink(System.out::println).
-                withBasePath(Paths.get(commandLine.getOptionValue('d')));
+                withBasePath(Paths.get(commandLine.getOptionValue('d'))).
+                withCustomPlugin(commandLine.getOptionValue('p'));
 
         configureReader(chronicleReader, commandLine);
 
@@ -112,6 +113,7 @@ public enum ChronicleReaderMain {
         final Options options = new Options();
 
         addOption(options, "d", "directory", true, "Directory containing chronicle queue files", false);
+        addOption(options, "p", "custom-plugin", true, "Custom plugin to render the contents of the queue", false);
         addOption(options, "i", "include-regex", true, "Display records containing this regular expression", false);
         addOption(options, "e", "exclude-regex", true, "Do not display records containing this regular expression", false);
         addOption(options, "f", "follow", false, "Tail behaviour - wait for new records to arrive", false);

--- a/src/main/java/net/openhft/chronicle/queue/reader/ChronicleReaderPlugin.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/ChronicleReaderPlugin.java
@@ -1,0 +1,12 @@
+package net.openhft.chronicle.queue.reader;
+
+import net.openhft.chronicle.wire.DocumentContext;
+
+/**
+ * Handle the document from the queue that is read in <code>ChronicleReader</>.
+ * Particularly useful when you need more than the text representation e.g.
+ * when your queue is written in binary.
+ */
+public interface ChronicleReaderPlugin {
+    void onReadDocument(DocumentContext dc);
+}


### PR DESCRIPTION
The default behaviour of ChronicleReader is to render the queue assuming it has been written using the yaml text format.  This doesn't work when the queue was written using a binary format.  In this case we need to be able to add a custom handler which is possible with this patch.

It is full backward compatible. 