### PR TITLE
Cache queue and tailer so ChronicleHistoryReader#readChronicle can be called repeatedly. Fixes #1102

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
@@ -45,9 +45,10 @@ public class ChronicleHistoryReaderMain {
         final Options options = options();
         final CommandLine commandLine = parseCommandLine(args, options);
 
-        final ChronicleHistoryReader chronicleHistoryReader = chronicleHistoryReader();
-        setup(commandLine, chronicleHistoryReader);
-        chronicleHistoryReader.execute();
+        try (final ChronicleHistoryReader chronicleHistoryReader = chronicleHistoryReader()) {
+            setup(commandLine, chronicleHistoryReader);
+            chronicleHistoryReader.execute();
+        }
     }
 
     protected void setup(@NotNull final CommandLine commandLine, @NotNull final ChronicleHistoryReader chronicleHistoryReader) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -194,7 +194,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
             // release the write lock if the process is dead
             if (writeLock instanceof TableStoreWriteLock) {
-                ((TableStoreWriteLock) writeLock).forceUnlockIfProcessIsDead();
+                writeLock.forceUnlockIfProcessIsDead();
             }
 
             this.appendLock = builder.appendLock();

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
@@ -116,15 +116,16 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
                 assertFalse(reader.readOne());
             }
 
-            ChronicleHistoryReader chronicleHistoryReader = new ChronicleHistoryReader()
+            try (ChronicleHistoryReader chronicleHistoryReader = new ChronicleHistoryReader()
                     .withBasePath(queuePath3.toPath())
                     .withTimeUnit(TimeUnit.MICROSECONDS)
-                    .withMessageSink(System.out::println);
-            Map<String, Histogram> histos = chronicleHistoryReader.readChronicle();
-            chronicleHistoryReader.outputData();
+                    .withMessageSink(System.out::println)) {
+                Map<String, Histogram> histos = chronicleHistoryReader.readChronicle();
+                chronicleHistoryReader.outputData();
 
-            Assert.assertEquals(5, histos.size());
-            Assert.assertEquals("[1, startTo1, 2, 1to2, endToEnd]", histos.keySet().toString());
+                Assert.assertEquals(5, histos.size());
+                Assert.assertEquals("[1, startTo1, 2, 1to2, endToEnd]", histos.keySet().toString());
+            }
         } finally {
             IOTools.deleteDirWithFiles(queuePath1.toString(), queuePath2.toString(), queuePath3.toString());
         }


### PR DESCRIPTION
#comment `ChronicleHistoryReader` now implements `Closeable`