### PR TITLE
Undeprecate ChronicleReaderMain. Fix #792, Fix #794

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,7 @@
                         </goals>
                         <configuration>
                             <referenceVersion>5.21ea0</referenceVersion>
+                            <binaryCompatibilityPercentageRequired>99.4</binaryCompatibilityPercentageRequired>
                             <artifactsURI>https://teamcity.chronicle.software/repository/download</artifactsURI>
                         </configuration>
                     </execution>

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
@@ -18,7 +18,7 @@
 
 package net.openhft.chronicle.queue;
 
-import net.openhft.chronicle.queue.reader.ChronicleReader;
+import net.openhft.chronicle.queue.reader.Reader;
 import net.openhft.chronicle.wire.WireType;
 import org.apache.commons.cli.*;
 import org.jetbrains.annotations.NotNull;
@@ -58,15 +58,15 @@ public class ChronicleReaderMain {
         final Options options = options();
         final CommandLine commandLine = parseCommandLine(args, options);
 
-        final ChronicleReader chronicleReader = chronicleReader();
+        final Reader chronicleReader = chronicleReader();
 
         configureReader(chronicleReader, commandLine);
 
         chronicleReader.execute();
     }
 
-    protected ChronicleReader chronicleReader() {
-        return new ChronicleReader();
+    protected Reader chronicleReader() {
+        return Reader.create();
     }
 
     protected CommandLine parseCommandLine(final @NotNull String[] args, final Options options) {
@@ -107,7 +107,7 @@ public class ChronicleReaderMain {
         System.exit(status);
     }
 
-    protected void configureReader(final ChronicleReader chronicleReader, final CommandLine commandLine) {
+    protected void configureReader(final Reader chronicleReader, final CommandLine commandLine) {
         final Consumer<String> messageSink = commandLine.hasOption('l') ?
                 s -> System.out.println(s.replaceAll("\n", "")) :
                 System.out::println;

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
@@ -31,8 +31,11 @@ import static java.util.Arrays.stream;
 
 /**
  * Display records in a Chronicle in a text form.
+ *
+ * New code should use net.openhft.chronicle.queue.main.ReaderMain instead
+ * as this class might get deprecated in the future.
+ *
  */
-@Deprecated /* For removal in x.22, use net.openhft.chronicle.queue.main.ReaderMain instead */
 public class ChronicleReaderMain {
 
     public static void main(@NotNull String[] args) {

--- a/src/main/java/net/openhft/chronicle/queue/internal/main/InternalReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/main/InternalReaderMain.java
@@ -18,6 +18,7 @@
 
 package net.openhft.chronicle.queue.internal.main;
 
+import net.openhft.chronicle.queue.ChronicleReaderMain;
 import net.openhft.chronicle.queue.reader.Reader;
 import net.openhft.chronicle.wire.WireType;
 import org.apache.commons.cli.*;
@@ -32,127 +33,13 @@ import static java.util.Arrays.stream;
 /**
  * Display records in a Chronicle in a text form.
  */
-public class InternalReaderMain {
+// This class just extends ChronicleReaderMain which might get deprecated later on.
+// Once deprecated and before ChronicleReaderMain is subsequently removed, that class
+// may be copied to this class.
+public class InternalReaderMain extends ChronicleReaderMain {
 
     public static void main(@NotNull String[] args) {
         new InternalReaderMain().run(args);
     }
 
-    public static void addOption(final Options options,
-                                 final String opt,
-                                 final String argName,
-                                 final boolean hasArg,
-                                 final String description,
-                                 final boolean isRequired) {
-        final Option option = new Option(opt, hasArg, description);
-        option.setArgName(argName);
-        option.setRequired(isRequired);
-        options.addOption(option);
-    }
-
-    protected void run(@NotNull String[] args) {
-        final Options options = options();
-        final CommandLine commandLine = parseCommandLine(args, options);
-
-        final Reader chronicleReader = chronicleReader();
-
-        configureReader(chronicleReader, commandLine);
-
-        chronicleReader.execute();
-    }
-
-    protected Reader chronicleReader() {
-        return Reader.create();
-    }
-
-    protected CommandLine parseCommandLine(final @NotNull String[] args, final Options options) {
-        final CommandLineParser parser = new DefaultParser();
-        CommandLine commandLine = null;
-        try {
-            commandLine = parser.parse(options, args);
-
-            if (commandLine.hasOption('h')) {
-                printHelpAndExit(options, 0);
-            }
-
-            if (!commandLine.hasOption('d')) {
-                System.out.println("Please specify the directory with -d\n");
-                printHelpAndExit(options, 1);
-            }
-        } catch (ParseException e) {
-            printHelpAndExit(options, 1);
-        }
-
-        return commandLine;
-    }
-
-    protected void printHelpAndExit(final Options options, int status) {
-        final PrintWriter writer = new PrintWriter(System.out);
-        new HelpFormatter().printHelp(
-                writer,
-                180,
-                this.getClass().getSimpleName(),
-                null,
-                options,
-                HelpFormatter.DEFAULT_LEFT_PAD,
-                HelpFormatter.DEFAULT_DESC_PAD,
-                null,
-                true
-        );
-        writer.flush();
-        System.exit(status);
-    }
-
-    protected void configureReader(final Reader chronicleReader, final CommandLine commandLine) {
-        final Consumer<String> messageSink = commandLine.hasOption('l') ?
-                s -> System.out.println(s.replaceAll("\n", "")) :
-                System.out::println;
-        chronicleReader
-                .withMessageSink(messageSink)
-                .withBasePath(Paths.get(commandLine.getOptionValue('d')));
-
-        if (commandLine.hasOption('i')) {
-            stream(commandLine.getOptionValues('i')).forEach(chronicleReader::withInclusionRegex);
-        }
-        if (commandLine.hasOption('e')) {
-            stream(commandLine.getOptionValues('e')).forEach(chronicleReader::withExclusionRegex);
-        }
-        if (commandLine.hasOption('f')) {
-            chronicleReader.tail();
-        }
-        if (commandLine.hasOption('m')) {
-            chronicleReader.historyRecords(Long.parseLong(commandLine.getOptionValue('m')));
-        }
-        if (commandLine.hasOption('n')) {
-            chronicleReader.withStartIndex(Long.decode(commandLine.getOptionValue('n')));
-        }
-        if (commandLine.hasOption('r')) {
-            final String r = commandLine.getOptionValue('r');
-            chronicleReader.asMethodReader(r.equals("null") ? null : r);
-        }
-        if (commandLine.hasOption('w')) {
-            chronicleReader.withWireType(WireType.valueOf(commandLine.getOptionValue('w')));
-        }
-        if (commandLine.hasOption('s')) {
-            chronicleReader.suppressDisplayIndex();
-        }
-    }
-
-    @NotNull
-    protected Options options() {
-        final Options options = new Options();
-
-        addOption(options, "d", "directory", true, "Directory containing chronicle queue files", false);
-        addOption(options, "i", "include-regex", true, "Display records containing this regular expression", false);
-        addOption(options, "e", "exclude-regex", true, "Do not display records containing this regular expression", false);
-        addOption(options, "f", "follow", false, "Tail behaviour - wait for new records to arrive", false);
-        addOption(options, "m", "max-history", true, "Show this many records from the end of the data set", false);
-        addOption(options, "n", "from-index", true, "Start reading from this index (e.g. 0x123ABE)", false);
-        addOption(options, "r", "as-method-reader", true, "Use when reading from a queue generated using a MethodWriter", false);
-        addOption(options, "w", "wire-type", true, "Control output i.e. JSON", false);
-        addOption(options, "s", "suppress-index", false, "Display index", false);
-        addOption(options, "l", "single-line", false, "Squash each output message into a single line", false);
-        addOption(options, "h", "help-message", false, "Print this help and exit", false);
-        return options;
-    }
 }

--- a/src/main/java/net/openhft/chronicle/queue/main/ReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/ReaderMain.java
@@ -19,7 +19,16 @@
 package net.openhft.chronicle.queue.main;
 
 import net.openhft.chronicle.queue.internal.main.InternalReaderMain;
+import net.openhft.chronicle.queue.reader.ChronicleReader;
+import net.openhft.chronicle.queue.reader.Reader;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Display records in a queue in a text form.
@@ -30,5 +39,31 @@ public final class ReaderMain {
     public static void main(@NotNull String[] args) {
         InternalReaderMain.main(args);
     }
+
+    /* Todo: Add a builder similar to this before ChronicleReaderMain is deprecated
+    interface Builder {
+
+        // These "standard" methods provide base functionality
+
+        BiFunction<String[], Options, CommandLine> standardParser();
+
+        Options standardOptions();
+
+        BiConsumer<Reader, CommandLine> standardConfigurator();
+
+        // These "withers" provide override capabilities
+
+        Builder withReader(Reader reader);
+
+        Builder withParser(BiFunction<? extends String[], ? extends Options, CommandLine> parser);
+
+        Builder withOptions(Options options);
+
+        Builder withConfigurator(BiConsumer<? super Reader, ? super CommandLine> configurator);
+
+        Consumer<String[]> build();
+
+    }
+    */
 
 }

--- a/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
@@ -8,12 +8,10 @@ import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-@Ignore("TODO: jerry to fix")
 @RequiredForClient
 public class MethodReaderObjectReuseTest extends QueueTestCommon {
     @Test
@@ -34,8 +32,9 @@ public class MethodReaderObjectReuseTest extends QueueTestCommon {
             MethodReader reader = cq.createTailer()
                     .methodReader(
                             (Pinger) pingDTO -> sb.append("ping ").append(pingDTO));
-            assertEquals(PingDTO.constructionExpected, PingDTO.constructionCounter);
             while (reader.readOne()) ;
+            // moved this assert below the readOne as object may be constructed lazily
+            assertEquals(PingDTO.constructionExpected, PingDTO.constructionCounter);
             assertEquals("ping !PingDTO {\n" +
                     "  bytes: \"\"\n" +
                     "}\n" +

--- a/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
@@ -32,9 +32,8 @@ public class MethodReaderObjectReuseTest extends QueueTestCommon {
             MethodReader reader = cq.createTailer()
                     .methodReader(
                             (Pinger) pingDTO -> sb.append("ping ").append(pingDTO));
-            while (reader.readOne()) ;
-            // moved this assert below the readOne as object may be constructed lazily
             assertEquals(PingDTO.constructionExpected, PingDTO.constructionCounter);
+            while (reader.readOne()) ;
             assertEquals("ping !PingDTO {\n" +
                     "  bytes: \"\"\n" +
                     "}\n" +

--- a/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
@@ -8,10 +8,12 @@ import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+@Ignore("TODO: jerry to fix")
 @RequiredForClient
 public class MethodReaderObjectReuseTest extends QueueTestCommon {
     @Test


### PR DESCRIPTION
This PR reverts the deprecation of `ChronicleReaderMain` which is overridable and widely used. Code is deduplicated by letting the `InternalReaderMain` class simply inherit from `ChronicleReaderMain`.

Generally, I think we should break out main classes and similar utility features from the Queue library over time and have a separate repository for this type of functionality. The Queue library should provide as little as possible.