### PR TITLE
Add read write buffer mode params to benchmark

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueMultiThreadedJLBHBenchmark2.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueMultiThreadedJLBHBenchmark2.java
@@ -42,7 +42,8 @@ public class QueueMultiThreadedJLBHBenchmark2 {
                 .useSingleQueueInstance(true)
                 .messageSize(MSGSIZE)
                 .blockSize(BLOCKSIZE)
-                .rollCycle(RollCycles.HUGE_DAILY);
+                .rollCycle(RollCycles.HUGE_DAILY)
+                .testClass(QueueMultiThreadedJLBHBenchmark2.class);
 
         for (int r = 0; r <= 1; r++) {
             int[] throughputs = {1_500_000, 250_000};


### PR DESCRIPTION
- Allow specification of readBufferMode and writeBufferMode in `QueueMultiThreadedJLBHBenchmark`
- Fix bug when determining whether document was read
- Allow specification of test class for output