### PR TITLE
Add shutdown hook to stop thread local cleaner executor service

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreComponentReferenceHandler.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreComponentReferenceHandler.java
@@ -47,6 +47,8 @@ public enum StoreComponentReferenceHandler implements Closeable {
                 }
             }
         });
+
+        Runtime.getRuntime().addShutdownHook(new Thread(THREAD_LOCAL_CLEANER_EXECUTOR_SERVICE::shutdown));
     }
 
     static ReferenceQueue<ExcerptAppender> appenderQueue() {


### PR DESCRIPTION
Similar to https://github.com/OpenHFT/Chronicle-Core/pull/69 but for Chronicle-Queue

Between these two PRs, I've observed with a profiler that all threads are being cleaned up after these shutdown hooks are run.