### PR TITLE
improve inconsistent sourceId detection

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQMeta.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQMeta.java
@@ -96,8 +96,9 @@ public class SCQMeta implements Metadata {
             this.roll.rollTimeZone(roll.rollTimeZone());
         }
 
-        if (!(other.sourceId == 0 || sourceId == 0 || other.sourceId == sourceId)) {
-            Jvm.warn().on(getClass(), "inconsistency with of source ids, existing sourceId=" + other.sourceId + ", requested sourceId=" + sourceId);
+        if (other.sourceId != sourceId) {
+            Jvm.warn().on(getClass(), "Overriding sourceId from existing metadata, was " + sourceId + ", overriding to " + other.sourceId);
+            this.sourceId = other.sourceId;
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -122,7 +122,7 @@ public class SingleChronicleQueueBuilderTest extends ChronicleQueueTestBase {
 
     @Test
     public void tryOverrideSourceId() {
-        expectException("inconsistency with of source ids");
+        expectException("Overriding sourceId from existing metadata");
 
         final File tmpDir = getTmpDir();
         final int firstSourceId = 1;

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
@@ -57,6 +57,8 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
     }
 
     private void checkWithQueueHistoryRecordHistoryInitial(Class<? extends DummyListener> dummyClass) {
+        expectException("Overriding sourceId from existing metadata, was 0, overriding to");
+
         MessageHistory.set(null);
 
         int extraTiming = 1;

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
@@ -79,6 +79,7 @@ public class ChronicleMethodReaderTest extends ChronicleQueueTestBase {
                 i++;
             }
         }
+        expectException("Overriding sourceId from existing metadata, was 0, overriding to");
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
@@ -68,6 +68,7 @@ public class ChronicleReaderTest extends ChronicleQueueTestBase {
                 events.say(i % 2 == 0 ? "hello" : "goodbye");
             }
         }
+        expectException("Overriding sourceId from existing metadata, was 0, overriding to 1");
     }
 
     @Test(timeout = 10_000L)


### PR DESCRIPTION
I don't believe this is an impactive change but sending round as a PR in case anyone has any insight as to why the original condition included `other.sourceId == 0 || sourceId == 0`