### PR TITLE
Implement lastIndex on ChronicleQueue

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -529,21 +529,11 @@ will only give you the last index appended by this appender; not the last index 
 If you wish to find the index of the last record written to the queue, then you have to call:
 
 ```
-ExcerptTailer tailer = queue.createTailer().toEnd().direction(TailerDirection.BACKWARD);
-try (DocumentContext dc = tailer.readingDocument()) {
-    if (dc.isPresent()) {
-        lastIndex = tailer.index());
-    }
-}
+queue.lastIndex()
 ```
-
-(note that `tailer.toEnd()` puts the tailer just past the last index written)
-
-Previously, we advised to call
-```
-lastIndex = queue.createTailer().toEnd().index() - 1;
-```
-But if the queue has rolled and there is no data in the new cycle, this will not work.
+Which will return the index of the last excerpt present in the queue (or -1 for an empty queue). Note that if the queue is
+being written to concurrently it's possible the value may be an under-estimate, as subsequent entries may have been written
+even before it was returned.
 
 === How to determine how many messages are between two indexes
 

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -212,6 +212,19 @@ public interface ChronicleQueue extends Closeable {
     long firstIndex();
 
     /**
+     * Returns the index of the last non-metadata excerpt written to this ChronicleQueue,
+     * or -1 if the queue is empty.
+     * <p>
+     * The value returned by this method will not be reliable in the event the queue
+     * is being written to concurrently, as subsequent excerpts may have been written
+     * by the time it is returned.
+     *
+     * @return The highest non-metadata index available for this ChronicleQueue, or -1 if
+     * the queue is empty
+     */
+    long lastIndex();
+
+    /**
      * Returns the {@link WireType} used for this ChronicleQueue.
      * <p>
      * For example, the WireType could be WireTypes.TEXT or WireTypes.BINARY.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -61,6 +61,7 @@ import java.util.function.*;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
+import static net.openhft.chronicle.queue.TailerDirection.BACKWARD;
 import static net.openhft.chronicle.queue.TailerDirection.NONE;
 import static net.openhft.chronicle.wire.Wires.*;
 
@@ -706,6 +707,20 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             return Long.MAX_VALUE;
 
         return rollCycle().toIndex(cycle, 0);
+    }
+
+    @Override
+    public long lastIndex() {
+        // This is a slow implementation that gets a Tailer/DocumentContext to find the last index
+        try (final ExcerptTailer tailer = createTailer().direction(BACKWARD).toEnd()) {
+            try (final DocumentContext documentContext = tailer.readingDocument()) {
+                if (documentContext.isPresent()) {
+                    return documentContext.index();
+                } else {
+                    return -1;
+                }
+            }
+        }
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -3611,4 +3611,49 @@ public class SingleChronicleQueueTest extends ChronicleQueueTestBase {
             Assert.assertEquals(expected, sb.toString());
         }
     }
+
+    @Test
+    public void lastIndexShouldReturnLastIndexForPopulatedQueue() {
+        File tmpDir = getTmpDir();
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(tmpDir).wireType(wireType).build()) {
+            long actualLastIndex;
+            try (ExcerptAppender appender = queue.acquireAppender()) {
+                appender.writeText("Hello!");
+                actualLastIndex = appender.lastIndexAppended();
+            }
+            assertEquals(actualLastIndex, queue.lastIndex());
+        }
+    }
+
+    @Test
+    public void lastIndexShouldReturnNegativeOneForEmptyQueue() {
+        File tmpDir = getTmpDir();
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(tmpDir).wireType(wireType).build()) {
+            assertEquals(-1, queue.lastIndex());
+        }
+    }
+
+    @Test
+    public void lastIndexShouldReturnNegativeOneForMetadataOnlyQueue() {
+        File tmpDir = getTmpDir();
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(tmpDir).wireType(wireType).build()) {
+            try (ExcerptAppender appender = queue.acquireAppender()) {
+                try (DocumentContext documentContext = appender.writingDocument(true)) {
+                    documentContext.wire().write().text("Hello!");
+                }
+            }
+            assertEquals(-1, queue.lastIndex());
+        }
+    }
+
+    @Test
+    public void lastIndexShouldReturnNegativeOneForEmptyPretouchedQueue() {
+        File tmpDir = getTmpDir();
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(tmpDir).wireType(wireType).build()) {
+            try (ExcerptAppender appender = queue.acquireAppender()) {
+                appender.pretouch();
+            }
+            assertEquals(-1, queue.lastIndex());
+        }
+    }
 }


### PR DESCRIPTION
As discussed last night, I've added an implementation of `lastIndex` for use when we are handshaking replication.