### PR TITLE
Capitalisation of headings and subheadings 

### DIFF
--- a/docs/antora/modules/advanced/pages/advanced.adoc
+++ b/docs/antora/modules/advanced/pages/advanced.adoc
@@ -7,12 +7,12 @@ author: Julia Gustafsson
 
 This chapter explains and motivates the low-level implementation details of Chronicle Queue.
 
-== Append-only data structure
+== Append-Only Data Structure
 Chronicle Queue is designed for sequential writes and reads. It also supports random access, and updates in-place. Although the size of an existing entry cannot be changed, an entry can be padded for future use.
 
 This append-only structure is more efficient for passing data between threads using the `CPU L2 cache` coherence bus. It can also be faster than attempting to pass an object between threads, as it avoids random access which can be common in `Java` objects where there can be a lot of reference chasing. Further, it is more efficient for persistence to disk; HDD and SSD are much more efficient when being accessed sequentially and simplifies replication.
 
-== Why memory mapped files?
+== Why Memory Mapped Files?
 Chronicle Queue is built on a class called `MappedBytes` in Chronicle Bytes. This visualises the file to act as an unbounded array of bytes mapped to a file. As data is appended, the queue will add memory mappings transparently, growing whenever data is written.
 
 The key benefit of using memory-mapped files is that the queue is no longer limited by the size of the JVM, or even the size of the main memory. Instead, the limitation is the available disk space. If you want to load 100 TB into a JVM for replay the operating system does all the heavy lifting for you.
@@ -20,7 +20,7 @@ The key benefit of using memory-mapped files is that the queue is no longer limi
 Another benefit of using a memory-mapped file is the ability to bind a portion of memory to an object. The key attributes in the header are bound when first loading, and after that they work like a normal object, updating off-heap memory and the file in a thread-safe manner.
 Enabling operations like `compareAndSet`, atomic add, or set max value (a set which only ever increases the value). As the data access is thread-safe, it can be shared between threads, or processes, as fast as the time it takes for an L2 cache miss; up to 25 nano-seconds.
 
-== Queue header
+== Queue Header
 Every queue starts with a header that stores basic information e.g. the wire type, the roll cycle, and how indexing is performed.
 
 Below follows an example of a queue header:
