### PR TITLE
Refresh directory listing and retry before failing nextCycle due to a missing store file

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1223,7 +1223,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
                 if (!fileFound) {
                     directoryListing.refresh(true);
-                    throw new IllegalStateException(
+                    throw new MissingStoreFileException(
                             String.format("Expected file to exist for cycle: %d, file: %s.%nminCycle: %d, maxCycle: %d%n" +
                                             "Available files: %s",
                                     currentCycle, currentCycleFile,
@@ -1240,7 +1240,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 file = tree.get(key);
             }
             if (file == null) {
-                throw new AssertionError("missing currentCycle, file=" + currentCycleFile);
+                throw new MissingStoreFileException("missing currentCycle, file=" + currentCycleFile);
             }
 
             switch (direction) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -500,6 +500,15 @@ class StoreTailer extends AbstractCloseable
     }
 
     private long nextIndexWithNextAvailableCycle(final int cycle) {
+        try {
+            return nextIndexWithNextAvailableCycle0(cycle);
+        } catch (MissingStoreFileException e) {
+            queue.refreshDirectoryListing();
+            return nextIndexWithNextAvailableCycle0(cycle);
+        }
+    }
+
+    private long nextIndexWithNextAvailableCycle0(final int cycle) {
         assert cycle != Integer.MIN_VALUE : "cycle == Integer.MIN_VALUE";
 
         if (cycle > queue.lastCycle() || direction == TailerDirection.NONE) {

--- a/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
@@ -4,6 +4,7 @@ import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.core.util.ObjectUtils;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import org.jetbrains.annotations.NotNull;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -13,6 +14,11 @@ public class RollCycleDefaultingTest extends QueueTestCommon {
     @Test
     public void alias() {
         assertEquals(RollCycles.class, ObjectUtils.implementationToUse(RollCycle.class));
+    }
+
+    @After
+    public void clearDefaultRollCycleProperty() {
+        System.clearProperty(QueueSystemProperties.DEFAULT_ROLL_CYCLE_PROPERTY);
     }
 
     @Test
@@ -99,6 +105,6 @@ public class RollCycleDefaultingTest extends QueueTestCommon {
         public long maxMessagesPerCycle() {
             return 0;
         }
-        
+
     }
 }


### PR DESCRIPTION
Fixes #948

I don't like this fix, and the fact we've implemented similar fixes in a few places makes me think there's a better place to catch this stuff, but the tests indicate it fixes the reported problem.