### PR TITLE
Add test for TableDirectoryListing.modCount and RollingResourcesCachetoLong

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
@@ -21,6 +21,8 @@ import static net.openhft.chronicle.queue.DirectoryUtils.tempDir;
 import static net.openhft.chronicle.queue.RollCycles.*;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class InternalAppenderWriteBytesTest extends ChronicleQueueTestBase {
 
@@ -284,6 +286,18 @@ public class InternalAppenderWriteBytesTest extends ChronicleQueueTestBase {
             result.clear();
             tailer.readBytes(result);
             assertEquals(test2, result);
+        }
+    }
+
+    @Test
+    public void testModCountAndToLong() throws Exception {
+        try {
+            try (final SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir()).timeProvider(() -> 0).build()) {
+                q.listCyclesBetween(-481902163, -1911694226);
+            }
+            fail("testModCountAndToLong should have thrown IllegalStateException");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains("'file not found' for the lowerCycle"));
         }
     }
 


### PR DESCRIPTION
Hey 😊
I want to contribute a test.
Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))