### PR TITLE
add performance log for normaliseEOFs and javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -513,6 +513,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     /**
      * @return the {@link WriteLock} that is used to lock writes to the queue. This is the mechanism used to
      * coordinate writes from multiple threads and processes.
+     * <p>This lock should only be held for a short time, as it will block progress of any writers to
+     * this queue. The default behaviour of {@link TableStoreWriteLock} is to override the lock after a timeout.
+     *
      * <p>This is also used to protect rolling to the next cycle
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -415,12 +415,16 @@ class StoreAppender extends AbstractCloseable
      * Ensure any missing EOF markers are added back to previous cycles
      */
     public void normaliseEOFs() {
+        long start = System.nanoTime();
         final WriteLock writeLock = queue.writeLock();
         writeLock.lock();
         try {
             normaliseEOFs0();
         } finally {
             writeLock.unlock();
+            long tookMillis = (System.nanoTime() - start) / 1_000_000;
+            if (tookMillis > 100)
+                Jvm.perf().on(getClass(), "Took " + tookMillis + "ms to normaliseEOFs");
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLock.java
@@ -31,6 +31,12 @@ import java.util.function.Supplier;
 
 import static net.openhft.chronicle.core.Jvm.warn;
 
+/**
+ * Implements {@link WriteLock) using memory access primitives - see {@link AbstractTSQueueLock}.
+ * <p>
+ * WARNING: the default behaviour (see also {@code queue.dont.recover.lock.timeout} system property) is
+ * for a timed-out lock to be overridden.
+ */
 public class TableStoreWriteLock extends AbstractTSQueueLock implements WriteLock {
     public static final String APPEND_LOCK_KEY = "chronicle.append.lock";
     private static final String LOCK_KEY = "chronicle.write.lock";

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/AbstractTSQueueLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/AbstractTSQueueLock.java
@@ -32,6 +32,12 @@ import java.util.function.Supplier;
 import static java.lang.String.format;
 import static net.openhft.chronicle.core.Jvm.getProcessId;
 
+/**
+ * Implements a lock using {@link LongValue} and primitives such as CAS.
+ * <p>
+ * WARNING: the default behaviour (see also {@code queue.dont.recover.lock.timeout} system property) is
+ * for a timed-out lock to be overridden.
+ */
 public abstract class AbstractTSQueueLock extends AbstractCloseable implements Closeable {
     protected static final long PID = getProcessId();
     public static final long UNLOCKED = 1L << 63;


### PR DESCRIPTION
We had a problem at a customers where they were creating a lot of appenders and `normaliseEOFs` was taking a long time to complete - so long, in fact, that other threads' WriteLocks were timing out. 

This PR contains a warning for slow `normaliseEOF`.