### PR TITLE
Fix NPM critical vulnerability, ignore node_modules

### DIFF
--- a/docs/antora/.gitignore
+++ b/docs/antora/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/docs/antora/package-lock.json
+++ b/docs/antora/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "chronicle-queue-antora-docs",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "UNLICENSED",
       "devDependencies": {
         "antora": "^3.0.1",
         "antora-site-generator-lunr": "^0.6.1",
@@ -1362,9 +1362,9 @@
       "dev": true
     },
     "node_modules/convict": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.1.tgz",
-      "integrity": "sha512-Mn4AJiYkR3TAZH1Xm/RU7gFS/0kM5TBSAQDry8y40Aez0ASY+3boUhv+3QE5XbOXiXM2JjdhkKve3IsBvWCibQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.3.tgz",
+      "integrity": "sha512-mTY04Qr7WrqiXifdeUYXr4/+Te4hPFWDvz6J2FVIKCLc2XBhq63VOSSYAKJ+unhZAYOAjmEdNswTOeHt7s++pQ==",
       "dev": true,
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
@@ -2521,9 +2521,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/minimisted": {
@@ -4806,9 +4806,9 @@
       }
     },
     "convict": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.1.tgz",
-      "integrity": "sha512-Mn4AJiYkR3TAZH1Xm/RU7gFS/0kM5TBSAQDry8y40Aez0ASY+3boUhv+3QE5XbOXiXM2JjdhkKve3IsBvWCibQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.3.tgz",
+      "integrity": "sha512-mTY04Qr7WrqiXifdeUYXr4/+Te4hPFWDvz6J2FVIKCLc2XBhq63VOSSYAKJ+unhZAYOAjmEdNswTOeHt7s++pQ==",
       "dev": true,
       "requires": {
         "lodash.clonedeep": "^4.5.0",
@@ -5716,9 +5716,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimisted": {


### PR DESCRIPTION
Hopefully this will quiet dependabot down

We could disable dependabot for that folder because it's not production code, but perhaps it's good to get notifications of updates.