### PR TITLE
Feature/issue1005 attempt deflake

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
@@ -1,13 +1,11 @@
 package net.openhft.chronicle.queue.impl.single;
 
-import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.queue.impl.StoreFileListener;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -92,16 +90,6 @@ public class RollCycleTest extends ChronicleQueueTestBase {
 
         assertEquals(1 + cyclesToWrite, observer.documentsRead);
         observer.queue.close();
-    }
-
-    @Before
-    public void enableCloseableTracing() {
-        AbstractCloseable.enableCloseableTracing();
-    }
-
-    @After
-    public void assertCloseablesClosed() {
-        AbstractCloseable.assertCloseablesClosed();
     }
 
     @After

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
@@ -30,8 +30,6 @@ import net.openhft.chronicle.queue.impl.RollingChronicleQueue;
 import net.openhft.chronicle.queue.util.QueueUtil;
 import net.openhft.chronicle.wire.*;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -295,15 +293,5 @@ public class SingleCQFormatTest extends ChronicleQueueTestBase {
             e.printStackTrace();
         }
 
-    }
-
-    @Before
-    public void enableCloseableTracing() {
-        AbstractCloseable.enableCloseableTracing();
-    }
-
-    @After
-    public void assertCloseablesClosed() {
-        AbstractCloseable.assertCloseablesClosed();
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
@@ -19,15 +19,12 @@ package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
-import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -489,15 +486,5 @@ public class ToEndTest extends ChronicleQueueTestBase {
             }
         }
         return results;
-    }
-
-    @Before
-    public void enableCloseableTracing() {
-        AbstractCloseable.enableCloseableTracing();
-    }
-
-    @After
-    public void assertCloseablesClosed() {
-        AbstractCloseable.assertCloseablesClosed();
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
@@ -1,7 +1,6 @@
 package net.openhft.chronicle.queue.impl.single.stress;
 
 import net.openhft.chronicle.bytes.StopCharTesters;
-import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ChronicleQueueTestBase;
@@ -13,9 +12,7 @@ import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.Wires;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -114,16 +111,6 @@ public class RollCycleMultiThreadTest extends ChronicleQueueTestBase {
             scheduledExecutorService.shutdown();
             scheduledExecutorService.awaitTermination(1, TimeUnit.SECONDS);
         }
-    }
-
-    @Before
-    public void enableCloseableTracing() {
-        AbstractCloseable.enableCloseableTracing();
-    }
-
-    @After
-    public void assertCloseablesClosed() {
-        AbstractCloseable.assertCloseablesClosed();
     }
 
     private class TestTimeProvider implements TimeProvider {

--- a/system.properties
+++ b/system.properties
@@ -9,3 +9,6 @@ closeable.warn.secs=0.2
 # reduce logging of the announcer
 chronicle.announcer.disable=true
 strict.discard.warning=true
+
+# for RollCycleMultiThreadStressTest and descendants to reduce resource consumption
+cores=6


### PR DESCRIPTION
Three changes in this PR:
1. some tests were calling AbstractCloseable.enableCloseableTracing() and AbstractCloseable.assertCloseablesClosed(); when they didn't need to (the base test class does)
2. remove the unused `writeOneThenWait` property from `RollCycleMultiThreadStressTest` and add back in diagnostic `Jvm.perf` output in case flakiness returns
3. reduce the number of cores that `RollCycleMultiThreadStressTest` tries to use. It tries to use _all_ the cores on the host and on a docker host Runtime.getRuntime().availableProcessors() returns the parent's cores. I have reduced this with `system.properties` and these tests run much more reliably now
I have not done much research into this but I believe Runtime.getRuntime().availableProcessors() behaves better on docker after Java 10. We may need to consider some changes in this area.