### PR TITLE
Fix broken test

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -74,11 +74,17 @@ public class SingleChronicleQueueBuilderTest extends ChronicleQueueTestBase {
 
     @Test(expected = IllegalArgumentException.class)
     public void setAllNullFieldsShouldFailWithDifferentHierarchy() {
-        SingleChronicleQueueBuilder b1 = Wires.tupleFor(SingleChronicleQueueBuilder.class, "ChronicleQueueBuilder");
-        SingleChronicleQueueBuilder b2 = SingleChronicleQueueBuilder.builder();
+        OneExtendedBuilder b1 = new OneExtendedBuilder();
+        OtherExtendedBuilder b2 = new OtherExtendedBuilder();
         b2.bufferCapacity(98765);
         b1.blockSize(1234567);
         b2.setAllNullFields(b1);
+    }
+
+    static class OneExtendedBuilder extends SingleChronicleQueueBuilder {
+    }
+
+    static class OtherExtendedBuilder extends SingleChronicleQueueBuilder {
     }
 
     @Test


### PR DESCRIPTION
This test used to test that you couldn't call `a.setAllNullFields(b)` where `a` and `b` were SingleChronicleQueueBuilders from different hierarchies. It hasn't done that since `wire.generate.tuples` was introduced and set to false by default (the expected exception was being thrown from `Wires.tupleFor`)

As part of another fix I made `Wires.tupleFor` return null and warn when `wire.generate.tuples` is false. That change caused this test to break in a different way.

BTW I checked, and this is the only use of `Wires.tupleFor` outside of `Chronicle-Wire` (in any of our organisations), changing behaviour to return null instead of throwing IllegalArgumentException is breaking I suppose, so would be OK if we want to go back and revert that behaviour change. This PR is still valid though even if we do that.