### PR TITLE
Allow named tailers to be used concurrently to split work #964

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -541,6 +541,12 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         return storeTailer;
     }
 
+    /**
+     * The last index read for a named tailer.
+     *
+     * @param id of the last index
+     * @return the LongValue reference to this value.
+     */
     @Override
     @NotNull
     public LongValue indexForId(@NotNull String id) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -205,10 +205,8 @@ class StoreTailer extends AbstractCloseable
     DocumentContext readingDocumentNamed(final boolean includeMetaData) {
         for (int i = 0; i < 1_000_000; i++) {
             this.indexChecker = indexValue.getVolatileValue();
-            if (this.index != indexChecker) {
-                System.out.println("move " + Long.toHexString(this.index) + " to " + Long.toHexString(indexChecker));
+            if (this.index != indexChecker)
                 moveToIndex(this.indexChecker);
-            }
 
             DocumentContext documentContext = readingDocument0(includeMetaData);
 

--- a/src/test/java/net/openhft/chronicle/queue/ConcurrentNamedTailersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ConcurrentNamedTailersTest.java
@@ -1,0 +1,211 @@
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.ref.LongReference;
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.wire.DocumentContext;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConcurrentNamedTailersTest {
+    @Test
+    public void concurrentNamedTailers() {
+        File tmpDir = new File(OS.getTarget(), IOTools.tempName("concurrentNamedTailers"));
+
+        final SetTimeProvider timeProvider = new SetTimeProvider("2021/12/03T12:34:56").advanceMillis(1000);
+        final String tailerName = "named";
+        try (ChronicleQueue q = SingleChronicleQueueBuilder.single(tmpDir).testBlockSize().timeProvider(timeProvider).build();
+             final ExcerptAppender appender = q.acquireAppender();
+             final ExcerptTailer tailer0 = q.createTailer(tailerName);
+             final ExcerptTailer tailer1 = q.createTailer(tailerName);
+             final ExcerptTailer tailer2 = q.createTailer(tailerName)) {
+
+            final Tasker tasker = appender.methodWriter(Tasker.class);
+            for (int i = 0; i < 20; i++)
+                tasker.task(i);
+
+            assertEquals(0x0, tailer0.index());
+            assertEquals(0x0, tailer1.index());
+            assertEquals(0x0, tailer2.index());
+
+            try (DocumentContext dc0 = tailer0.readingDocument()) {
+                assertEquals(0x4a1400000000L, tailer0.index());
+
+                try (DocumentContext dc1 = tailer1.readingDocument()) {
+                    assertEquals(0x4a1400000001L, tailer1.index());
+                    assertEquals(0x4a1400000000L, tailer0.index());
+
+                    try (DocumentContext dc2 = tailer2.readingDocument()) {
+                        assertEquals(0x4a1400000002L, tailer2.index());
+                        assertEquals(0x4a1400000001L, tailer1.index());
+                        assertEquals(0x4a1400000000L, tailer0.index());
+                    }
+                }
+            }
+
+            try (DocumentContext dc0 = tailer0.readingDocument()) {
+                assertEquals(0x4a1400000003L, tailer0.index());
+
+                assertTrue(tailer2.moveToIndex(0x4a140000000AL));
+
+                try (DocumentContext dc1 = tailer1.readingDocument()) {
+                    assertEquals(0x4a140000000AL, tailer1.index());
+                    assertEquals(0x4a1400000003L, tailer0.index());
+
+                    try (DocumentContext dc2 = tailer2.readingDocument()) {
+                        assertEquals(0x4a140000000BL, tailer2.index());
+                        assertEquals(0x4a140000000AL, tailer1.index());
+                        assertEquals(0x4a1400000003L, tailer0.index());
+                    }
+                }
+            }
+
+            IOTools.deleteDirWithFiles(tmpDir);
+        }
+    }
+
+    @Test
+    public void raceConditions() throws IllegalAccessException {
+        File tmpDir = new File(OS.getTarget(), IOTools.tempName("raceConditions"));
+
+        final SetTimeProvider timeProvider = new SetTimeProvider("2021/12/03T12:34:56").advanceMillis(1000);
+        final String tailerName = "named";
+        try (ChronicleQueue q = SingleChronicleQueueBuilder.single(tmpDir).testBlockSize().timeProvider(timeProvider).build();
+             final ExcerptAppender appender = q.acquireAppender();
+             final ExcerptTailer tailer0 = q.createTailer(tailerName)) {
+
+            final Tasker tasker = appender.methodWriter(Tasker.class);
+            for (int i = 0; i < 20; i++)
+                tasker.task(i);
+
+            DummyLongReference indexValue = new DummyLongReference();
+            Jvm.getField(tailer0.getClass(), "indexValue")
+                    .set(tailer0, indexValue);
+
+            indexValue.getValues.add(0x4a1100000000L);
+
+            assertEquals(0x4a1100000000L, tailer0.index());
+
+            assertEquals(0, indexValue.setValues.size());
+
+            indexValue.getValues.add(0x4a1100000000L);
+            indexValue.getValues.add(0x4a1200000000L);
+            // pretend another tailer came in
+            indexValue.getValues.add(0x4a1400000001L);
+            indexValue.getValues.add(0x4a1400000001L);
+            indexValue.getValues.add(0x4a1400000001L);
+
+
+            try (DocumentContext dc0 = tailer0.readingDocument()) {
+                assertEquals(0x4a1400000001L, tailer0.index());
+            }
+
+            // changed before read
+            indexValue.getValues.add(0x4a1400000003L);
+            indexValue.getValues.add(0x4a1400000003L);
+
+            // changed during read
+            indexValue.getValues.add(0x4a1400000005L);
+            // changed during read again
+            indexValue.getValues.add(0x4a1400000007L);
+            // stable
+            indexValue.getValues.add(0x4a1400000007L);
+            indexValue.getValues.add(0x4a1400000007L);
+
+            try (DocumentContext dc0 = tailer0.readingDocument()) {
+                assertEquals(0x4a1400000007L, tailer0.index());
+            }
+            assertEquals("[4a1400000002, 4a1400000003, 4a1400000007, 4a1400000007, 4a1400000008]",
+                    indexValue.setValues.stream().map(Long::toHexString).collect(Collectors.toList()).toString());
+
+            IOTools.deleteDirWithFiles(tmpDir);
+        }
+    }
+
+    interface Tasker {
+        void task(int taskId);
+    }
+
+    static class DummyLongReference implements LongReference {
+        List<Long> getValues = new ArrayList<>();
+        List<Long> setValues = new ArrayList<>();
+
+        @Override
+        public void bytesStore(BytesStore bytesStore, long offset, long length) throws IllegalStateException, IllegalArgumentException, BufferOverflowException, BufferUnderflowException {
+            throw new AssertionError();
+        }
+
+        @Override
+        public @Nullable BytesStore bytesStore() {
+            throw new AssertionError();
+        }
+
+        @Override
+        public long offset() {
+            return 0;
+        }
+
+        @Override
+        public long maxSize() {
+            return 0;
+        }
+
+        @Override
+        public long getValue() throws IllegalStateException {
+            return getValues.remove(0);
+        }
+
+        @Override
+        public void setValue(long value) throws IllegalStateException {
+            setValues.add(value);
+        }
+
+        @Override
+        public long getVolatileValue() throws IllegalStateException {
+            return getValue();
+        }
+
+        @Override
+        public void setVolatileValue(long value) throws IllegalStateException {
+            setValue(value);
+        }
+
+        @Override
+        public void setOrderedValue(long value) throws IllegalStateException {
+            setValue(value);
+        }
+
+        @Override
+        public long addValue(long delta) throws IllegalStateException {
+            throw new AssertionError();
+        }
+
+        @Override
+        public long addAtomicValue(long delta) throws IllegalStateException {
+            throw new AssertionError();
+        }
+
+        @Override
+        public boolean compareAndSwapValue(long expected, long value) throws IllegalStateException {
+            if (getValue() == expected) {
+                setValue(value);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
@@ -1,0 +1,44 @@
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MultipleNamedTailersTest {
+    @Test
+    public void multipleTailers() {
+        File tmpDir = new File(OS.getTarget(), "multipleTailers" + System.nanoTime());
+
+        try (ChronicleQueue q1 = SingleChronicleQueueBuilder.single(tmpDir).testBlockSize().rollCycle(RollCycles.TEST_SECONDLY).build();
+             ExcerptAppender appender = q1.acquireAppender();
+             ExcerptTailer tailer1 = q1.createTailer();
+             ExcerptTailer namedTailer1 = q1.createTailer("named1");
+             ChronicleQueue q2 = SingleChronicleQueueBuilder.single(tmpDir).testBlockSize().build();
+             ExcerptTailer tailer2 = q2.createTailer();
+             ExcerptTailer namedTailer2 = q2.createTailer("named2")) {
+            for (int i = 0; i < 1_000_000; i++) {
+                final String id0 = "" + i;
+                appender.writeText(id0);
+                final long index0 = appender.lastIndexAppended();
+                check(tailer1, id0, index0);
+                check(namedTailer1, id0, index0);
+                check(tailer2, id0, index0);
+                check(namedTailer2, id0, index0);
+            }
+        }
+    }
+
+    private void check(ExcerptTailer tailer1, String id0, long index0) {
+        try (DocumentContext dc = tailer1.readingDocument()) {
+            assertTrue(dc.isPresent());
+            assertEquals(index0, tailer1.index());
+            assertEquals(id0, dc.wire().getValueIn().text());
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
@@ -44,9 +44,9 @@ public class MultipleNamedTailersTest {
             if (!empty)
                 appender.writeText("0");
 
-            try (ExcerptTailer namedTailer1 = q1.createTailer("named1");
+            try (ExcerptTailer namedTailer1 = q1.createTailer("named");
                  ChronicleQueue q2 = SingleChronicleQueueBuilder.single(tmpDir).testBlockSize().build();
-                 ExcerptTailer namedTailer2 = q2.createTailer("named2")) {
+                 ExcerptTailer namedTailer2 = q2.createTailer("named")) {
                 for (int i = 0; i < 3_000; i++) {
                     final String id0 = "" + i;
                     if (i > 0 || empty)

--- a/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
@@ -1,29 +1,53 @@
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class MultipleNamedTailersTest {
+    private final boolean empty;
+
+    public MultipleNamedTailersTest(boolean empty) {
+        this.empty = empty;
+    }
+
+    @Parameterized.Parameters(name = "empty={0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[]{true},
+                new Object[]{false}
+        );
+    }
+
     @Test
     public void multipleTailers() {
         File tmpDir = new File(OS.getTarget(), "multipleTailers" + System.nanoTime());
 
-        try (ChronicleQueue q1 = SingleChronicleQueueBuilder.single(tmpDir).testBlockSize().rollCycle(RollCycles.TEST_SECONDLY).build();
+        try (ChronicleQueue q1 = SingleChronicleQueueBuilder.single(tmpDir).testBlockSize()
+//                .timeProvider(new SetTimeProvider("2021/12/15T11:22:33").advanceMicros(10))
+                .rollCycle(RollCycles.TEST_SECONDLY).build();
              ExcerptAppender appender = q1.acquireAppender();
              ExcerptTailer tailer1 = q1.createTailer();
              ExcerptTailer namedTailer1 = q1.createTailer("named1");
              ChronicleQueue q2 = SingleChronicleQueueBuilder.single(tmpDir).testBlockSize().build();
              ExcerptTailer tailer2 = q2.createTailer();
              ExcerptTailer namedTailer2 = q2.createTailer("named2")) {
+            if (!empty)
+                appender.writeText("0");
             for (int i = 0; i < 1_000_000; i++) {
-                final String id0 = "" + i;
+                final String id0 = "" + (i + (empty ? 0 : 1));
                 appender.writeText(id0);
                 final long index0 = appender.lastIndexAppended();
                 check(tailer1, id0, index0);
@@ -32,11 +56,13 @@ public class MultipleNamedTailersTest {
                 check(namedTailer2, id0, index0);
             }
         }
+        IOTools.deleteDirWithFiles(tmpDir);
     }
 
     private void check(ExcerptTailer tailer1, String id0, long index0) {
         try (DocumentContext dc = tailer1.readingDocument()) {
             assertTrue(dc.isPresent());
+            assertEquals(Long.toHexString(index0), Long.toHexString(tailer1.index()));
             assertEquals(index0, tailer1.index());
             assertEquals(id0, dc.wire().getValueIn().text());
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
 
 @RunWith(Parameterized.class)
 public final class MessageHistoryTest extends ChronicleQueueTestBase {
@@ -72,6 +73,7 @@ public final class MessageHistoryTest extends ChronicleQueueTestBase {
 
     @Test
     public void shouldAccessMessageHistoryWhenTailerIsMovedToEnd() {
+        assumeFalse(named);
         try (final ChronicleQueue inputQueue = createQueue(inputQueueDir, 1);
              final ChronicleQueue outputQueue = createQueue(outputQueueDir, 2)) {
             generateTestData(inputQueue, outputQueue);
@@ -89,6 +91,7 @@ public final class MessageHistoryTest extends ChronicleQueueTestBase {
 
     @Test
     public void chainedMessageHistory() {
+        assumeFalse(named);
         try (final ChronicleQueue inputQueue = createQueue(inputQueueDir, 1);
              final ChronicleQueue middleQueue = createQueue(middleQueueDir, 2);
              final ChronicleQueue outputQueue = createQueue(middleQueueDir, 2)) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
@@ -31,14 +31,32 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class RollingCycleTest extends QueueTestCommon {
+    protected final boolean named;
+
+    public RollingCycleTest(boolean named) {
+        this.named = named;
+    }
+
+    @Parameterized.Parameters(name = "named={0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[]{true},
+                new Object[]{false}
+        );
+    }
 
     @BeforeClass
     public static void sync() {
@@ -216,13 +234,13 @@ public class RollingCycleTest extends QueueTestCommon {
                     "00000210 fc cc 5e cc da                                   ··^··            \n" +
                     "...\n";
 
-           // System.out.println("Wrote: " + numWritten + " messages");
+            // System.out.println("Wrote: " + numWritten + " messages");
 
             long numRead = 0;
             final TestBytesMarshallable reusableData = new TestBytesMarshallable(0);
-            final ExcerptTailer currentPosTailer = queue.createTailer()
+            final ExcerptTailer currentPosTailer = queue.createTailer(named ? "named" : null)
                     .toStart();
-            final ExcerptTailer endPosTailer = queue.createTailer().toEnd();
+            final ExcerptTailer endPosTailer = queue.createTailer(named ? "named2" : null).toEnd();
             while (currentPosTailer.index() < endPosTailer.index()) {
                 try {
                     assertTrue(currentPosTailer.readBytes(reusableData));
@@ -239,7 +257,7 @@ public class RollingCycleTest extends QueueTestCommon {
             }
             assertFalse(currentPosTailer.readBytes(reusableData));
 
-           // System.out.println("Wrote " + numWritten + " Read " + numRead);
+            // System.out.println("Wrote " + numWritten + " Read " + numRead);
 
             String dump = queue.dump();
             assertTrue(dump.contains(expectedEagerFile1));


### PR DESCRIPTION
Previously the behaviour of concurrent named tailers with the same name was undefined and not supported.
This change adds support for splitting work by named tailer by checking whether the index has changed during the call to readingDocument 
(changing the index in the table store at the end of readingDocument instead of close() )
I have added a test to show it detects and retries if the index is change while readingDocument is being performed.