### PR TITLE
Make QueueMultiThreadedJLBHBenchmark more configurable...

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueMultiThreadedJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueMultiThreadedJLBHBenchmark.java
@@ -30,45 +30,67 @@ import net.openhft.chronicle.jlbh.JLBHTask;
 import net.openhft.chronicle.jlbh.TeamCityHelper;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.RollCycle;
+import net.openhft.chronicle.queue.RollCycles;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Paths;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.bench.BenchmarkUtils.join;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.single;
 
 public class QueueMultiThreadedJLBHBenchmark implements JLBHTask {
-    private static final int ITERATIONS = 1_000_000;
+    private final int iterations;
+    private final String path;
+    private final int messageSize;
+    private final Long blockSize;
+    private final String tailerAffinity;
+    private final RollCycle rollCycle;
+    private final boolean usePretoucher;
+    private final boolean useSingleQueueInstance;
     private SingleChronicleQueue sourceQueue;
     private SingleChronicleQueue sinkQueue;
     private ExcerptTailer tailer;
     private ExcerptAppender appender;
-    private Datum datum = new Datum();
+    private final Datum datum;
     private boolean stopped = false;
     private Thread tailerThread;
     private JLBH jlbh;
     private NanoSampler writeProbe;
+    private ScheduledExecutorService pretoucherExecutorService;
 
     public static void main(String[] args) {
-        JLBHOptions lth = new JLBHOptions()
-                .warmUpIterations(50000)
-                .iterations(ITERATIONS)
-                .throughput(100_000)
-                // disable as otherwise single GC event skews results heavily
-                .recordOSJitter(false)
-                .accountForCoordinatedOmission(false)
-                .skipFirstRun(true)
-                .runs(5)
-                .jlbhTask(new QueueMultiThreadedJLBHBenchmark());
-        new JLBH(lth).start();
+        new Builder().run();
+    }
+
+    public QueueMultiThreadedJLBHBenchmark(int iterations, String path, String tailerAffinity, @Nullable RollCycle rollCycle,
+                                           int messageSize, @Nullable Long blockSize, boolean usePretoucher,
+                                           boolean useSingleQueueInstance) {
+        this.iterations = iterations;
+        this.path = path;
+        this.tailerAffinity = tailerAffinity;
+        this.rollCycle = rollCycle;
+        this.messageSize = messageSize;
+        this.blockSize = blockSize;
+        this.usePretoucher = usePretoucher;
+        this.useSingleQueueInstance = useSingleQueueInstance;
+        this.datum = new Datum(messageSize);
     }
 
     @Override
     public void init(JLBH jlbh) {
         this.jlbh = jlbh;
-        IOTools.deleteDirWithFiles("replica", 10);
+        IOTools.deleteDirWithFiles(path, 10);
 
-        sourceQueue = single("replica").build();
-        sinkQueue = single("replica").build();
+        sourceQueue = createQueueInstance();
+        sinkQueue = useSingleQueueInstance ? sourceQueue : createQueueInstance();
         appender = sourceQueue.acquireAppender()
                 .disableThreadSafetyCheck(true);
         tailer = sinkQueue.createTailer()
@@ -76,9 +98,16 @@ public class QueueMultiThreadedJLBHBenchmark implements JLBHTask {
 
         NanoSampler readProbe = jlbh.addProbe("read");
         writeProbe = jlbh.addProbe("write");
+
+        if (usePretoucher) {
+            pretoucherExecutorService = Executors.newSingleThreadScheduledExecutor(
+                    new NamedThreadFactory("pretoucher", true));
+            pretoucherExecutorService.scheduleAtFixedRate(() -> sourceQueue.acquireAppender().pretouch(), 1, 200, TimeUnit.MILLISECONDS);
+        }
+
         tailerThread = new Thread(() -> {
-            try (final AffinityLock affinityLock = AffinityLock.acquireCore()) {
-                Datum datum2 = new Datum();
+            try (final AffinityLock affinityLock = AffinityLock.acquireLock(tailerAffinity)) {
+                Datum datum2 = new Datum(messageSize);
                 while (!stopped) {
                     long beforeReadNs = System.nanoTime();
                     try (DocumentContext dc = tailer.readingDocument()) {
@@ -95,6 +124,17 @@ public class QueueMultiThreadedJLBHBenchmark implements JLBHTask {
         tailerThread.start();
     }
 
+    private SingleChronicleQueue createQueueInstance() {
+        final SingleChronicleQueueBuilder builder = single(path);
+        if (blockSize != null) {
+            builder.blockSize(blockSize);
+        }
+        if (rollCycle != null) {
+            builder.rollCycle(rollCycle);
+        }
+        return builder.build();
+    }
+
     @Override
     public void run(long startTimeNS) {
         datum.ts = startTimeNS;
@@ -106,16 +146,23 @@ public class QueueMultiThreadedJLBHBenchmark implements JLBHTask {
 
     @Override
     public void complete() {
+        if (pretoucherExecutorService != null) {
+            pretoucherExecutorService.shutdownNow();
+        }
         stopped = true;
         join(tailerThread);
         sinkQueue.close();
         sourceQueue.close();
-        TeamCityHelper.teamCityStatsLastRun(getClass().getSimpleName(), jlbh, ITERATIONS, System.out);
+        TeamCityHelper.teamCityStatsLastRun(getClass().getSimpleName(), jlbh, iterations, System.out);
     }
 
     private static class Datum implements BytesMarshallable {
         public long ts = 0;
-        public byte[] filler = new byte[4088];
+        public final byte[] filler;
+
+        public Datum(int messageSize) {
+            this.filler = new byte[messageSize - 8];
+        }
 
         @Override
         public void readMarshallable(BytesIn bytes) throws IORuntimeException {
@@ -127,6 +174,106 @@ public class QueueMultiThreadedJLBHBenchmark implements JLBHTask {
         public void writeMarshallable(BytesOut bytes) {
             bytes.writeLong(ts);
             bytes.writeSkip(filler.length);
+        }
+    }
+
+    public static class Builder {
+        private int runs = Integer.getInteger("runs", 5);
+        private String path = Paths.get(System.getProperty("path", ".")).resolve("replica").normalize().toString();
+        private Integer messageSize = Integer.getInteger("messageSize", 4_096);
+        private Long blockSize = Long.getLong("blockSize"); // use default when not specified
+        private String producerAffinity = System.getProperty("producerAffinity", "last-1");
+        private String consumerAffinity = System.getProperty("consumerAffinity", "last-2");
+        private int warmupIterations = Integer.getInteger("warmupIterations", 50_000);
+        private int iterations = Integer.getInteger("iterations", 1_000_000);
+        private int throughput = Integer.getInteger("throughput", 100_000);
+        private boolean usePretoucher = Boolean.getBoolean("usePretoucher");
+        private boolean useSingleQueueInstance = Boolean.getBoolean("useSingleQueue");
+        private RollCycle rollCycle = getRollCycle();
+
+        public void run() {
+            final QueueMultiThreadedJLBHBenchmark jlbhTask = new QueueMultiThreadedJLBHBenchmark(iterations, path, consumerAffinity,
+                    rollCycle, messageSize, blockSize, usePretoucher, useSingleQueueInstance);
+            JLBHOptions lth = new JLBHOptions()
+                    .warmUpIterations(warmupIterations)
+                    .iterations(iterations)
+                    .throughput(throughput)
+                    // disable as otherwise single GC event skews results heavily
+                    .recordOSJitter(false)
+                    .accountForCoordinatedOmission(false)
+                    .skipFirstRun(true)
+                    .acquireLock(() -> AffinityLock.acquireLock(producerAffinity))
+                    .runs(runs)
+                    .jlbhTask(jlbhTask);
+            new JLBH(lth).start();
+        }
+
+        private RollCycle getRollCycle() {
+            final String rollCycle = System.getProperty("rollCycle");
+            if (rollCycle != null) {
+                return RollCycles.valueOf(rollCycle);
+            }
+            return null;
+        }
+
+        public Builder runs(int runs) {
+            this.runs = runs;
+            return this;
+        }
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder messageSize(Integer messageSize) {
+            this.messageSize = messageSize;
+            return this;
+        }
+
+        public Builder blockSize(Long blockSize) {
+            this.blockSize = blockSize;
+            return this;
+        }
+
+        public Builder producerAffinity(String producerAffinity) {
+            this.producerAffinity = producerAffinity;
+            return this;
+        }
+
+        public Builder consumerAffinity(String consumerAffinity) {
+            this.consumerAffinity = consumerAffinity;
+            return this;
+        }
+
+        public Builder warmupIterations(int warmupIterations) {
+            this.warmupIterations = warmupIterations;
+            return this;
+        }
+
+        public Builder iterations(int iterations) {
+            this.iterations = iterations;
+            return this;
+        }
+
+        public Builder throughput(int throughput) {
+            this.throughput = throughput;
+            return this;
+        }
+
+        public Builder usePretoucher(boolean usePretoucher) {
+            this.usePretoucher = usePretoucher;
+            return this;
+        }
+
+        public Builder useSingleQueueInstance(boolean useSingleQueueInstance) {
+            this.useSingleQueueInstance = useSingleQueueInstance;
+            return this;
+        }
+
+        public Builder rollCycle(RollCycle rollCycle) {
+            this.rollCycle = rollCycle;
+            return this;
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueMultiThreadedJLBHBenchmark2.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueMultiThreadedJLBHBenchmark2.java
@@ -17,65 +17,40 @@
  */
 package net.openhft.chronicle.queue.bench;
 
-import net.openhft.affinity.AffinityLock;
-import net.openhft.chronicle.bytes.BytesIn;
-import net.openhft.chronicle.bytes.BytesMarshallable;
-import net.openhft.chronicle.bytes.BytesOut;
 import net.openhft.chronicle.bytes.MappedFile;
-import net.openhft.chronicle.core.Jvm;
-import net.openhft.chronicle.core.io.IORuntimeException;
-import net.openhft.chronicle.core.io.IOTools;
-import net.openhft.chronicle.core.util.NanoSampler;
-import net.openhft.chronicle.jlbh.JLBH;
-import net.openhft.chronicle.jlbh.JLBHOptions;
-import net.openhft.chronicle.jlbh.JLBHTask;
-import net.openhft.chronicle.jlbh.TeamCityHelper;
-import net.openhft.chronicle.queue.ExcerptAppender;
-import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.RollCycles;
-import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
-import net.openhft.chronicle.threads.NamedThreadFactory;
-import net.openhft.chronicle.wire.DocumentContext;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
-import static net.openhft.chronicle.queue.bench.BenchmarkUtils.join;
-import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.single;
-
-public class QueueMultiThreadedJLBHBenchmark2 implements JLBHTask {
+public class QueueMultiThreadedJLBHBenchmark2 {
     private static final String PATH = System.getProperty("path", "/dev/shm") + "/replica";
     private static final int MSGSIZE = 512;
     private final static String CPU1 = System.getProperty("cpu1", "last-1");
     private final static String CPU2 = System.getProperty("cpu2", "last-2");
     private static final int ITERATIONS = 2_000_000_000;
     private static final long BLOCKSIZE = 4L << 40;
-    private static final int RUNS = 3;
-    private static volatile long startTime;
-    private static volatile Thread thread;
-    private final Datum datum = new Datum();
-    private SingleChronicleQueue sourceQueue;
-    private SingleChronicleQueue sinkQueue;
-    private ExcerptTailer tailer;
-    private ExcerptAppender appender;
-    private boolean stopped = false;
-    private Thread tailerThread;
-    private JLBH jlbh;
-    private NanoSampler writeProbe;
-    private ScheduledExecutorService pretoucher;
 
     public static void main(String[] args) {
         System.out.println("-Dpath=" + PATH + " -Dcpu1=" + CPU1 + " -Dcpu2=" + CPU2);
         warmUp();
 
-        QueueMultiThreadedJLBHBenchmark2 bench = new QueueMultiThreadedJLBHBenchmark2();
+        final QueueMultiThreadedJLBHBenchmark.Builder commonOptions = new QueueMultiThreadedJLBHBenchmark.Builder()
+                .runs(1)
+                .path(PATH)
+                .producerAffinity(CPU1)
+                .consumerAffinity(CPU2)
+                .warmupIterations(5_000_000)
+                .usePretoucher(true)
+                .useSingleQueueInstance(true)
+                .messageSize(MSGSIZE)
+                .blockSize(BLOCKSIZE)
+                .rollCycle(RollCycles.HUGE_DAILY);
 
         for (int r = 0; r <= 1; r++) {
             int[] throughputs = {1_500_000, 250_000};
             for (int throughput : throughputs) {
                 System.out.println("Throughput: " + (throughput / 1000) + "k msgs/s");
-                bench.run1(throughput, r == 0 ? 150_000_000 : ITERATIONS);
+                commonOptions.throughput(throughput)
+                        .iterations(r == 0 ? 150_000_000 : ITERATIONS)
+                        .run();
             }
         }
     }
@@ -104,104 +79,5 @@ public class QueueMultiThreadedJLBHBenchmark2 implements JLBHTask {
         }, "watcher");
         watcher.setDaemon(true);
         watcher.start();*/
-    }
-
-    void run1(int throughput, int iterations) {
-        JLBHOptions lth = new JLBHOptions()
-                .warmUpIterations(5_000_000)
-                .iterations(iterations)
-                .throughput(throughput)
-                // disable as otherwise single GC event skews results heavily
-                .recordOSJitter(false)
-                .accountForCoordinatedOmission(false)
-                .skipFirstRun(true)
-                .acquireLock(() -> AffinityLock.acquireLock(CPU1))
-                .runs(1)
-                .jlbhTask(new QueueMultiThreadedJLBHBenchmark2());
-        new JLBH(lth).start();
-    }
-
-    @Override
-    public void init(JLBH jlbh) {
-        this.jlbh = jlbh;
-        IOTools.deleteDirWithFiles(PATH, 10);
-        sourceQueue = single(PATH).blockSize(BLOCKSIZE).rollCycle(RollCycles.HUGE_DAILY).build();
-        sinkQueue = sourceQueue; //single(PATH).blockSize(BLOCKSIZE).rollCycle(RollCycles.HUGE_DAILY).build();
-        appender = sourceQueue.acquireAppender();
-        tailer = sinkQueue.createTailer().disableThreadSafetyCheck(true);
-
-        NanoSampler readProbe = jlbh.addProbe("read");
-        writeProbe = jlbh.addProbe("write");
-
-        pretoucher = Executors.newSingleThreadScheduledExecutor(
-                new NamedThreadFactory("pretoucher", true));
-        pretoucher.scheduleAtFixedRate(() -> sourceQueue.acquireAppender().pretouch(), 1, 200, TimeUnit.MILLISECONDS);
-
-        tailerThread = new Thread(() -> {
-            try (AffinityLock lock = AffinityLock.acquireLock(CPU2)) {
-                Datum datum2 = new Datum();
-                while (!stopped) {
-                    long beforeReadNs = System.nanoTime();
-                    try (DocumentContext dc = tailer.readingDocument()) {
-                        if (dc.wire() == null)
-                            continue;
-                        datum2.readMarshallable(dc.wire().bytes());
-                        long now = System.nanoTime();
-                        jlbh.sample(now - datum2.ts);
-                        readProbe.sampleNanos(now - beforeReadNs);
-                    }
-                }
-            }
-        });
-        tailerThread.start();
-    }
-
-    @Override
-    public void run(long startTimeNS) {
-        startTime = startTimeNS;
-        if (thread == null)
-            thread = Thread.currentThread();
-        datum.ts = startTimeNS;
-        try (DocumentContext dc = appender.writingDocument()) {
-            Jvm.safepoint();
-            datum.writeMarshallable(dc.wire().bytes());
-        }
-        long nanos = System.nanoTime() - startTimeNS;
-        writeProbe.sampleNanos(nanos);
-        startTime = Long.MAX_VALUE;
-
-/*
-        if (nanos > 1_000_000) {
-            Jvm.safepoint();
-            System.out.println("+++ Took " + nanos / 1000 + " us to write Datum");
-        }
-*/
-    }
-
-    @Override
-    public void complete() {
-        pretoucher.shutdownNow();
-        stopped = true;
-        join(tailerThread);
-        sinkQueue.close();
-        sourceQueue.close();
-        TeamCityHelper.teamCityStatsLastRun(getClass().getSimpleName(), jlbh, ITERATIONS, System.out);
-    }
-
-    private static class Datum implements BytesMarshallable {
-        public long ts = 0;
-        public byte[] filler = new byte[MSGSIZE - 8];
-
-        @Override
-        public void readMarshallable(BytesIn bytes) throws IORuntimeException {
-            ts = bytes.readLong();
-            bytes.read(filler);
-        }
-
-        @Override
-        public void writeMarshallable(BytesOut bytes) {
-            bytes.writeLong(ts);
-            bytes.write(filler);
-        }
     }
 }


### PR DESCRIPTION
 consolidate QueueMultiThreadedJLBHBenchmark2 to use it.

This adds a bit of noise to the benchmark, you could argue it's a bad idea, but it makes it very configurable via environment variables which might come in handy for our tests

**Note** QueueMultiThreadedJLBHBenchmark2 had SIGBUS before these changes and gets a more orderly, but still concerning `InternalError` after them. I'm not sure the reason for the error or why it would have changed?
**Note again** This only occurs on `/dev/shm`, perhaps it just assumes more memory than I have. Still not sure why it went from being a SIGBUS to an `InternalError`