@@ -54,7 +54,7 @@ header: !SCQStore { # <2>
 NOTE: The `SCQStore` "bootstraps" the queue itself. A custom implementation could be provided to adapt the behavior of the queue, provided it supports the same interface. The rolling and indexing strategies can also be customized.
 
 [#_queue_documents]
-== Queue documents
+== Queue Documents
 A queue message comprise two parts, a 4-byte header followed by an xref:getting-started:glossary.adoc#e[excerpt]. The excerpt , also referred to as the message, contains the actual data, which could be of any type, including text, numbers, or serialised blobs. Regardless of the type, all information is stored as a series of bytes in the excerpt.
 
 .A Chronicle Queue stores an ordered collection of messages

--- a/docs/antora/modules/configuration/pages/block-size.adoc
+++ b/docs/antora/modules/configuration/pages/block-size.adoc
@@ -1,4 +1,4 @@
-= Block size
+= Block Size
 keywords: block size, chronicle queue, queue, java
 author: Julia Gustafsson
 :reftext: Block size
@@ -17,7 +17,7 @@ SingleChronicleQueue queue = ChronicleQueue.singleBuilder("rollCycleTest")
 
 NOTE: The minimum block size is 2^16^ bytes.
 
-== General advice on block size
+== General Advice on Block Size
 The block size should preferably be adapted to the size of the queue messages. A good rule of thumb is to use a block size that is at least *four times* the message size. If trying to write a message  to the queue that exceeds the block size, an `IllegalStateException` is thrown and the write is aborted.
 
 It is also recommended using the same block size for each queue instance when replicating queues. The block size is not written to the queue's metadata, so should ideally be set to the same value when creating the queue instances.

--- a/docs/antora/modules/configuration/pages/buffer-modes.adoc
+++ b/docs/antora/modules/configuration/pages/buffer-modes.adoc
@@ -1,4 +1,4 @@
-= ★ Buffer modes
+= ★ Buffer Modes
 keywords: buffer modes, chronicle queue, queue, java
 author: Julia Gustafsson
 :reftext: Buffer modes

--- a/docs/antora/modules/configuration/pages/index-count.adoc
+++ b/docs/antora/modules/configuration/pages/index-count.adoc
@@ -1,4 +1,4 @@
-= Index count
+= Index Count
 keywords: index count, chronicle queue, queue, java
 author: Julia Gustafsson
 :reftext: Index count

--- a/docs/antora/modules/configuration/pages/index-spacing.adoc
+++ b/docs/antora/modules/configuration/pages/index-spacing.adoc
@@ -1,4 +1,4 @@
-= Index sizing
+= Index Sizing
 keywords: index sizing, chronicle queue, queue, java
 author: Julia Gustafsson
 :reftext: Index sizing

--- a/docs/antora/modules/configuration/pages/roll-cycle.adoc
+++ b/docs/antora/modules/configuration/pages/roll-cycle.adoc
@@ -20,12 +20,12 @@ _cycle_ numbers present in the directory. Maintaining this table allows an `Exce
 
 The following sections describe how rolling is performed, how the roll cycle interval can be customized, and finally provide some general advice to consider when deciding the rolling schedule.
 
-== How rolling works
+== How Rolling Works
 When the queue reaches the point in time when it should roll, the appender will atomically write an end-of-file (EOF) mark at the end of the current file, to indicate that no other appender should write to it. Likewise, no tailer should read further than this mark.
 
 If the process was shut down and later restarted after rolling should have occurred, the appender will try to locate the old file(s) and write the EOF marker. However, after a certain timeout, the tailers will act as if there is an EOF mark in the file(s) regardless.
 
-== Roll cycle configuration
+== Roll Cycle Configuration
 The interval for rolling is configured using the queue's attribute `rollCycle`. As an example, the queue can be configured to roll its file (i.e. create a new file) every day by providing the `RollCycle.DAILY`:
 
 [source, java]
@@ -50,7 +50,7 @@ In the case where another Chronicle Queue instance is created before any appends
 ====
 
 [#epoch]
-== Controlling the exact roll time
+== Controlling the Exact Roll Time
 Chronicle Queue is UTC time based and uses `System.currentTimeMillis()` to evaluate when it is time to roll the queue. Rolling occurs whenever a new time frame of the selected kind is started, meaning for minutely rolling a new queue is created when a new minute begins and daily rolls occurs at midnight UTC time.
 
 This behavior can be changed using Chronicle Queue’s attribute `epoch()`. Epoch refers to a milliseconds offset to the set time frame.In other words, if you set the epoch to be `epoch(1)` and use `RollCycle.DAILY` the queue will roll at 1 millisecond past midnight UTC time.Putting it together:
@@ -75,7 +75,7 @@ SingleChronicleQueue queue = ChronicleQueue.singleBuilder("rollCycleTest")
 
 IMPORTANT: We do not recommend that you change the epoch on systems which already has `.cq4` files created, which are using a different epoch setting.
 
-== Available roll-cycles
+== Available Roll-Cycles
 As described earlier, the roll-cycle determines how often a new queue is created. However, each roll-cycle also leverages queues with a varying message capacity. This results in different roll-cycles having a maximum capacity in terms of throughput.
 
 The available roll-cycles and their capacities are summarized in the table below:
@@ -113,7 +113,7 @@ The available roll-cycles and their capacities are summarized in the table below
 
 IMPORTANT: Roll-cycles named _TEST*_ should only be used in test environments.
 
-== Timezone rollover ★
+== Timezone Rollover ★
 Chronicle Queue bases its roll times on the UTC time zone. However, Chronicle Queue Enterprise supports time zone rollover. This allows specifying a time and periodicity of queue rollovers which takes account of the user's local timezone, rather than UTC.
 
 [IMPORTANT]
@@ -144,7 +144,7 @@ SingleChronicleQueue queue = ChronicleQueue.singleBuilder("/timezone")
     .build();
 ----
 
-== Archiving old queue files ★
+== Archiving Old Queue Files ★
 Over time, it may become necessary to automatically delete or archive old queue files. An automated process needs to ensure that there are no active file-handles open on a queue file before attempting to delete.
 
 To facilitate this operation, Chronicle Queue Enterprise tracks references to its _roll-cycle_ files internally. Ensuring there are no references to a given file it is done by checking that `ChronicleQueue.numberOfReferences()` returns zero.
@@ -170,13 +170,13 @@ public void removeOldQueueFiles() throws IOException {
 }
 ----
 
-== General advice on rolling
+== General Advice on Rolling
 At roll-time, a few unavoidable objects and memory mappings are created, and the old memory mappings are released. This activity can introduce slight jitter to your application. Chronicle aim's to keep this to a minimum, and control when it occurs. However, it is still recommended avoiding rolling at critical points in time to the extent possible.
 
-=== Adapt to down-time
+=== Adapt to Down-Time
 In systems that are not always active, it is advised to schedule rolls during the down-time. However, for applications with a buzy feed and no down-time, Chronicle recommends using minutely rolling (a new queue is created every minute). This keep jitter to a minimum, as only one minute’s worth of data has to be unmapped on a queue-roll.
 
-=== Avoid large files
+=== Avoid Large Files
 It is generally recommended limiting the size of queue files to around < 250GB as unmapping a large `.cq4` file has can cause unwanted jitter. Therefore, if possible, use a more regular roll-cycle to avoid any performance penalties associated with unmapping large files.
 
 

--- a/docs/antora/modules/configuration/pages/wire-type.adoc
+++ b/docs/antora/modules/configuration/pages/wire-type.adoc
@@ -1,4 +1,4 @@
-= Wire type
+= Wire Type
 keywords: wire type, chronicle queue, queue, java
 author: Julia Gustafsson
 :reftext: Wire type

--- a/docs/antora/modules/demos/pages/demos.adoc
+++ b/docs/antora/modules/demos/pages/demos.adoc
@@ -8,7 +8,7 @@ author: Julia Gustafsson
 Chronicle have tutorials in
 The TensorFlow tutorials are written as Jupyter notebooks and run directly in Google Colab—a hosted notebook environment that requires no setup. Click the Run in Google Colab button.
 
-== What you need to get started
+== What You Need to Get Started
 - Maven 3.6.x
 - Java 8 update 180+
 - Intellij CE or another IDE
@@ -20,7 +20,7 @@ image::Two-hop-latency.PNG[]
 
 https://github.com/OpenHFT/Chronicle-Queue-Demo/tree/master/order-processor
 
-== Downloading and running sample programs
+== Downloading and Running Sample Programs
 
 If you're running Windows, you will need to install the `git` client and `open-ssh` Cygwin, https://cygwin.com/install.html[here],
 with a guide showing installation and packages http://www.mcclean-cooper.com/valentino/cygwin_install/[here].

--- a/docs/antora/modules/demos/pages/message-history.adoc
+++ b/docs/antora/modules/demos/pages/message-history.adoc
@@ -9,7 +9,7 @@ This demo shows a publisher writing to a queue while a bridger process writes to
 
 NOTE: The source code for this demo can be found link:https://github.com/OpenHFT/Chronicle-Queue-Demo/tree/master/message-history-demo[here].
 
-== Running the demo from IntelliJ
+== Running the Demo from IntelliJ
 The following steps are needed
 
 - Open the `pom.xml` as a project
@@ -19,7 +19,7 @@ The following steps are needed
 
 NOTE: You can run the `PublisherMain` with `-Devents=1000000` for more events, and `-Drate=5000` to adjust the rate per second of messages.
 
-== Running the demo from Maven
+== Running the Demo from Maven
 
 .Prebuilding the code
 [source,sh]
@@ -69,7 +69,7 @@ WARNING: An illegal reflective access operation has occurred
 WARNING: Illegal reflective access by net.openhft.compiler.MyJavaFileManager (file:/C:/Users/peter/.m2/repository/net/openhft/compiler/2.3.4/compiler-2.3.4.jar) to method com.sun.tools.javac.file.JavacFileManager.listLocationsForModules(javax.tools.JavaFileManager$Location)
 ----
 
-== Expected output
+== Expected Output
 
 The microsecond timestamps are based on wall clock, however the nanosecond time stamps are based on the uptime of the machine.
 

--- a/docs/antora/modules/encryption/pages/encryption.adoc
+++ b/docs/antora/modules/encryption/pages/encryption.adoc
@@ -14,7 +14,7 @@ Chronicle Queue Enterprise introduces the ability to encrypt your message queues
 * The same encryption key must be available when accessing these encrypted queue files.
 ====
 
-== AES encryption
+== AES Encryption
 AES 64-bit encryption can be used by specifying `aesEncryption` at queue build time, and supplying an 8-bit encryption key.
 
 For example:
@@ -34,7 +34,7 @@ public SingleChronicleQueueBuilder aesEncryption(@Nullable byte[] keyBytes) {
     }
 ....
 
-== Customer specified encryption
+== Customer Specified Encryption
 You can supply a bespoke encryption method to encrypt your messages using, perhaps, a more complex encryption method.
 
 For example, you could perhaps combine encryption with salting, and/or compression.

--- a/docs/antora/modules/getting-started/pages/quick-start.adoc
+++ b/docs/antora/modules/getting-started/pages/quick-start.adoc
@@ -1,4 +1,4 @@
-= Get started with Chronicle Queue
+= Get Started with Chronicle Queue
 keywords: chronicle queue, queue, java
 author: Julia Gustafsson
 :reftext: Get started with Chronicle Queue
@@ -52,7 +52,7 @@ dependencies {
 == Hello World with Chronicle Queue
 Now that the installation is complete it is time to create a first queue and try appending and reading messages from it.
 
-=== Creating a new queue
+=== Creating a New Queue
 A new Chronicle Queue is obtained from a builder by passing the field `singleBuilder` the path where the queue is to be stored. The example below creates an `IndexedChronicle` which creates two `RandomAccessFiles`; one for indexes, and one for data having names relatively:
 
 [source, java]
@@ -68,7 +68,7 @@ The queue files will reside in the directory `getting-started` and files are nam
 ${java.io.tmpdir}/getting-started/{today}.cq4
 ----
 
-=== Writing to a queue
+=== Writing to a Queue
 Messages are written, or appended, to a queue using an appender. The appender writes messages to the end of the queue only, there is no way to insert messages at a specific location.
 
 Here is how you can append a simple text message containing the text "Hello World!":
@@ -112,7 +112,7 @@ queue.close();
 
 IMPORTANT: No data will be lost when closing the queue. This procedure only cleans up resources that were used at runtime.
 
-=== Putting it all together
+=== Putting it all Together
 
 Putting these instructions together, the application looks as follows:
 

--- a/docs/antora/modules/getting-started/pages/use-cases.adoc
+++ b/docs/antora/modules/getting-started/pages/use-cases.adoc
@@ -5,7 +5,7 @@ author: Julia Gustafsson
 :navtitle: Use cases
 :source-highlighter: highlight.js
 
-== Producer-centric systems
+== Producer-Centric Systems
 Chronicle Queue is most often used for producer-centric systems where you need to retain a lot of data for days or years.
 
 Most messaging systems are consumer-centric. Flow control is implemented to avoid the consumer ever getting overloaded; even momentarily. A common example is a server supporting multiple GUI users. Those users might be on different machines (OS and hardware), different qualities of network (latency and bandwidth), doing a variety of other things at different times. For this reason it makes sense for the client consumer to tell the producer when to back off, delaying any data until the consumer is ready to take more data.
@@ -16,7 +16,7 @@ IMPORTANT: Chronicle Queue does *not* support operating off any network file sys
 The reason for this is those file systems do not provide all the required primitives for memory-mapped files Chronicle Queue uses.
 If any networking is needed (e.g. to make the data accessible to multiple hosts), the only supported way is Chronicle Queue Replication (Enterprise feature).
 
-== Market data
+== Market Data
 
 Market data publishers don't give you the option to push back on the producer for long; if at all.
 A few of our users consume data from CME OPRA. This produces peaks of 10 million events per minute, sent as UDP packets without any retry.
@@ -27,21 +27,21 @@ For market data in particular, real time means in a *few microseconds*; it doesn
 Chronicle Queue is fast and efficient, and has been used to increase the speed that data is passed between threads.
 In addition, it also keeps a record of every message passed allowing you to significantly reduce the amount of logging that you need to do.
 
-== Compliance systems
+== Compliance Systems
 
 Compliance systems are required by more and more systems these days.
 Everyone has to have them, but no one wants to be slowed down by them.
 By using Chronicle Queue to buffer data between monitored systems and the compliance system, you don't need to worry about the impact of compliance recording for your monitored systems.
 Again, Chronicle Queue can support millions of events per-second, per-server, and access data which has been retained for years.
 
-== Latency sensitive micro-services
+== Latency Sensitive Micro-Services
 
 Chronicle Queue supports low latency IPC (Inter Process Communication) between JVMs on the same machine in the order of magnitude of 1 microsecond; as well as between machines with a typical latency of 10 microseconds for modest throughputs of a few hundred thousands.
 Chronicle Queue supports throughputs of millions of events per second, with stable microsecond latencies.
 
 See https://vanilla-java.github.io/tag/Microservices/[Articles on the use of Chronicle Queue in Microservices]
 
-== Log replacement
+== Log Replacement
 
 A Chronicle Queue can be used to build state machines.
 All the information about the state of those components can be reproduced externally, without direct access to the components, or to their state.

--- a/docs/antora/modules/introduction/pages/introduction.adoc
+++ b/docs/antora/modules/introduction/pages/introduction.adoc
@@ -5,13 +5,13 @@ author: Per Minborg, Julia Gustafsson
 :navtitle: Introduction
 :source-highlighter: highlight.js
 
-== A high performance message queue
+== A High Performance Message Queue
 Chronicle Queue is a low-latency message queue that allows persistence of messages in high performance, mission critical applications. It can be used for low latency Interprocess Communication (IPC) without affecting your system performance, hence is tailored to transfer large amounts of data.
 
-== Overview of documentation
+== Overview of Documentation
 The Chronicle Queue documentation comprises two parts of which the first is this comprehensive user guide, and the second a rich library of runnable code examples.
 
-=== User guide
+=== User Guide
 The user guide is structured as follows:
 
 WARNING: This section is under construction
@@ -24,12 +24,12 @@ WARNING: This section is under construction
 * **★ Replication** - Replication is an Enterprise feature allowing queues to be automatically replicated across machines or cores. This chapter teaches how that is accomplished.
 * **★ Encryption** - Learn how to protect the contents of a Chronicle Queue with encryption.
 
-=== Runnable demos
+=== Runnable Demos
 Chronicle has gathered all runnable code demonstrations on GitHub for easy access. The demos are great examples of how the learnings from the user guide can be put into practise.
 
 NOTE: The documentation primarily covers usage of Chronicle Queue with Java. If you are interested in the C++ version please contact link:mailto:sales@chronicle.software[sales@chronicle.software].
 
-== Where to begin
+== Where to Begin
 If this is your first time getting to know Chronicle Queue, you may want to familiarize yourself with the overall capabilities of Queue by reading xref:what-is-chronicle-queue:what-is-chronicle-queue.adoc[What is Chronicle Queue?]. Thereafter, follow the xref:getting-started:quick-start.adoc[Quick-start Guide] to get set up in minutes. Then you are ready to explore the rest of the chapters that explores
 
 In case you are not yet interested in integrating Queue in one of your projects, you may want to start out by running one of our demos. You find our demonstrations [here].
@@ -47,7 +47,7 @@ Chronicle Queue Enterprise is a commercially supported version of Chronicle Queu
 
 For more information on Chronicle Queue Enterprise, please contact link:mailto:sales@chronicle.software[sales@chronicle.software].
 
-== Phone home
+== Phone Home
 Chronicle Queue sends usage data and platform information via a secure connection to Google Analytics, a web analytics service provided by Google, Inc.("Google"). This data is collected to learn how Chronicle's products are used, which in turn helps us focus our resources more efficiently in our effort to improve our libraries and provide better and more widely adopted solutions for the community.
 
 Learn more about what data is collected and why link:https://github.com/OpenHFT/Chronicle-Queue/blob/ea/DISCLAIMER.adoc[here.]

--- a/docs/antora/modules/performance/pages/contended-writes.adoc
+++ b/docs/antora/modules/performance/pages/contended-writes.adoc
@@ -1,4 +1,4 @@
-= Contended writes
+= Contended Writes
 keywords: contended writes, chronicle queue, queue, java, performance, low-latency
 author: Niel Clifford, Julia Gustafsson
 :reftext: Contended writes
@@ -20,7 +20,7 @@ ChronicleQueue queue = ChronicleQueue.singleBuilder("queue")
 
 IMPORTANT: During a buffered write, `DocumentContext.index()` will throw an `IndexNotAvailableException`. This is because no index is assigned until the buffer is written back to the queue, which happens when the `DocumentContext` is closed.
 
-== General advice on double buffering
+== General Advice on Double Buffering
 Double buffering is only useful if:
 
 * the majority of the objects being written to the queue are big enough
@@ -31,7 +31,7 @@ Double buffering is only useful if:
 Below are benchmark results for various data sizes at the frequency of 10 KHz for a cumbersome message (see `net.openhft.chronicle.queue.bench.QueueContendedWritesJLBHBenchmark`).
 
 === 1 KB messages
-==== Double-buffer disabled
+==== Double-Buffer Disabled
 ----
 ------------------ SUMMARY (Concurrent) --------------------
 Percentile   run1         run2         run3      % Variation
@@ -52,7 +52,7 @@ worst:      82477.06     45891.58     28172.29        29.54
 ------------------------------------------------------------
 ----
 
-==== Double-buffer enabled
+==== Double-Buffer Enabled
 ----
 ------------------ SUMMARY (Concurrent) --------------------
 Percentile   run1         run2         run3      % Variation
@@ -74,7 +74,7 @@ worst:      69042.18     28368.90     28876.80         1.18
 ----
 
 === 4 KB messages
-==== Double-buffer disabled
+==== Double-Buffer Disabled
 ----
 ------------------ SUMMARY (Concurrent) --------------------
 Percentile   run1         run2         run3      % Variation
@@ -95,7 +95,7 @@ worst:      35504.13     42778.62     87130.11        40.87
 ------------------------------------------------------------
 ----
 
-==== Double-buffer enabled
+==== Double-Buffer Enabled
 ----
 ------------------ SUMMARY (Concurrent) --------------------
 Percentile   run1         run2         run3      % Variation

--- a/docs/antora/modules/performance/pages/performance.adoc
+++ b/docs/antora/modules/performance/pages/performance.adoc
@@ -1,4 +1,4 @@
-= Performance tuning
+= Performance Tuning
 keywords: chronicle queue, queue java, performance, low-latency
 author: Julia Gustafsson
 :reftext: Performance tuning
@@ -7,29 +7,29 @@ author: Julia Gustafsson
 
 NOTE: TBW, I have only pasted text here that seems to fit under this category
 
-== Using high resolution timings across machines
+== Using High Resolution Timings Across Machines
 On most systems `System.nanoTime()` is roughly the number of nanoseconds since the system last rebooted (although different JVMs may behave differently). This is the same across JVMs on the same machine, but wildly different between machines. The absolute difference when it comes to machines is meaningless. However, the information can be used to detect outliers; you can’t determine what the best latency is, but you can determine how far off the best latencies you are. This is useful if you are focusing on the 99th percentile latencies. We have a class called `RunningMinimum` to obtain timings from different machines, while compensating for a drift in the nanoTime between machines. The more often you take measurements, the more accurate this running minimum is.
 
 == Avoid Interrupts
 For performance reasons, Chronicle Queue does not check for interrupts. Because of this, it is recommended to avoid using Chronicle Queue with code that generates interrupts. If you can not avoid generating interrupts then we suggest that you create a separate instance of Chronicle Queue per thread.
 
-== Performance between Disk and RAM. Should we specify faster RAM or a faster disk to Chronicle improve read/write performance?
+== Performance Between Disk and RAM. Should we Specify Faster RAM or a Faster Disk to Chronicle Improve Read/Write Performance?
 
 Chronicle recommends lots of high-speed RAM. This is because Chronicle uses the page cache and RAM is in effect a cache to the disk.
 
 There are two cases where having a high-speed disk will give you a real benefit:
 
-=== Data rate
+=== Data Rate
 If the rate of data that you are writing exceeds the disk write speed. In most applications this is unlikely to occur.
 
-=== Page cache miss
+=== Page Cache Miss
 For Chronicle queues which write and read messages lineally across memory, we mitigate this situation with the use of the Chronicle pre-toucher. The pre-toucher ensures that the page is loaded into the page cache before being written into the queue.
 
 For Chronicle Map, it is somewhat more complicated because Chronicle Map reads and writes your entries with random access across both the memory and disk. In this situation, if the entire map can be held within the page cache, then a read, or write, to the map will not have to access the disk. The operating system will work in the background ensuring that entries written to the page cache are propagated to the disk, but this is done via the operating system and is not on the critical path.
 
 It follows that if you have quite a few maps, especially large maps, and your page cache is not large enough to hold all of these maps, then a read, or write, to a random entry may cause a cache miss. This in turn would cause a disk read or write. If you were going to install high-speed SSDs, Chronicle recommends that you use them to store the Chronicle maps and leave the slower cheap disks for the Chronicle queues. In addition, you should avoid using network attached storage, as this usually offers worst performance than local disks.
 
-== How do we reduce garbage?
+== How do we Reduce Garbage?
 
 For the most latency-sensitive systems, you may want to keep your allocation rate to below `300` KB/s.
 At this rate you will produce less than `24` GB of garbage a day, and

--- a/docs/antora/modules/performance/pages/pretouching.adoc
+++ b/docs/antora/modules/performance/pages/pretouching.adoc
@@ -1,4 +1,4 @@
-= Pre-touching
+= Pre-Touching
 keywords: chronicle queue, queue, java, performance, low-latency, preloader, pre-touching
 author: Niel Clifford, Julia Gustafsson
 :reftext: Pre-touching
@@ -19,7 +19,7 @@ There are two ways to perform pre-touching, outlined below:
 * **Triggering pre-touches manually** - Perform pre-touching once for the current appender using `ExcerptAppender.pretouch()`
 * **Automatically pre-touching using Chronicle's preloader ★** - The preloader automatically pre-touches segments at a given time interval _(Enterprise feature)_.
 
-== Pre-touching once
+== Pre-Touching Once
 A single pre-touching operation can be performed by the appender by calling `pretouch()` as follows:
 
 [source, java]
@@ -45,7 +45,7 @@ newSingleThreadScheduledExecutor().scheduleAtFixedRate(
 <3> The period between successive executions
 <4> The time unit of the `initialDelay` and period parameters
 
-== Automatic pre-touching ★
+== Automatic Pre-Touching ★
 The easiest way to configure periodical pre-touching is by using Chronicle's out-of-process preloader. It can be activated in the Chronicle Queue Builder as follows:
 
 [source, java]

--- a/docs/antora/modules/queue-operations/pages/appending.adoc
+++ b/docs/antora/modules/queue-operations/pages/appending.adoc
@@ -135,7 +135,7 @@ outputs the following:
 }
 ----
 
-== Writing an object
+== Writing an Object
 [source, java]
 ----
 package net.openhft.chronicle.queue;
@@ -192,7 +192,7 @@ outputs the following:
 }
 ----
 
-== Writing raw data
+== Writing Raw Data
 You can write "raw data" which is self-describing. The types will always be correct; position is the only indication as to the meaning of those values.
 
 [source,Java]
@@ -283,7 +283,7 @@ Hello World
 000402e0 6C 6F 20 57 6F 72 6C 64                          lo World
 ----
 
-== Writing to a queue using `ChronicleWriter`
+== Writing to a Queue Using `ChronicleWriter`
 
 If using `MethodReader` and `MethodWriter` then you can write single-argument method calls to a queue
 using `net.openhft.chronicle.queue.ChronicleWriterMain` or the shell script `queue_writer.sh` e.g.

--- a/docs/antora/modules/queue-operations/pages/queue-operations.adoc
+++ b/docs/antora/modules/queue-operations/pages/queue-operations.adoc
@@ -1,4 +1,4 @@
-= Queue operations
+= Queue Operations
 keywords: queue, java, appending, tailing, chronicle
 author: Julia Gustafsson
 :reftext: Queue operations

--- a/docs/antora/modules/queue-operations/pages/read-write-proxies.adoc
+++ b/docs/antora/modules/queue-operations/pages/read-write-proxies.adoc
@@ -1,4 +1,4 @@
-= Read/write proxies
+= Read/Write Proxies
 keywords: queue, java, proxy, appending, tailing, chronicle
 author: Julia Gustafsson
 :reftext: Read/write proxies

--- a/docs/antora/modules/queue-operations/pages/tailing.adoc
+++ b/docs/antora/modules/queue-operations/pages/tailing.adoc
@@ -102,7 +102,7 @@ An abstraction can be added to filter messages, or assign messages to just one m
 
 As Chronicle Queue doesn't partition its topics, you get total ordering of all messages within that topic. Across topics, there is no guarantee of ordering; if you want to replay deterministically from a system which consumes from multiple topics, we suggest replaying from that system's output.
 
-== Tailers and file handlers clean up
+== Tailers and File Handlers Clean Up
 
 Chronicle Queue tailers may create file handlers, the file handlers are cleaned up whenever the associated chronicle queue's `close()` method is invoked or whenever the Jvm runs a Garbage Collection.
 If you are writing your code not have GC pauses and you explicitly want to clean up the file handlers, you can call the following:
@@ -146,7 +146,7 @@ boolean messageAvailable = tailer.toEnd().direction(TailerDirection.BACKWARD).
         readingDocument().isPresent();
 ----
 
-== Restartable tailers
+== Restartable Tailers
 
 AKA named tailers.
 
@@ -187,7 +187,7 @@ NOTE: The `direction()` is not preserved across restarts, only the next index to
 NOTE: The index of a tailer is only progressed when the `DocumentContext.close()` is called.
 If this is prevented by an error, the same message will be read on each restart.
 
-== Command line tools - reading and writing a Chronicle Queue
+== Command Line Tools - Reading and Writing a Chronicle Queue
 
 Chronicle Queue stores its data in binary format, with a file extension of `cq4`:
 
@@ -284,7 +284,7 @@ $ ./bin/dump_queue.sh <file path>
 ----
 
 '''
-=== Reading a queue using `ChronicleReaderMain`
+=== Reading a Queue Using `ChronicleReaderMain`
 
 The second tool for logging the contents of the chronicle queue is the `ChronicleReaderMain` (in the Chronicle Queue project). As mentioned above, it is able to perform several operations beyond printing the file content to the console. For example, it can be used to tail a queue to detect whenever new messages are added (rather like $tail -f).
 

--- a/docs/antora/modules/ring-buffer/pages/ring-buffer.adoc
+++ b/docs/antora/modules/ring-buffer/pages/ring-buffer.adoc
@@ -16,7 +16,7 @@ TIP: https://jerryshea.github.io/2018/07/27/RingBuffer.html[This article] gives 
 .Chronicle Ring Buffer
 image::chronicle-ring.png[Chronicle Ring Buffer, width=700px]
 
-== The mechanics of Chronicle Ring Buffer
+== The Mechanics of Chronicle Ring Buffer
 
 The Chronicle Queue Enterprise Ring Buffer is a multi-writer, multi-reader, zero-garbage collection, monitored ring buffer implementation which takes `Bytes`. As the Chronicle stack is built on `Bytes`, you can use the ring buffer for byte arrays, packed objects, or you can serialise (or de-serialise objects out of, or into, it using https://github.com/OpenHFT/Chronicle-Wire[Chronicle Wire].
 
@@ -24,7 +24,7 @@ Backing the ring buffer with a persistent BytesStore (that is, one backed with a
 
 IMPORTANT: The maximum size of a message that can be written to a ring buffer is 1/4 of its capacity. An exception will be thrown if this is exceeded. The exception may be thrown at either read or write time depending on how the RB is written to, and whether asserts are enabled.
 
-== Common scenarios
+== Common Scenarios
 - Back the ring buffer with an in-memory BytesStore. +
 You can have multiple writers and multiple readers in the same process. The ring buffer does not survive longer than the process.
 
@@ -78,7 +78,7 @@ The ring buffer can be used in one of two ways in `EnterpriseSingleChronicleQueu
 - Asynchronous writes
 - Writes and reads using ring buffer
 
-=== Asynchronous writes
+=== Asynchronous Writes
 
 If `writeBufferMode` is set to `BufferMode.Asynchronous` then any writes to the queue will be given to the ring buffer. A background task is created in the builder's event loop to drain the ring buffer in to the underlying (disk-backed) Chronicle queue. Reads are made from the underlying queue. This use-case is designed to help with very "bursty" writes,
 which cannot afford to be blocked by a slow underlying disk sub-system. The ring's buffer size must be carefully chosen to allow for the maximum burst size.
@@ -98,14 +98,14 @@ which cannot afford to be blocked by a slow underlying disk sub-system. The ring
         ...
     }
 ----
-=== Writes and reads using ring buffer
+=== Writes and Reads Using Ring Buffer
 
 If both `writeBufferMode` and `readBufferMode` are set to `BufferMode.Asynchronous` then any writes to the queue will
 be given to the ring buffer and reads will read from the ring buffer. This gives the lowest possible latency as the
 disk subsystem is not involved at all. As with asynchronous writes, a background task is created in the builder's event
 loop to drain the ring buffer in to the underlying (disk-backed) chronicle queue.
 
-==== Example for asynchronous reads and writes using a memory-mapped file and two processes
+==== Example for Asynchronous Reads and Writes Using a Memory-Mapped File and Two Processes
 
 If you don't need access across processes, then no need to set `bufferBytesStoreCreator`. The default `bufferBytesStoreCreator` will create an in-memory `ByteStore`.
 
@@ -148,10 +148,10 @@ the only benefit to be gained with a memory mapped file is if it mapped to a fas
     }
 ----
 
