### PR TITLE
Polish: replace deprecated build() method with get()

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
@@ -71,7 +71,7 @@ public final class MessageHistoryTest {
 
     private void generateTestData(final ChronicleQueue inputQueue, final ChronicleQueue outputQueue) {
         final First first = inputQueue.acquireAppender().
-                methodWriterBuilder(First.class).recordHistory(true).build();
+                methodWriterBuilder(First.class).recordHistory(true).get();
         first.say("one");
         first.say("two");
         first.say("three");

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -490,7 +490,7 @@ public class SingleChronicleQueueTest extends ChronicleQueueTestBase {
                 try (ChronicleQueue inQueue = builder(inQueueTmpDir, wireType).rollCycle(RollCycles.TEST_SECONDLY).sourceId(2).timeProvider(tp).build()) {
 
                     // write some initial data to the inqueue
-                    final Msg msg = inQueue.acquireAppender().methodWriterBuilder(Msg.class).recordHistory(true).build();
+                    final Msg msg = inQueue.acquireAppender().methodWriterBuilder(Msg.class).recordHistory(true).get();
 
                     msg.msg("somedata-0");
                     assertEquals(1, inQueueTmpDir.listFiles(file -> file.getName().endsWith("cq4")).length);
@@ -503,7 +503,7 @@ public class SingleChronicleQueueTest extends ChronicleQueueTestBase {
 
                     // read a message on the in queue and write it to the out queue
                     {
-                        Msg out = outQueue.acquireAppender().methodWriterBuilder(Msg.class).recordHistory(true).build();
+                        Msg out = outQueue.acquireAppender().methodWriterBuilder(Msg.class).recordHistory(true).get();
                         MethodReader methodReader = inQueue.createTailer().methodReader((Msg) out::msg);
 
                         // reads the somedata-0

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/preroucher/PretoucherSoakTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/preroucher/PretoucherSoakTest.java
@@ -21,7 +21,7 @@ public class PretoucherSoakTest {
                 .rollCycle(RollCycles.TEST_SECONDLY).build();
         ExcerptAppender outQueueAppender = outQueue.acquireAppender();
 
-        HeartbeatListener heartbeatWriter = outQueueAppender.methodWriterBuilder(HeartbeatListener.class).methodWriterListener((m, a) -> validateAll(a)).recordHistory(true).build();
+        HeartbeatListener heartbeatWriter = outQueueAppender.methodWriterBuilder(HeartbeatListener.class).methodWriterListener((m, a) -> validateAll(a)).get();
 
         Monitor.addPeriodicUpdateSource(10, () -> currentTimeMillis -> {
             outQueueAppender.pretouch();


### PR DESCRIPTION
Replace deprecated build() method with get().