### PR TITLE
Don't create the createAppenderCondition for read-only queues

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -337,11 +337,13 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     }
 
     private void postBuild(@NotNull SingleChronicleQueue chronicleQueue) {
-        /*
-            The condition has a circular dependency with the Queue, so we need to add it after the queue is
-            constructed. This is to avoid passing `this` out of the constructor.
-         */
-        chronicleQueue.createAppenderCondition(requireNonNull(createAppenderConditionCreator().apply(chronicleQueue)));
+        if (!readOnly()) {
+            /*
+                The condition has a circular dependency with the Queue, so we need to add it after the queue is
+                constructed. This is to avoid passing `this` out of the constructor.
+             */
+            chronicleQueue.createAppenderCondition(requireNonNull(createAppenderConditionCreator().apply(chronicleQueue)));
+        }
     }
 
     private boolean checkEnterpriseFeaturesRequested() {
@@ -596,7 +598,6 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
 
     /**
      * Enable out-of-process pretoucher (AKA preloader) (Queue Enterprise feature)
-     *
      */
     public SingleChronicleQueueBuilder enablePreloader(final long pretouchIntervalMillis) {
         this.pretouchIntervalMillis = pretouchIntervalMillis;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -142,4 +142,21 @@ public class SingleChronicleQueueBuilderTest extends ChronicleQueueTestBase {
             assertEquals(firstSourceId, q.sourceId());
         }
     }
+
+    @Test
+    public void buildWillNotSetCreateAppenderConditionWhenQueueIsReadOnly() {
+        final File tmpDir = getTmpDir();
+        try (ChronicleQueue ignored = SingleChronicleQueueBuilder.single(tmpDir).build()) {
+            // just create the queue
+        }
+
+        try (SingleChronicleQueue ignored = SingleChronicleQueueBuilder.single(tmpDir)
+                .createAppenderConditionCreator(q -> {
+                    throw new AssertionError("This should never be called");
+                })
+                .readOnly(true)
+                .build()) {
+            // This will throw if we attempt to create the createAppender condition
+        }
+    }
 }


### PR DESCRIPTION
This is the first step to fixing ChronicleEnterprise/Chronicle-Services#242

When a read-only queue is created it will skip creating the `createAppenderCondition`.

The replicated queue `createAppenderCondition` attempts to acquire a long value from the table store which requires getting an exclusive lock. We should skip this for read-only tables as we may not have permission to do that, and we don't need it anyway, because you can't acquire an appender on a read-only table.