### PR TITLE
Implement a test for the surefire interrupt flag bug, remove surefire:3.0.0-M4 pinning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,8 +232,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- <version>3.0.0-M5</version> Clears Thread.interrupted() -->
-                <version>3.0.0-M4</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <!--                    <reuseForks>false</reuseForks>-->

--- a/src/test/java/net/openhft/chronicle/queue/SurefireInterruptFlagTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/SurefireInterruptFlagTest.java
@@ -1,0 +1,21 @@
+package net.openhft.chronicle.queue;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SurefireInterruptFlagTest {
+
+    /**
+     * Test for https://issues.apache.org/jira/browse/SUREFIRE-1863
+     */
+    @Test
+    void testSurefireLeavesInterruptFlagIntactOnOutput() {
+        assertFalse(Thread.currentThread().isInterrupted());
+        Thread.currentThread().interrupt();
+        assertTrue(Thread.currentThread().isInterrupted());
+        System.out.println("Hello world!");
+        assertTrue(Thread.currentThread().isInterrupted());
+    }
+}


### PR DESCRIPTION
Not sure if we need to merge this, but just a data point for the surefire thing