### PR TITLE
Polish: suppress warning on unchecked conversion

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleMultiThreadTest.java
@@ -64,6 +64,7 @@ public class RollCycleMultiThreadTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testRead2() throws Exception {
         File path = DirectoryUtils.tempDir("testRead2");


### PR DESCRIPTION
```
Type safety: The expression of type RollCycleMultiThreadTest.ParallelQueueObserver needs unchecked conversion to conform to Callable<Object>
```