### PR TITLE
Tell dependabot to make less noise about the Antora directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "develop"
+  # Antora is used to generate documentation, we don't need to know about
+  # vulnerabilities in or updates to the full tree of dependencies
+  - package-ecosystem: "npm"
+    directory: "/docs/antora"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "direct"

--- a/docs/antora/build-local.sh
+++ b/docs/antora/build-local.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-#DOCSEARCH_ENABLED=true DOCSEARCH_ENGINE=lunr NODE_PATH="$(npm -g root)" antora --generator antora-site-generator-lunr site-local.yml
 npm ci && npm run build-local

--- a/docs/antora/build.sh
+++ b/docs/antora/build.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-DOCSEARCH_ENABLED=true DOCSEARCH_ENGINE=lunr NODE_PATH="$(npm -g root)" antora --generator antora-site-generator-lunr site.yml
-
+npm ci && npm run build


### PR DESCRIPTION
I _think_ this means we will only check antora directory monthly, and we'll only alert to updates to/vulnerabilities in the libraries we directly depend on, not the tree of 5 million transitive npm dependencies

Also tidy up the build scripts