### PR TITLE
Await for createAppenderCondition interruptibly

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -352,7 +352,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         try {
             long firstIndex = firstIndex();
             writer.append("# firstIndex: ").append(Long.toHexString(firstIndex)).append("\n");
-            try (ExcerptTailer tailer = createTailer()){
+            try (ExcerptTailer tailer = createTailer()) {
                 if (!tailer.moveToIndex(fromIndex)) {
                     if (firstIndex > fromIndex) {
                         tailer.toStart();
@@ -437,9 +437,12 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
     @NotNull
     protected ExcerptAppender newAppender() {
-
-        createAppenderCondition.awaitUninterruptibly();
-
+        try {
+            createAppenderCondition.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted waiting for condition to create appender", e);
+        }
         final WireStorePool newPool = WireStorePool.withSupplier(storeSupplier, storeFileListener);
         return new StoreAppender(this, newPool, checkInterrupts);
     }


### PR DESCRIPTION
The problems we were seeing in the windows build were legitimate. I remember I waited uninterruptibly which seemed like a bad idea at the time, turns out it was. Instead here we wait until we're interrupted then throw an `IllegalStateException`, but re-setting the interrupted flag. There's not much else we can do here, I'd like to propagate the `InterruptedException`, but that's a big API change and the `QueueLock` throws `IllegalStateException` when it's interrupted anyhow so its not really a change in behaviour.