### PR TITLE
Bug - proxy needs public access

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/LastAppendedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LastAppendedTest.java
@@ -140,7 +140,7 @@ public class LastAppendedTest extends ChronicleQueueTestBase {
         }
     }
 
-    interface Msg {
+    public interface Msg {
         void msg(String s);
     }
 }


### PR DESCRIPTION
For proxy to access it, message must be public:

    mvn clean test -Dtest=net.openhft.chronicle.queue.LastAppndedTest

results in passing tests but this is printed to error stream:

```
/net/openhft/chronicle/wire/proxy/Proxy4.java:8: error: net.openhft.chronicle.queue.LastAppendedTest.Msg is not public in net.openhft.chronicle.queue.LastAppendedTest; cannot be accessed from outside package
public class Proxy4 implements net.openhft.chronicle.queue.LastAppendedTest.Msg,
                                                                           ^
[main] DEBUG net.openhft.chronicle.wire.VanillaMethodWriterBuilder - 
java.lang.ClassNotFoundException: net.openhft.chronicle.wire.proxy.Proxy4
package net.openhft.chronicle.wire.proxy;

import net.openhft.chronicle.core.Jvm;
import java.lang.reflect.InvocationHandler;
import java.lang.reflect.Method;
import java.util.ArrayList;
import java.util.List;
public class Proxy4 implements net.openhft.chronicle.queue.LastAppendedTest.Msg,
              net.openhft.chronicle.core.io.Closeable {

  private final Object proxy;
  private final InvocationHandler handler;
  private Method[] methods = new  Method[4];
  private List<Object[]> args = new ArrayList<Object[]>(2);

  public Proxy4(Object proxy, InvocationHandler handler) {
    this.proxy = proxy;
    this.handler = handler;
    args.add(new Object[0]);
    args.add(new Object[1]);
    methods[0]=net.openhft.chronicle.queue.LastAppendedTest.Msg.class.getMethods()[0];
    methods[1]=net.openhft.chronicle.core.io.Closeable.class.getMethods()[0];
    methods[2]=net.openhft.chronicle.core.io.Closeable.class.getMethods()[1];
    methods[3]=net.openhft.chronicle.core.io.Closeable.class.getMethods()[2];
  }

  public void msg(java.lang.String s) {
    Method method = this.methods[0];
    Object[] a = this.args.get(1);
    a[0] = s;
    try {
       handler.invoke(proxy,method,a);
    } catch (Throwable throwable) {
       throw Jvm.rethrow(throwable);
    }
  }
  public void closeQuietly(java.lang.Object[] closables) {
    Method method = this.methods[1];
    Object[] a = this.args.get(1);
    a[0] = closables;
    try {
       handler.invoke(proxy,method,a);
    } catch (Throwable throwable) {
       throw Jvm.rethrow(throwable);
    }
  }
  public void closeQuietly(java.lang.Object o) {
    Method method = this.methods[2];
    Object[] a = this.args.get(1);
    a[0] = o;
    try {
       handler.invoke(proxy,method,a);
    } catch (Throwable throwable) {
       throw Jvm.rethrow(throwable);
    }
  }
  public void close() {
    Method method = this.methods[3];
    Object[] a = this.args.get(0);
    try {
       handler.invoke(proxy,method,a);
    } catch (Throwable throwable) {
       throw Jvm.rethrow(throwable);
    }
  }
}

	at net.openhft.chronicle.wire.GeneratedProxyClass.from(GeneratedProxyClass.java:95)
	at net.openhft.chronicle.wire.VanillaMethodWriterBuilder.generatedProxyClass(VanillaMethodWriterBuilder.java:101)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
	at net.openhft.chronicle.wire.VanillaMethodWriterBuilder.get(VanillaMethodWriterBuilder.java:131)
	at net.openhft.chronicle.wire.VanillaMethodWriterBuilder.build(VanillaMethodWriterBuilder.java:95)
	at net.openhft.chronicle.queue.LastAppendedTest.testLastWrittenMetadata(LastAppendedTest.java:103)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.Verifier$1.evaluate(Verifier.java:35)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:379)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:340)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:125)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:413)
Caused by: java.lang.ClassNotFoundException: net.openhft.chronicle.wire.proxy.Proxy4
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at net.openhft.compiler.CachedCompiler.loadFromJava(CachedCompiler.java:163)
	at net.openhft.compiler.CachedCompiler.loadFromJava(CachedCompiler.java:76)
	at net.openhft.chronicle.wire.GeneratedProxyClass.from(GeneratedProxyClass.java:92)
	... 36 more
```