### PR TITLE
Recover from _some_ missing files scenarios more gracefully, improve testing

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/MissingStoreFileException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/MissingStoreFileException.java
@@ -1,0 +1,10 @@
+package net.openhft.chronicle.queue.impl.single;
+
+/**
+ * Thrown when a store file we expect to be present is missing (probably because it was deleted)
+ */
+public class MissingStoreFileException extends IllegalStateException {
+    public MissingStoreFileException(String s) {
+        super(s);
+    }
+}


### PR DESCRIPTION
Fixes #913 (somewhat)

This PR fixes some of the low-hanging-fruit places where we used to choke on a missing file. Basically just repeating the pattern of "refresh directory listing and retry once when a file that we expect to be there is not".

Still lots of things will be broken under this scenario but this PR makes it a tiny bit more resilient, while being, I think, a low-risk change.

I won't be offended if this is rejected, I was ambivalent about the change, because it's not a proper fix. But perfect is the enemy of good.