### PR TITLE
Polish:  suppress warning unparameterized raw type Consumer<T>

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -589,6 +589,7 @@ public class SingleChronicleQueue implements RollingChronicleQueue {
         return isClosed.get();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void close() {
 


### PR DESCRIPTION
```
Type safety: The method accept(Object) belongs to the raw type Consumer. References to generic type Consumer<T> should be parameterized	SingleChronicleQueue.java line 601
```