### PR TITLE
Polish

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
@@ -175,6 +175,7 @@ public class ContendedWriterTest {
     }
 
     private static class SlowToSerialiseAndDeserialise implements Marshallable {
+        @SuppressWarnings("unused")
         private final StringBuilder sb = new StringBuilder();
         private final long writePauseMs;
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
@@ -50,6 +50,7 @@ public final class DocumentOrderingTest {
             // move time to beyond the next cycle
             clock.addAndGet(TimeUnit.SECONDS.toMillis(2L));
 
+            @SuppressWarnings("unused")
             final Future<RecordInfo> otherDocumentWriter = attemptToWriteDocument(queue);
 
             firstOpenDocument.close();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
@@ -1015,6 +1015,7 @@ public class SingleCQFormat2Test extends ChronicleQueueTestBase {
         MappedFile.checkMappedFiles();
     }
 
+    @SuppressWarnings("unused")
     private static class MyData extends AbstractMarshallable {
         final String name;
         final long num;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -3689,6 +3689,7 @@ public class SingleChronicleQueueTest extends ChronicleQueueTestBase {
     public void checkReferenceCountingWhenRollingAndCheckFileDeletion() {
         SetTimeProvider timeProvider = new SetTimeProvider();
 
+        @SuppressWarnings("unused")
         MappedFile mappedFile1, mappedFile2, mappedFile3, mappedFile4;
 
         try (ChronicleQueue queue =

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
@@ -233,6 +233,7 @@ public class ToEndTest {
             checkOneFile(baseDir);
 
             // if this appender isn't created, the tailer toEnd doesn't cause a roll.
+            @SuppressWarnings("unused")
             ExcerptAppender appender = queue.acquireAppender();
             checkOneFile(baseDir);
 


### PR DESCRIPTION
Suppress unused variables warnings for variables which are (likely) incorrectly flagged as unused.