### PR TITLE
Support binary search in the presence of excerpts that can't be compared

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/BinarySearch.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/BinarySearch.java
@@ -55,6 +55,7 @@ public enum BinarySearch {
                                               @NotNull Comparator<Wire> c,
                                               @NotNull ExcerptTailer tailer,
                                               @NotNull final ChronicleQueue queue) {
+        long readPosition = key.bytes().readPosition();
 
         final Iterator<Long> iterator = cycles.iterator();
         if (!iterator.hasNext())
@@ -89,6 +90,8 @@ public enum BinarySearch {
                         break;
                     } catch (NotComparableException e) {
                         // Keep scanning forward
+                    } finally {
+                        key.bytes().readPosition(readPosition);
                     }
                 }
             }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/NotComparableException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/NotComparableException.java
@@ -1,0 +1,16 @@
+package net.openhft.chronicle.queue.impl.single;
+
+/**
+ * Thrown by a binary search comparator when the value we're searching on is not present in the current
+ * entry.
+ * <p>
+ * The assumption is that this occurs rarely. If it does, it will significantly reduce the performance
+ * of the binary search.
+ */
+public final class NotComparableException extends RuntimeException {
+
+    public static final NotComparableException INSTANCE = new NotComparableException();
+
+    private NotComparableException() {
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
@@ -1,0 +1,165 @@
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.annotation.RequiredForClient;
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.queue.*;
+import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.SelfDescribingMarshallable;
+import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.text.ParseException;
+import java.util.*;
+
+import static org.junit.Assert.assertTrue;
+
+
+@RequiredForClient
+@RunWith(Parameterized.class)
+public class SparseBinarySearchTest extends ChronicleQueueTestBase {
+
+    private static final GapTolerantComparator GAP_TOLERANT_COMPARATOR = new GapTolerantComparator();
+
+    private final int numberOfMessages;
+    private final float percentageWithValues;
+
+    public SparseBinarySearchTest(int numberOfMessages, float percentageWithValues) {
+        this.numberOfMessages = numberOfMessages;
+        this.percentageWithValues = percentageWithValues;
+    }
+
+    @Parameterized.Parameters(name = "items in queue: {0}, percentage with values: {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> parameters = new ArrayList<>();
+        List<Integer> numbersOfMessages = Arrays.asList(0, 1, 2, 100);
+        List<Float> percentagesWithValues = Arrays.asList(0.0f, 0.1f, 0.9f);
+
+        for (int nom : numbersOfMessages) {
+            for (float pwv : percentagesWithValues) {
+                parameters.add(new Object[]{nom, pwv});
+            }
+        }
+        return parameters;
+    }
+
+    @Test
+    public void testBinarySearchWithManyGapsAndManyRollCycles() throws ParseException {
+        runWithTimeParameters(RollCycles.TEST_SECONDLY, 300);
+    }
+
+    @Test
+    public void testBinarySearchWithManyGaps() throws ParseException {
+        runWithTimeParameters(RollCycles.DAILY, 1);
+    }
+
+    public void runWithTimeParameters(RollCycle rollCycle, long incrementInMillis) throws ParseException {
+        final SetTimeProvider stp = new SetTimeProvider();
+        stp.currentTimeMillis(0);
+
+        try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(getTmpDir())
+                .rollCycle(rollCycle)
+                .timeProvider(stp)
+                .build()) {
+
+            final ExcerptAppender appender = queue.acquireAppender();
+            Set<Integer> entriesWithValues = new HashSet<>();
+            Random random = new Random();
+            for (int i = 0; i < numberOfMessages; i++) {
+                try (final DocumentContext dc = appender.writingDocument()) {
+                    final MyData myData = new MyData();
+                    final boolean putValueAtIndex = random.nextFloat() < percentageWithValues;
+                    myData.key = putValueAtIndex ? i : -1;
+                    myData.value = "some value where the key=" + i;
+                    dc.wire().getValueOut().typedMarshallable(myData);
+                    stp.currentTimeMillis(stp.currentTimeMillis() + incrementInMillis);
+                    if (putValueAtIndex) {
+                        entriesWithValues.add(i);
+                    }
+                }
+            }
+
+            try (final ExcerptTailer tailer = queue.createTailer()) {
+                for (int j = 0; j < numberOfMessages; j++) {
+                    try (DocumentContext ignored = tailer.readingDocument()) {
+                        Wire key = toWire(j);
+                        long index = BinarySearch.search(queue, key, GAP_TOLERANT_COMPARATOR);
+                        if (entriesWithValues.contains(j)) {
+                            Assert.assertEquals(tailer.index(), index);
+                        } else {
+                            assertTrue(index < 0);
+                        }
+                        key.bytes().releaseLast();
+                    }
+                }
+            }
+
+            Wire key = toWire(numberOfMessages);
+            assertTrue("Should not find non-existent", BinarySearch.search(queue, key, GAP_TOLERANT_COMPARATOR) < 0);
+        }
+    }
+
+    static class GapTolerantComparator implements Comparator<Wire> {
+
+        @Override
+        public int compare(Wire o1, Wire o2) {
+            final long readPositionO1 = o1.bytes().readPosition();
+            final long readPositionO2 = o2.bytes().readPosition();
+            try {
+                final MyData myDataO1;
+                try (final DocumentContext dc = o1.readingDocument()) {
+                    myDataO1 = dc.wire().getValueIn().typedMarshallable();
+                }
+
+                final MyData myDataO2;
+                try (final DocumentContext dc = o2.readingDocument()) {
+                    myDataO2 = dc.wire().getValueIn().typedMarshallable();
+                }
+
+                if (myDataO1.key >= 0 && myDataO2.key >= 0) {
+                    final int compare = Integer.compare(myDataO1.key, myDataO2.key);
+                    return compare;
+                } else {
+                    throw NotComparableException.INSTANCE;
+                }
+            } finally {
+                o1.bytes().readPosition(readPositionO1);
+                o2.bytes().readPosition(readPositionO2);
+            }
+        }
+    }
+
+    @NotNull
+    private Wire toWire(int key) {
+        final MyData myData = new MyData();
+        myData.key = key;
+        myData.value = Integer.toString(key);
+        Wire wire = WireType.BINARY.apply(Bytes.elasticByteBuffer());
+        wire.usePadding(true);
+
+        try (final DocumentContext dc = wire.writingDocument()) {
+            dc.wire().getValueOut().typedMarshallable(myData);
+        }
+
+        return wire;
+    }
+
+    public static class MyData extends SelfDescribingMarshallable {
+        private int key;
+        private String value;
+
+        @NotNull
+        @Override
+        public String toString() {
+            return "MyData{" +
+                    "key=" + key +
+                    ", value='" + value + '\'' +
+                    '}';
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/TimestampComparator.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/TimestampComparator.java
@@ -1,6 +1,7 @@
 package net.openhft.chronicle.queue.internal.reader;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.queue.impl.single.NotComparableException;
 import net.openhft.chronicle.queue.reader.Reader;
 import net.openhft.chronicle.queue.reader.comparator.BinarySearchComparator;
 import net.openhft.chronicle.wire.ServicesTimestampLongConverter;
@@ -33,6 +34,8 @@ public class TimestampComparator implements BinarySearchComparator {
             final long key1 = wire1.read(TS).int64();
             final long key2 = wire2.read(TS).int64();
             return Long.compare(key1, key2);
+        } catch (Exception e) {
+            throw NotComparableException.INSTANCE;
         } finally {
             wire1.bytes().readPosition(readPositionO1);
             wire2.bytes().readPosition(readPositionO2);


### PR DESCRIPTION
In implementing the start-from-timestamp functionality in chronicle reader, we ran into the issue in services that there are queue excerpts that contain only history entries and no "payload". This meant that binary search was unable to continue. This PR changes the binary search to be tolerant of "sparse" data. Comparators can optionally throw `NotComparableException` when given an excerpt that can't be compared, and the binary search will walk forward until it finds an entry that can be compared.

The assumption here is that non-comparable excerpts are rare and don't appear in long sequences. The less true that assumption is, the worse this search will perform and may perform worse than a linear search in extreme cases.

An optimisation would be to make more effort to find the "middle" comparable element, so trying elements in distance-from-current-middle order (i.e. in both directions) rather than just moving the "middle" to the right like we do. That would be an optimisation we could add easily if it was deemed worthwhile.

With a comparator that never throws `NotComparableException`, the behaviour should be identical to the previous implementation.