### PR TITLE
Limit overlapSize. Fix #1062.

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -154,6 +154,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             fileAbsolutePath = path.getAbsolutePath();
             wireType = builder.wireType();
             blockSize = builder.blockSize();
+            // the maximum message size is 1L << 30 so greater overlapSize has no effect
             overlapSize = Math.min(Math.max(64 << 10, builder.blockSize() / 4), 1L << 30);
             useSparseFile = builder.useSparseFiles();
             sparseCapacity = builder.sparseCapacity();

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -154,7 +154,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             fileAbsolutePath = path.getAbsolutePath();
             wireType = builder.wireType();
             blockSize = builder.blockSize();
-            overlapSize = Math.max(64 << 10, builder.blockSize() / 4);
+            overlapSize = Math.min(Math.max(64 << 10, builder.blockSize() / 4), 1L << 30);
             useSparseFile = builder.useSparseFiles();
             sparseCapacity = builder.sparseCapacity();
             eventLoop = builder.eventLoop();
@@ -872,7 +872,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @PackageLocal
     MappedFile mappedFile(File file) throws FileNotFoundException {
         long chunkSize = OS.pageAlign(blockSize);
-        long overlapSize = OS.pageAlign(blockSize / 4);
+        long overlapSize = OS.pageAlign(Math.min(blockSize / 4, 1L << 30));
         return useSparseFile
                 ? MappedFile.ofSingle(file, sparseCapacity, readOnly)
                 : MappedFile.of(file, chunkSize, overlapSize, readOnly);


### PR DESCRIPTION
Limits the overlap size of mapping memory to 1 GB.