### PR TITLE
Make help printed by default (no args) for CLI tools

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
@@ -79,22 +79,30 @@ public class ChronicleHistoryReaderMain {
             commandLine = parser.parse(options, args);
 
             if (commandLine.hasOption('h')) {
-                new HelpFormatter().printHelp(ChronicleHistoryReaderMain.class.getSimpleName(), options);
-                System.exit(0);
+                printHelpAndExit(options, 0);
             }
         } catch (ParseException e) {
-            printUsageAndExit(options);
+            printHelpAndExit(options, 1);
         }
 
         return commandLine;
     }
 
-    protected void printUsageAndExit(final Options options) {
+    protected void printHelpAndExit(final Options options, int status) {
         final PrintWriter writer = new PrintWriter(System.out);
-        new HelpFormatter().printUsage(writer, 180,
-                ChronicleHistoryReaderMain.class.getSimpleName(), options);
+        new HelpFormatter().printHelp(
+                writer,
+                180,
+                this.getClass().getSimpleName(),
+                null,
+                options,
+                HelpFormatter.DEFAULT_LEFT_PAD,
+                HelpFormatter.DEFAULT_DESC_PAD,
+                null,
+                true
+        );
         writer.flush();
-        System.exit(1);
+        System.exit(status);
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
@@ -68,26 +68,35 @@ public class ChronicleReaderMain {
             commandLine = parser.parse(options, args);
 
             if (commandLine.hasOption('h')) {
-                new HelpFormatter().printHelp(this.getClass().getSimpleName(), options);
-                System.exit(0);
+                printHelpAndExit(options, 0);
             }
 
             if (!commandLine.hasOption('d')) {
                 System.out.println("Please specify the directory with -d\n");
-                printUsageAndExit(options);
+                printHelpAndExit(options, 1);
             }
         } catch (ParseException e) {
-            printUsageAndExit(options);
+            printHelpAndExit(options, 1);
         }
 
         return commandLine;
     }
 
-    protected void printUsageAndExit(final Options options) {
+    protected void printHelpAndExit(final Options options, int status) {
         final PrintWriter writer = new PrintWriter(System.out);
-        new HelpFormatter().printUsage(writer, 180, this.getClass().getSimpleName(), options);
+        new HelpFormatter().printHelp(
+                writer,
+                180,
+                this.getClass().getSimpleName(),
+                null,
+                options,
+                HelpFormatter.DEFAULT_LEFT_PAD,
+                HelpFormatter.DEFAULT_DESC_PAD,
+                null,
+                true
+        );
         writer.flush();
-        System.exit(1);
+        System.exit(status);
     }
 
     protected void configureReader(final ChronicleReader chronicleReader, final CommandLine commandLine) {


### PR DESCRIPTION
Very minor but maybe it would be a bit nicer to have something more descriptive than just usage printed when no arguments are provided. It seems to be a de facto standard to do so if a tool doesn't have lots of options and huge help info. E.g., off the top of my head, CLI such as java, groovy, sdkman do this. Code is based on http://commons.apache.org/proper/commons-cli/usage.html