### PR TITLE
Expose forceUnlockIfProcessIsDead and isLockedByCurrentProcess via the WriteLock interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,22 @@
                     <scmBranch>gh-pages</scmBranch>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ReadOnlyWriteLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ReadOnlyWriteLock.java
@@ -17,6 +17,8 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
+import java.util.function.LongConsumer;
+
 public class ReadOnlyWriteLock implements WriteLock {
     @Override
     public void lock() {
@@ -30,5 +32,16 @@ public class ReadOnlyWriteLock implements WriteLock {
 
     @Override
     public void close() {
+    }
+
+    @Override
+    public boolean forceUnlockIfProcessIsDead() {
+        throw new IllegalStateException("Queue is read-only");
+    }
+
+    @Override
+    public boolean isLockedByCurrentProcess(LongConsumer notCurrentProcessConsumer) {
+        notCurrentProcessConsumer.accept(Long.MAX_VALUE);
+        return false;
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/WriteLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/WriteLock.java
@@ -18,6 +18,7 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import java.io.Closeable;
+import java.util.function.LongConsumer;
 
 public interface WriteLock extends Closeable {
 
@@ -33,6 +34,16 @@ public interface WriteLock extends Closeable {
 
         @Override
         public void close() {
+        }
+
+        @Override
+        public boolean forceUnlockIfProcessIsDead() {
+            return true;
+        }
+
+        @Override
+        public boolean isLockedByCurrentProcess(LongConsumer notCurrentProcessConsumer) {
+            return true;
         }
     };
 
@@ -52,4 +63,31 @@ public interface WriteLock extends Closeable {
     default boolean locked() {
         return false;
     }
+
+    /**
+     * Forcibly unlocks only if the process that currently holds the lock is no-longer running.
+     * <p>
+     * This will leave the lock in following states:
+     * <ul>
+     *   <li>
+     *     <b>unlocked</b>
+     *     <ul>
+     *       <li>if the lock was already unlocked</li>
+     *       <li>if the lock was held by a dead process</li>
+     *     </ul>
+     *   </li>
+     *   <li>
+     *     <b>locked</b>
+     *     <ul>
+     *       <li>if the lock was held by the current process</li>
+     *       <li>if the lock was held by another live process</li>
+     *     </ul>
+     *   </li>
+     * </ul>
+     *
+     * @return {@code true} lock was left in an <b>unlocked</b> state, {@code false} if the lock was left in a <b>locked</b> state.
+     */
+    boolean forceUnlockIfProcessIsDead();
+
+    boolean isLockedByCurrentProcess(LongConsumer notCurrentProcessConsumer);
 }


### PR DESCRIPTION
Just so we don't need to downcast to do this that whole lock hierarchy could probably do with a review, I wonder how much if it is still necessary

Also changed so that ChronicleQueue subclasses don't have to re-implement the createAppenderCondition blocking when overriding appender creation

And publish test sources, to go with the test jar we already publish