### PR TITLE
Re-enable and improve toEnd index tests after fix to #825

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
@@ -27,7 +27,10 @@ import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -39,6 +42,8 @@ import static org.junit.Assert.*;
 
 public class ToEndTest extends ChronicleQueueTestBase {
     private static final long FIVE_SECONDS = SECONDS.toMicros(5);
+    private static final String ZERO_AS_HEX_STRING = Long.toHexString(0);
+    private static final String LONG_MIN_VALUE_AS_HEX_STRING = Long.toHexString(Long.MIN_VALUE);
     private static List<File> pathsToDelete = new LinkedList<>();
     long lastCycle;
     private Map<ExceptionKey, Integer> exceptionKeyIntegerMap;
@@ -291,30 +296,33 @@ public class ToEndTest extends ChronicleQueueTestBase {
     }
 
     @Test
-    public void shouldReturnZeroForEmptyQueue() {
+    public void shouldReturnExpectedValuesForEmptyQueue() {
         SetTimeProvider timeProvider = new SetTimeProvider();
         try (final SingleChronicleQueue queue = createQueue(timeProvider)) {
-            assertEquals(0, getNextWriteIndex(queue));
+            assertEquals(ZERO_AS_HEX_STRING, tailerToEndIndex(queue));
+            assertEquals(LONG_MIN_VALUE_AS_HEX_STRING, lastWriteIndex(queue));
         }
     }
 
-    @Ignore("Broken by https://github.com/OpenHFT/Chronicle-Queue/issues/825")
     @Test
-    public void shouldReturnZeroForEmptyPretouchedQueue() {
+    public void shouldReturnExpectedValuesForEmptyPretouchedQueue() {
         SetTimeProvider timeProvider = new SetTimeProvider();
         try (final SingleChronicleQueue queue = createQueue(timeProvider)) {
             pretouchQueue(queue);
-            assertEquals(Long.MIN_VALUE, lastWriteIndex(queue));
+
+            assertEquals(ZERO_AS_HEX_STRING, tailerToEndIndex(queue));
+            assertEquals(LONG_MIN_VALUE_AS_HEX_STRING, lastWriteIndex(queue));
 
             timeProvider.advanceMicros(FIVE_SECONDS);
             pretouchQueue(queue);
-            assertEquals(Long.MIN_VALUE, lastWriteIndex(queue));
+
+            assertEquals(ZERO_AS_HEX_STRING, tailerToEndIndex(queue));
+            assertEquals(LONG_MIN_VALUE_AS_HEX_STRING, lastWriteIndex(queue));
         }
     }
 
-    @Ignore("Broken by https://github.com/OpenHFT/Chronicle-Queue/issues/825")
     @Test
-    public void shouldReturnZeroForQueueWithOnlyMetadata() {
+    public void shouldReturnExpectedValuesForQueueWithOnlyMetadata() {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.advanceMicros(FIVE_SECONDS);
         try (final SingleChronicleQueue queue = createQueue(timeProvider)) {
@@ -383,51 +391,55 @@ public class ToEndTest extends ChronicleQueueTestBase {
                     "\"\": hello!\n" +
                     "...\n" +
                     "# 130280 bytes remaining\n", queue.dump());
-            assertEquals(Long.MIN_VALUE, lastWriteIndex(queue));
+            assertEquals(LONG_MIN_VALUE_AS_HEX_STRING, lastWriteIndex(queue));
+            assertEquals(ZERO_AS_HEX_STRING, tailerToEndIndex(queue));
         }
     }
 
     @Test
-    public void shouldReturnNextWriteIndexForNonEmptyRolledByPretouch() {
+    public void shouldReturnExpectedValuesForNonEmptyQueueRolledByPretouch() {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.advanceMicros(FIVE_SECONDS);
         try (final SingleChronicleQueue queue = createQueue(timeProvider)) {
             writeExcerptToQueue(queue);
-            long nextIndex = getNextWriteIndex(queue);
+            String lastWriteIndexBefore = lastWriteIndex(queue);
+            String tailerToEndIndexBefore = tailerToEndIndex(queue);
 
             timeProvider.advanceMicros(FIVE_SECONDS);
-
             pretouchQueue(queue);
-            assertEquals(nextIndex, getNextWriteIndex(queue));
+
+            assertEquals(lastWriteIndexBefore, lastWriteIndex(queue));
+            assertEquals(tailerToEndIndexBefore, tailerToEndIndex(queue));
         }
     }
 
-    @Ignore("Broken by https://github.com/OpenHFT/Chronicle-Queue/issues/825")
     @Test
-    public void shouldReturnNextWriteIndexForNonEmptyRolledByMetadata() {
+    public void shouldReturnExpectedValuesForNonEmptyQueueRolledByMetadata() {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.advanceMicros(FIVE_SECONDS);
         try (final SingleChronicleQueue queue = createQueue(timeProvider)) {
             writeExcerptToQueue(queue);
-            long nextIndex = lastWriteIndex(queue);
+            String lastWriteIndexBefore = lastWriteIndex(queue);
+            String tailerToEndIndexBefore = tailerToEndIndex(queue);
 
             timeProvider.advanceMicros(FIVE_SECONDS);
-
             writeMetadataToQueue(queue);
-            assertEquals(nextIndex, lastWriteIndex(queue));
+
+            assertEquals(lastWriteIndexBefore, lastWriteIndex(queue));
+            assertEquals(tailerToEndIndexBefore, tailerToEndIndex(queue));
         }
     }
 
-    private long getNextWriteIndex(SingleChronicleQueue queue) {
+    private String tailerToEndIndex(SingleChronicleQueue queue) {
         try (final ExcerptTailer tailer = queue.createTailer().toEnd()) {
-            return tailer.index();
+            return Long.toHexString(tailer.index());
         }
     }
 
-    private long lastWriteIndex(SingleChronicleQueue queue) {
+    private String lastWriteIndex(SingleChronicleQueue queue) {
         try (final ExcerptTailer tailer = queue.createTailer().direction(TailerDirection.BACKWARD).toEnd();
-        DocumentContext dc = tailer.readingDocument()) {
-            return dc.index();
+             DocumentContext dc = tailer.readingDocument()) {
+            return Long.toHexString(dc.index());
         }
     }
 


### PR DESCRIPTION
This is just a PR to re-enable and improve the `toEnd` index tests after Peter's fixes to address #825 

I'm not sure if I've misunderstood it, but there seems to be one remaining discrepancy.

### `shouldReturnExpectedValuesForQueueWithOnlyMetadata`
In this test, there is a queue with a secondly roll-cycle that begins empty then has a metadata excerpt written to it after a 5 second delay. 

Afterwards
* `tailer.direction(BACKWARD).toEnd().index()` returns `Long.MIN_VALUE`
  * which is expected as there are no non-metadata excerpts.
* `tailer.toEnd().index()` returns `0x500000000` (sequence zero in the 5th roll cycle)
  * This suggests that `tailer.toEnd().index()` will return the index of the last metadata excerpt when a metadata excerpt is the last thing in the queue. Which if true, is inconsistent with....

### `shouldReturnExpectedValuesForQueueRolledByMetadata`
This test has a queue which begins empty, then an excerpt is appended to it after a 5 second delay, then after another 5 second delay a metadata excerpt is written.

We record the `tailer().toEnd().index()` after the first excerpt is written and again after the second (metadata) excerpt is written, and they are equal. So in this scenario the writing of the metadata excerpt does not advance `tailer().toEnd().index()`.

I'm not sure if this is expected behaviour but I don't think [the documentation](https://github.com/OpenHFT/Chronicle-Queue#excerpttailertoend) is clear.
Specifically 

> ...will place the tailer just after the last existing record in the queue

It seems in the empty queue scenario the definition of _last existing record_ includes metadata excerpts, where in the non-empty queue _last existing record_ does not include metadata excerpts.