### PR TITLE
Polish: suppress type safety warning on unparameterized Byteable

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueSingleThreadedJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueSingleThreadedJLBHBenchmark.java
@@ -59,7 +59,8 @@ public class QueueSingleThreadedJLBHBenchmark implements JLBHTask {
         new JLBH(lth).start();
     }
 
-    @Override
+    //@SuppressWarnings("unchecked")
+	@Override
     public void init(JLBH jlbh) {
         IOTools.deleteDirWithFiles("replica", 10);
 


### PR DESCRIPTION
```
Type safety: The method bytesStore(BytesStore, long, long) belongs to the raw type Byteable. References to generic type Byteable<B,Underlying> should be parameterized
```