### PR TITLE
Optimize table directory refresh

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -173,9 +173,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             readOnly = builder.readOnly();
 
             if (readOnly) {
-                this.directoryListing = new FileSystemDirectoryListing(path, fileToCycleFunction());
+                this.directoryListing = new FileSystemDirectoryListing(path, fileNameToCycleFunction());
             } else {
-                this.directoryListing = new TableDirectoryListing(metaStore, path.toPath(), fileToCycleFunction());
+                this.directoryListing = new TableDirectoryListing(metaStore, path.toPath(), fileNameToCycleFunction());
                 directoryListing.init();
             }
 
@@ -812,8 +812,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         return directoryListing.getMaxCreatedCycle();
     }
 
+    @Deprecated(/* to be removed in x.23 */)
     protected int fileToCycle(final File queueFile) {
-        return fileToCycleFunction().applyAsInt(queueFile);
+        return fileNameToCycleFunction().applyAsInt(queueFile.getName());
     }
 
     @NotNull
@@ -872,11 +873,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     @NotNull
-    private ToIntFunction<File> fileToCycleFunction() {
-        return f -> {
-            final String name = f.getName();
-            return dateCache.parseCount(name.substring(0, name.length() - SUFFIX.length()));
-        };
+    private ToIntFunction<String> fileNameToCycleFunction() {
+        return name -> dateCache.parseCount(name.substring(0, name.length() - SUFFIX.length()));
     }
 
     void removeCloseListener(final StoreTailer storeTailer) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
@@ -34,7 +34,7 @@ public class TableDirectoryListingTest extends ChronicleQueueTestBase {
                 binary(tableFile, Metadata.NoMeta.INSTANCE).build();
         listing = new TableDirectoryListing(tablestore,
                 testDirectory.toPath(),
-                f -> Integer.parseInt(f.getName().split("\\.")[0]));
+                f -> Integer.parseInt(f.split("\\.")[0]));
         listing.init();
         tempFile = File.createTempFile("foo", "bar");
         tempFile.deleteOnExit();


### PR DESCRIPTION
The fix is based on the fact that lexicographical order of queue files matches the chronological order. It allows to avoid parsing every file name, which is quite expensive. We still generate an array of strings for every refresh, but it demonstrates surprisingly low pressure, probably due to built-in string deduplication (since Java 8).
I have also tried approaches with `Files#walkFileTree` or directory streams, they appeared to be very garbag-y as well.
Allocation stats for 1 minute run are below, the fix decreases total amount of allocated space from 31M to 56K.

Before the fix:
![before_fix_alloc](https://user-images.githubusercontent.com/2736390/137036884-d7fa4796-d88b-4f85-8916-9e858e9de4d5.png)
![before_fix_gc](https://user-images.githubusercontent.com/2736390/137036897-aaf03295-e740-4047-874e-d1b99d4b01ba.png)
After the fix:
![after_fix_alloc](https://user-images.githubusercontent.com/2736390/137036925-24985005-cb46-4956-98fa-8c376d4e9046.png)
![after_fix_gc](https://user-images.githubusercontent.com/2736390/137036954-73875645-cbe7-4c8d-836f-2f1f71351f16.png)

The difference was measured in synthetic scenario:
- RollCycles.MINUTELY
- ~5k queue files
- forceDirectoryListingRefreshIntervalMs is forced to 1s
- jvm.resource.tracing=false
- assertions disabled
- one record is appended to the queue every 1s