### PR TITLE
Manage nested writing document calls counter

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -25,10 +25,7 @@ import net.openhft.chronicle.core.annotation.PackageLocal;
 import net.openhft.chronicle.core.announcer.Announcer;
 import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.Closeable;
-import net.openhft.chronicle.core.threads.CleaningThreadLocal;
-import net.openhft.chronicle.core.threads.EventLoop;
-import net.openhft.chronicle.core.threads.OnDemandEventLoop;
-import net.openhft.chronicle.core.threads.ThreadLocalHelper;
+import net.openhft.chronicle.core.threads.*;
 import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.core.util.StringUtils;
 import net.openhft.chronicle.core.values.LongValue;
@@ -433,7 +430,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             createAppenderCondition.await();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted waiting for condition to create appender", e);
+            throw new InterruptedRuntimeException("Interrupted waiting for condition to create appender", e);
         }
         final WireStorePool newPool = WireStorePool.withSupplier(storeSupplier, storeFileListener);
         return new StoreAppender(this, newPool, checkInterrupts);

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -330,6 +330,15 @@ class StoreAppender extends AbstractCloseable
         // we allow the sink process to write metaData
         checkAppendLock(metaData);
         count++;
+        try {
+            return prepareAndReturnWriteContext(metaData);
+        } catch (RuntimeException e) {
+            count--;
+            throw e;
+        }
+    }
+
+    private StoreAppender.StoreAppenderContext prepareAndReturnWriteContext(boolean metaData) {
         if (count > 1) {
             assert metaData == writeContext.metaData;
             return writeContext;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -6,6 +6,7 @@ import net.openhft.chronicle.core.StackTrace;
 import net.openhft.chronicle.core.annotation.UsedViaReflection;
 import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.QueueSystemProperties;
@@ -869,7 +870,7 @@ class StoreAppender extends AbstractCloseable
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new IllegalStateException(e);
+                throw new InterruptedRuntimeException(e);
             } catch (StreamCorruptedException | UnrecoverableTimeoutException e) {
                 throw new IllegalStateException(e);
             } finally {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TSQueueLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TSQueueLock.java
@@ -17,6 +17,7 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
+import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
 import net.openhft.chronicle.queue.impl.TableStore;
 import net.openhft.chronicle.queue.impl.table.AbstractTSQueueLock;
 import net.openhft.chronicle.threads.Pauser;
@@ -64,8 +65,8 @@ public class TSQueueLock extends AbstractTSQueueLock implements QueueLock {
         Pauser tlPauser = pauser.get();
         try {
             while (!lock.compareAndSwapValue(UNLOCKED, lockValueFromTid)) {
-                if (count++ > 1000 && Thread.interrupted())
-                    throw new IllegalStateException("Interrupted");
+                if (count++ > 1000 && Thread.currentThread().isInterrupted())
+                    throw new InterruptedRuntimeException("Interrupted");
                 tlPauser.pause(timeout, TimeUnit.MILLISECONDS);
                 value = lock.getVolatileValue();
             }
@@ -99,8 +100,8 @@ public class TSQueueLock extends AbstractTSQueueLock implements QueueLock {
         Pauser tlPauser = pauser.get();
         try {
             while (value!=UNLOCKED) {
-                if (Thread.interrupted())
-                    throw new IllegalStateException("Interrupted");
+                if (Thread.currentThread().isInterrupted())
+                    throw new InterruptedRuntimeException("Interrupted");
                 tlPauser.pause(timeout, TimeUnit.MILLISECONDS);
                 value = lock.getVolatileValue();
             }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLock.java
@@ -18,6 +18,7 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.StackTrace;
+import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
 import net.openhft.chronicle.queue.impl.TableStore;
 import net.openhft.chronicle.queue.impl.table.AbstractTSQueueLock;
 import net.openhft.chronicle.threads.TimingPauser;
@@ -64,8 +65,8 @@ public class TableStoreWriteLock extends AbstractTSQueueLock implements WriteLoc
             long start = System.currentTimeMillis();
             while (!lock.compareAndSwapValue(UNLOCKED, PID)) {
                 // add a tiny delay
-                if (Thread.interrupted())
-                    throw new IllegalStateException("Interrupted for the lock file:" + path);
+                if (Thread.currentThread().isInterrupted())
+                    throw new InterruptedRuntimeException("Interrupted for the lock file:" + path);
                 tlPauser.pause(timeout, TimeUnit.MILLISECONDS);
                 value = lock.getVolatileValue();
             }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -1,0 +1,156 @@
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.util.concurrent.Semaphore;
+
+import static org.junit.Assert.assertEquals;
+
+public class StoreAppenderTest {
+
+    public static final String TEST_TEXT = "Some text some text some text";
+
+    @Test
+    public void writingDocumentAcquisitionWorksAfterInterruptedAttempt() throws InterruptedException {
+        final Path queueDirectory = IOTools.createTempDirectory("StoreAppenderTest.writingDocumentAcquisitionWorksAfterInterruptedAttempt");
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.toFile()).build()) {
+            final BlockingWriter blockingWriter = new BlockingWriter(queue);
+            final BlockedWriter blockedWriter = new BlockedWriter(queue);
+
+            writeSomeText(queue, 5);
+            blockedWriter.makeSuccessfulWrite();
+            writeSomeText(queue, 5);
+
+            expectTestText(queue, 11);
+
+            blockingWriter.blockWrites();
+            blockedWriter.makeInterruptedAttemptToWrite();
+            blockingWriter.unblockWrites();
+            writeSomeText(queue, 5);
+
+            blockedWriter.makePostInterruptAttemptToWrite();
+
+            expectTestText(queue, 16);
+        }
+    }
+
+    private void expectTestText(ChronicleQueue chronicleQueue, int times) {
+        try (final ExcerptTailer tailer = chronicleQueue.createTailer()) {
+            for (int i = 0; i < times; i++) {
+                assertEquals(TEST_TEXT, tailer.readText());
+            }
+        }
+    }
+
+    private void writeSomeText(ChronicleQueue chronicleQueue, int times) {
+        try (final ExcerptAppender appender = chronicleQueue.acquireAppender()) {
+            for (int i = 0; i < times; i++) {
+                appender.writeText(TEST_TEXT);
+            }
+        }
+    }
+
+    static class BlockedWriter {
+
+        private Thread t;
+        private final SingleChronicleQueue queue;
+        private Semaphore waitingToAcquire;
+        private Semaphore waitingAfterInterrupt;
+
+        public BlockedWriter(SingleChronicleQueue queue) {
+            this.queue = queue;
+        }
+
+        public void makeSuccessfulWrite() {
+            waitingToAcquire = new Semaphore(0);
+            waitingAfterInterrupt = new Semaphore(0);
+            t = new Thread(this::makeInterruptedWriteAttemptThenTryAgain);
+            t.setName("blocked-writer");
+            t.start();
+            waitForThreads(waitingToAcquire);
+        }
+
+        public void makeInterruptedAttemptToWrite() {
+            waitingToAcquire.release(1);
+            // Wait till the lock() call has been made
+            Jvm.pause(10);
+            t.interrupt();
+            waitForThreads(waitingAfterInterrupt);
+        }
+
+        public void makePostInterruptAttemptToWrite() throws InterruptedException {
+            waitingAfterInterrupt.release();
+            t.join();
+        }
+
+        private void makeInterruptedWriteAttemptThenTryAgain() {
+            try (final ExcerptAppender appender = queue.acquireAppender()) {
+                appender.writeText(TEST_TEXT);
+                acquire(waitingToAcquire);
+                try (final DocumentContext documentContext = appender.writingDocument()) {
+                    throw new AssertionError("We shouldn't get here");
+                } catch (InterruptedRuntimeException e) {
+                    // This is expected, we should get interrupted, clear the interrupt
+                    Thread.interrupted();
+                }
+                acquire(waitingAfterInterrupt);
+                appender.writeText(TEST_TEXT);
+            }
+        }
+    }
+
+    static class BlockingWriter {
+
+        private Thread t;
+        private final SingleChronicleQueue queue;
+        private final Semaphore inWritingDocument = new Semaphore(0);
+
+        public BlockingWriter(SingleChronicleQueue queue) {
+            this.queue = queue;
+        }
+
+        public void blockWrites() {
+            t = new Thread(this::acquireWritingDocumentThenBlock);
+            t.setName("blocking-writer");
+            t.start();
+            waitForThreads(inWritingDocument);
+        }
+
+        public void unblockWrites() throws InterruptedException {
+            inWritingDocument.release(1);
+            t.join();
+            t = null;
+        }
+
+        private void acquireWritingDocumentThenBlock() {
+            try (final ExcerptAppender appender = queue.acquireAppender()) {
+                try (final DocumentContext documentContext = appender.writingDocument()) {
+                    acquire(inWritingDocument);
+                    documentContext.rollbackOnClose();
+                }
+            }
+        }
+    }
+
+    private static void acquire(Semaphore semaphore) {
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            throw new AssertionError("This shouldn't happen");
+        }
+    }
+
+    private static void waitForThreads(Semaphore semaphore) {
+        while (!semaphore.hasQueuedThreads()) {
+            Jvm.pause(10);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #896

Also use InterruptedRuntimeException instead of IllegalStateException and stop clearing interrupted flag in interrupted locks