-=== Drainer thread
+=== Drainer Thread
 When the queue's event loop is closed, the drainer thread will wait up to 5 seconds to finish draining to the underlying queue. If draining can not complete, a warning message is logged
 
-== Unsupported operations
+== Unsupported Operations
 The following operations are unsupported when using `EnterpriseSingleChronicleQueue` backed by a ring buffer:
 
 * Writing and reading of metadata

--- a/docs/antora/modules/what-is-chronicle-queue/pages/what-is-chronicle-queue.adoc
+++ b/docs/antora/modules/what-is-chronicle-queue/pages/what-is-chronicle-queue.adoc
@@ -5,7 +5,7 @@ author: Julia Gustafsson
 :navtitle: What is Chronicle Queue
 :source-highlighter: highlight.js
 
-== A Low-latency message queue
+== A Low-Latency Message Queue
 Chronicle Queue is a "record everything" message queue which operates with microsecond real-time latency. It can be used for rapid Interprocess Communication (IPC) without affecting your system performance. Hence, it is tailored to transfer and store large amounts of data in low-latency environments, where recording of information is a central e.g. the most demanding High Frequency Trading systems.
 
 You could consider Chronicle Queue to be similar to a low-latency broker-less durable/persisted JVM topic. It is a distributed, unbounded, and persisted queue that:
