### PR TITLE
Fix dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
     schedule:
       interval: "monthly"
     allow:
-      - dependency-type: "direct"
+      - dependency-type: "production"


### PR DESCRIPTION
Looks like dependabot doesn't distinguish between direct and transitive dependencies for npm. Feeling a bit more confident about this approach. We have no `production` dependencies in that project so should be good.

We won't get alerted about new versions of antora with this approach, but maybe we don't care.