### PR TITLE
Update ChronicleReaderMain.java

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
@@ -49,9 +49,11 @@ public enum ChronicleReaderMain {
 
         final ChronicleReader chronicleReader = new ChronicleReader().
                 withMessageSink(System.out::println).
-                withBasePath(Paths.get(commandLine.getOptionValue('d'))).
-                withCustomPlugin(commandLine.getOptionValue('p'));
+                withBasePath(Paths.get(commandLine.getOptionValue('d')));
 
+        if(commandLine.hasOption('p')) {
+            chronicleReader.withCustomPlugin(commandLine.getOptionValue('p'));
+        }
         configureReader(chronicleReader, commandLine);
 
         chronicleReader.execute();


### PR DESCRIPTION
At the moment a custom plugin must be set - this allows the Reader to function even without the -p option being set.