### PR TITLE
Polish: suppress restricted API warnings from use of Unsafe

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueExcerpts.java
@@ -1054,6 +1054,7 @@ public class SingleChronicleQueueExcerpts {
             return net.openhft.chronicle.wire.NoDocumentContext.INSTANCE;
         }
 
+        @SuppressWarnings("restriction")
         @Override
         public boolean peekDocument() {
             int header = UnsafeMemory.UNSAFE.getIntVolatile(null, address);

--- a/src/test/java/net/openhft/chronicle/queue/bench/ThroughputPerfMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/ThroughputPerfMain.java
@@ -94,6 +94,7 @@ public class ThroughputPerfMain {
         IOTools.deleteDirWithFiles(base, 2);
     }
 
+    @SuppressWarnings("restriction")
     private static long writeMessages(long address, long canWrite, int writeCount) {
         long length = 0;
         long count = 0;

--- a/src/test/java/net/openhft/chronicle/queue/bench/ThroughputPerfMain2.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/ThroughputPerfMain2.java
@@ -70,6 +70,7 @@ public class ThroughputPerfMain2 {
         IOTools.deleteDirWithFiles(base, 2);
     }
 
+    @SuppressWarnings("restriction")
     private static long writeMessages(long address, long canWrite, int writeCount) {
         long length = 0;
         long count = 0;


### PR DESCRIPTION
Suppress the restricted API warnings from `UnsafeMemory.UNSAFE`:
```
Access restriction: The method 'Unsafe.copyMemory(long, long, long)' is not API
  (restriction on required library '/home/jan/jdk1.8.0_202/jre/lib/rt.jar')
  ThroughputPerfMain.java line 1
Access restriction: The method 'Unsafe.copyMemory(long, long, long)' is not API
  (restriction on required library '/home/jan/jdk1.8.0_202/jre/lib/rt.jar')
  ThroughputPerfMain2.java line 79
Access restriction: The method 'Unsafe.getIntVolatile(Object, long)' is not API
  (restriction on required library '/home/jan/jdk1.8.0_202/jre/lib/rt.jar')
  SingleChronicleQueueExcerpts.java line 1059
Access restriction: The method 'Unsafe.putOrderedInt(Object, long, int)' is not API
  (restriction on required library '/home/jan/jdk1.8.0_202/jre/lib/rt.jar')
  ThroughputPerfMain.java line 104
Access restriction: The method 'Unsafe.putOrderedInt(Object, long, int)' is not API
  (restriction on required library '/home/jan/jdk1.8.0_202/jre/lib/rt.jar')
  ThroughputPerfMain2.java line 80
```

This change was originally proposed in #587 (but without identifying the warnings).