### PR TITLE
Polish: remove deprecated method call

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
@@ -114,7 +114,6 @@ public class OrderManagerTest {
                 OrderIdeaListener orderManager = out.acquireAppender()
                         .methodWriterBuilder(OrderIdeaListener.class)
                         .addInterface(MarketDataListener.class)
-                        .recordHistory(true)
                         .get();
                 SidedMarketDataCombiner combiner = new SidedMarketDataCombiner((MarketDataListener) orderManager);
 


### PR DESCRIPTION
Removing the deprecated call does not change the test outcome.