@@ -45,7 +45,7 @@ NOTE: 100 million events per minute is sending an event every 660 nanoseconds; r
 IMPORTANT: This performance is not achieved using a *large cluster of machines*.
 This is using one thread to publish, and one thread to consume.
 
-== No garbage collection
+== No Garbage Collection
 High-performance applications simply cannot tolerate the non-deterministic slowdowns that the Java garbage collector yields when cleaning the heap. Therefore, Chronicle Queue avoids garbage collection altogether by managing the memory stack manually with `RandomAccessFiles`. This means a Chronicle Queue can be viewed as a management interface over off-heap memory, on which anyone can build their own solution. E.g. it is suitable for exceptionally fast interprocess communication (IPC) with no negative impact on the system performance.
 
 == Persistent
@@ -58,7 +58,7 @@ Replication for Chronicle Queue supports Chronicle Wire Enterprise. This enables
 
 Chronicle Queue also supports LZW, Snappy, and GZIP compression. These formats however add significant latency. These are only useful if you have strict limitations on network bandwidth.
 
-=== Delivery mode semantics
+=== Delivery Mode Semantics
 Chronicle Queue supports a number of semantics:
 
 * Every message is replayed on restart.


### PR DESCRIPTION
This is the same PR to capitalise the headings and subheadings, but I had tried to merge it to the wrong branch. This has been fixed. 