### PR TITLE
Polish: suppress warning on unparameterized readUtf8

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
@@ -81,6 +81,7 @@ public class DtoBytesMarshallableTest {
         StringBuilder name = new StringBuilder();
         int age;
 
+        @SuppressWarnings("unchecked")
         public void readMarshallable(BytesIn bytes) {
             age = bytes.readInt();
             name.setLength(0);
@@ -98,6 +99,7 @@ public class DtoBytesMarshallableTest {
         StringBuilder name = new StringBuilder();
         int age;
 
+        @SuppressWarnings("unchecked")
         public void readMarshallable(BytesIn bytes) {
             age = bytes.readInt();
             name.setLength(0);


### PR DESCRIPTION
```
Type safety: The method readUtf8(Appendable) belongs to the raw type StreamingDataInput. References to generic type StreamingDataInput<S> should be parameterized
```