### PR TITLE
 After segment has just been rolled over, index is not initialized yet

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -273,6 +273,8 @@ class SCQIndexing extends AbstractCloseable implements Demarshallable, WriteMars
     // visible for testing
     @Nullable
     ScanResult moveToIndex0(@NotNull final ExcerptContext ec, final long index) {
+        if (index2Index.getVolatileValue() == NOT_INITIALIZED)
+            return null;
 
         Wire wire = ec.wireForIndex();
         LongArrayValues index2index = getIndex2index(wire);
@@ -309,6 +311,7 @@ class SCQIndexing extends AbstractCloseable implements Demarshallable, WriteMars
                 return linearScan(ec.wire(), index, startIndex, fromAddress);
             }
         } while (secondaryOffset >= 0);
+
         return null; // no index,
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
@@ -36,8 +36,8 @@ import static org.junit.Assert.assertEquals;
 @RequiredForClient
 public class CycleNotFoundTest extends ChronicleQueueTestBase {
 
-    private static final int NUMBER_OF_TAILERS = 10;
-    private static final long INTERVAL_US = 25;
+    private static final int NUMBER_OF_TAILERS = 20;
+    private static final long INTERVAL_US = 50;
     private static final long NUMBER_OF_MSG = 100_000; // this is working this  1_000_000 but
     // reduced so that it runs quicker for the continuous integration (CI)
 
@@ -52,7 +52,7 @@ public class CycleNotFoundTest extends ChronicleQueueTestBase {
         Runnable reader = () -> {
             long count = 0;
             try (ChronicleQueue rqueue = SingleChronicleQueueBuilder
-                    .fieldlessBinary(path)
+                    .binary(path)
                     .testBlockSize()
                     .rollCycle(RollCycles.TEST_SECONDLY)
                     .build()) {
@@ -96,7 +96,7 @@ public class CycleNotFoundTest extends ChronicleQueueTestBase {
                 new NamedThreadFactory("appender"));
         Future<?> submit = executorService1.submit(() -> {
             ChronicleQueue wqueue = SingleChronicleQueueBuilder
-                    .fieldlessBinary(path)
+                    .binary(path)
                     .testBlockSize()
                     .rollCycle(TEST_SECONDLY)
                     .build();


### PR DESCRIPTION
Test which will catch #998 much more eagerly, once per 10-20 runs