### PR TITLE
Throw UnsupportedOperationException if someone tries to clear or reset the used-by thread

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -799,6 +799,16 @@ class StoreAppender extends AbstractCloseable
         }
     }
 
+    @Override
+    public void clearUsedByThread() {
+        throw new UnsupportedOperationException("clearUsedByThread should never be called on a StoreAppender. They are ThreadLocal and bound to the thread they're created on.");
+    }
+
+    @Override
+    public void resetUsedByThread() {
+        throw new UnsupportedOperationException("resetUsedByThread should never be called on a StoreAppender. They are ThreadLocal and bound to the thread they're created on.");
+    }
+
     final class StoreAppenderContext implements WriteDocumentContext {
 
         boolean isClosed = true;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -1,27 +1,45 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.Jvm;
-import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import java.nio.file.Path;
+import java.io.IOException;
 import java.util.concurrent.Semaphore;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class StoreAppenderTest {
 
     public static final String TEST_TEXT = "Some text some text some text";
 
+    @Rule
+    public final TemporaryFolder queueDirectory = new TemporaryFolder();
+
     @Test
-    public void writingDocumentAcquisitionWorksAfterInterruptedAttempt() throws InterruptedException {
-        final Path queueDirectory = IOTools.createTempDirectory("StoreAppenderTest.writingDocumentAcquisitionWorksAfterInterruptedAttempt");
-        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.toFile()).build()) {
+    public void clearUsedByThreadThrowsUnsupportedOperationException() throws IOException {
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder()).build()) {
+            assertThrows(UnsupportedOperationException.class, () -> ((StoreAppender) queue.acquireAppender()).clearUsedByThread());
+        }
+    }
+
+    @Test
+    public void resetUsedByThreadThrowsUnsupportedOperationException() throws IOException {
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder()).build()) {
+            assertThrows(UnsupportedOperationException.class, () -> ((StoreAppender) queue.acquireAppender()).resetUsedByThread());
+        }
+    }
+
+    @Test
+    public void writingDocumentAcquisitionWorksAfterInterruptedAttempt() throws InterruptedException, IOException {
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder()).build()) {
             final BlockingWriter blockingWriter = new BlockingWriter(queue);
             final BlockedWriter blockedWriter = new BlockedWriter(queue);
 


### PR DESCRIPTION
It seems that this would never be a good idea (and doesn't work anyway). So perhaps by throwing an exception people can pick that up in development.

I could also throw on a call to `disableThreadSafetyCheck(false)` but maybe you have to let people shoot themselves in the foot if they're really keen?