### PR TITLE
Make createAppender blocking pluggable

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/NoOpCondition.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/NoOpCondition.java
@@ -1,0 +1,48 @@
+package net.openhft.chronicle.queue.impl.single;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+
+/**
+ * A condition that is always true
+ */
+public final class NoOpCondition implements Condition {
+
+    public static final NoOpCondition INSTANCE = new NoOpCondition();
+
+    private NoOpCondition() {}
+
+    @Override
+    public void await() throws InterruptedException {
+    }
+
+    @Override
+    public void awaitUninterruptibly() {
+    }
+
+    @Override
+    public long awaitNanos(long l) {
+        return l;
+    }
+
+    @Override
+    public boolean await(long l, TimeUnit timeUnit) throws InterruptedException {
+        return true;
+    }
+
+    @Override
+    public boolean awaitUntil(@NotNull Date date) {
+        return true;
+    }
+
+    @Override
+    public void signal() {
+    }
+
+    @Override
+    public void signalAll() {
+    }
+}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/NoopQueueLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/NoopQueueLock.java
@@ -17,6 +17,10 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
+/**
+ * @deprecated To be removed in .22
+ */
+@Deprecated
 public class NoopQueueLock implements QueueLock {
 
     @Override
@@ -33,6 +37,11 @@ public class NoopQueueLock implements QueueLock {
 
     @Override
     public void quietUnlock() {
+    }
+
+    @Override
+    public boolean isLocked() {
+        return false;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/QueueLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/QueueLock.java
@@ -19,6 +19,10 @@ package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.io.Closeable;
 
+/**
+ * @deprecated To be remove in .22
+ */
+@Deprecated
 public interface QueueLock extends Closeable {
 
     void waitForLock();
@@ -37,4 +41,11 @@ public interface QueueLock extends Closeable {
      * only unlocks if locked
      */
     void quietUnlock();
+
+    /**
+     * Is this lock locked?
+     *
+     * @return true if the lock is locked
+     */
+    boolean isLocked();
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/QueueLockUnlockedCondition.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/QueueLockUnlockedCondition.java
@@ -1,0 +1,58 @@
+package net.openhft.chronicle.queue.impl.single;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+
+/**
+ * An adapter so we can use the QueueLock as an acquireAppenderCondition for backward
+ * compatibility
+ *
+ * @deprecated This goes when QueueLock goes (.22)
+ */
+@Deprecated
+public class QueueLockUnlockedCondition implements Condition {
+
+    private final SingleChronicleQueue singleChronicleQueue;
+
+    public QueueLockUnlockedCondition(SingleChronicleQueue singleChronicleQueue) {
+        this.singleChronicleQueue = singleChronicleQueue;
+    }
+
+    @Override
+    public void await() throws InterruptedException {
+        singleChronicleQueue.queueLock().waitForLock();
+    }
+
+    @Override
+    public void awaitUninterruptibly() {
+        singleChronicleQueue.queueLock().waitForLock();
+    }
+
+    @Override
+    public long awaitNanos(long l) {
+        throw new UnsupportedOperationException("unsupported");
+    }
+
+    @Override
+    public boolean await(long l, TimeUnit timeUnit) throws InterruptedException {
+        throw new UnsupportedOperationException("unsupported");
+    }
+
+    @Override
+    public boolean awaitUntil(@NotNull Date date) {
+        throw new UnsupportedOperationException("unsupported");
+    }
+
+    @Override
+    public void signal() {
+        throw new UnsupportedOperationException("unsupported");
+    }
+
+    @Override
+    public void signalAll() {
+        throw new UnsupportedOperationException("unsupported");
+    }
+}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TSQueueLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TSQueueLock.java
@@ -30,7 +30,10 @@ import static net.openhft.chronicle.core.Jvm.warn;
 
 /**
  * Implements queue lock via TableStore mechanism.
+ *
+ * @deprecated To be removed in .22
  */
+@Deprecated
 public class TSQueueLock extends AbstractTSQueueLock implements QueueLock {
 
     private static final String LOCK_KEY = "chronicle.queue.lock";
@@ -152,6 +155,11 @@ public class TSQueueLock extends AbstractTSQueueLock implements QueueLock {
                 warn().on(getClass(), "Queue lock was locked by another thread, current-thread-tid=" + tid + ", lock value=" + value+", this lock was not removed.");
             }
         }
+    }
+
+    @Override
+    public boolean isLocked() {
+        return lockedBy() != UNLOCKED;
     }
 
     private boolean isLockHeldByCurrentThread(long tid) {


### PR DESCRIPTION
This PR just moves to using a `Condition` to block the creation of a new appender.

Currently we await on the QueueLock to be unlocked before a new appender is returned.

This change allows the Condition on which we wait to be configured. So the existing behaviour (waiting on the QueueLock) can be preserved until .22, but we can optionally provide a more sophisticated condition for those use cases where that's required.

The Condition interface is a bit of overkill, but its nice to use a standard interface here.