### PR TITLE
Add test for file handle leak, fix existing AppenderFileHandleLeakTest

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCache.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCache.java
@@ -50,7 +50,7 @@ public class ReferenceCountedCache<K, T extends ReferenceCounted & Closeable, V,
             rv = transformer.apply(value);
         }
 
-        BackgroundResourceReleaser.run(bgCleanup);
+        triggerExpiry();
 
         return rv;
     }
@@ -85,6 +85,18 @@ public class ReferenceCountedCache<K, T extends ReferenceCounted & Closeable, V,
                 .filter(o -> o instanceof ManagedCloseable)
                 .map(o -> (ManagedCloseable) o)
                 .forEach(ManagedCloseable::warnAndCloseIfNotClosed);
+    }
+
+    /**
+     * This is part of a temporary fix for https://github.com/OpenHFT/Chronicle-Queue/issues/1148
+     * <p>
+     * It will be removed
+     *
+     * @deprecated This should not be used
+     */
+    @Deprecated
+    public void triggerExpiry() {
+        BackgroundResourceReleaser.run(bgCleanup);
     }
 
     void bgCleanup() {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -238,6 +238,19 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         }
     }
 
+    /**
+     * This is a brittle, ugly and temporary fix for https://github.com/OpenHFT/Chronicle-Queue/issues/1148
+     * <p>
+     * We will fast-follow with a proper fix whereby the cache is made aware when references are released,
+     * so it can flush itself
+     *
+     * @deprecated This should not be used
+     */
+    @Deprecated
+    public void flushMappedFileCache_temporaryFix() {
+        storeSupplier.mappedFileCache.triggerExpiry();
+    }
+
     protected void createAppenderCondition(@NotNull Condition createAppenderCondition) {
         this.createAppenderCondition = createAppenderCondition;
     }
@@ -965,7 +978,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             directoryListing.refresh(true);
         } finally {
             writeLock.unlock();
-            if(fireOnReleasedEvent != null)
+            if (fireOnReleasedEvent != null)
                 BackgroundResourceReleaser.run(fireOnReleasedEvent);
             long tookMillis = (System.nanoTime() - start) / 1_000_000;
             if (tookMillis > WARN_SLOW_APPENDER_MS)

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -297,6 +297,7 @@ class StoreAppender extends AbstractCloseable
             assert wire != old || wire == null;
             releaseBytesFor(old);
         }
+        ((SingleChronicleQueue)queue).flushMappedFileCache_temporaryFix();
     }
 
     private Wire createWire(@NotNull final WireType wireType) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -818,8 +818,10 @@ class StoreTailer extends AbstractCloseable
         assert !QueueSystemProperties.CHECK_INDEX || headerNumberCheck((AbstractWire) wireForIndex);
         assert wire != wireForIndexOld;
 
-        if (wireForIndexOld != null)
+        if (wireForIndexOld != null) {
             wireForIndexOld.bytes().releaseLast();
+            queue.flushMappedFileCache_temporaryFix();
+        }
     }
 
     @NotNull

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
@@ -14,7 +14,6 @@ import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.WireType;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -37,7 +36,6 @@ public final class AppenderFileHandleLeakTest extends ChronicleQueueTestBase {
 
     private final ExecutorService threadPool = Executors.newFixedThreadPool(THREAD_COUNT,
             new NamedThreadFactory("test"));
-    private final List<String> lastFileHandles = new ArrayList<>();
     private final TrackingStoreFileListener storeFileListener = new TrackingStoreFileListener();
     private final AtomicLong currentTime = new AtomicLong(System.currentTimeMillis());
     private File queuePath;
@@ -152,7 +150,6 @@ public final class AppenderFileHandleLeakTest extends ChronicleQueueTestBase {
 
     }
 
-    @Ignore("TODO FIX")
     @Test
     public void tailerShouldReleaseFileHandlesAsQueueRolls() throws IOException, InterruptedException {
         assumeTrue(OS.isLinux() || OS.isMacOSX());
@@ -164,15 +161,14 @@ public final class AppenderFileHandleLeakTest extends ChronicleQueueTestBase {
         final int messagesPerThread = 10;
         try (ChronicleQueue queue = createQueue(currentTime::get)) {
             file = queue.file();
-            final List<String> fileHandlesAtStart = new ArrayList<>(lastFileHandles);
 
             for (int j = 0; j < messagesPerThread; j++) {
                 writeMessage(j, queue);
                 currentTime.addAndGet(500);
             }
 
-            fileHandlesAtStart.clear();
-
+            // StoreFileListener#onAcquired() is called on the background resource releaser thread
+            BackgroundResourceReleaser.releasePendingResources();
             int acquiredBefore = storeFileListener.acquiredCounts.size();
             storeFileListener.reset();
 
@@ -194,9 +190,8 @@ public final class AppenderFileHandleLeakTest extends ChronicleQueueTestBase {
 
             assertEquals(messagesPerThread, messageCount);
 
+            // StoreFileListener#onAcquired() is called on the background resource releaser thread
             BackgroundResourceReleaser.releasePendingResources();
-            // tailers do not call StoreFileListener correctly - see
-            // https://github.com/OpenHFT/Chronicle-Queue/issues/694
             Jvm.debug().on(getClass(), "storeFileListener " + storeFileListener);
 
             assertEquals(acquiredBefore, storeFileListener.acquiredCounts.size());
@@ -207,7 +202,7 @@ public final class AppenderFileHandleLeakTest extends ChronicleQueueTestBase {
     }
 
     @Override
-    public void assertReferencesReleased()  {
+    public void assertReferencesReleased() {
         threadPool.shutdownNow();
         try {
             assertTrue(threadPool.awaitTermination(5L, TimeUnit.SECONDS));
@@ -220,24 +215,24 @@ public final class AppenderFileHandleLeakTest extends ChronicleQueueTestBase {
     private static boolean isFileHandleClosed(File file) throws IOException {
         Process plsof = null;
         try {
-            plsof = new ProcessBuilder("lsof", "|", "grep", file.getAbsolutePath()).start();
+            plsof = new ProcessBuilder("lsof", "-p", String.valueOf(Jvm.getProcessId())).start();
+            int openFilesCount = 0;
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(plsof.getInputStream()))) {
                 String line;
-                while ((line = reader.readLine()) != null) {
-                        // System.out.println(line);
-                    if (line.contains(file.getAbsolutePath())) {
-                        reader.close();
-                        plsof.destroy();
-                        return false;
+                while (plsof.isAlive()) {
+                    line = reader.readLine();
+                    if (line != null && line.contains(file.getAbsolutePath())) {
+                        openFilesCount++;
+                        Jvm.error().on(AppenderFileHandleLeakTest.class, "Found open file:\n" + line);
                     }
                 }
+                assertEquals("lsof call terminated with error", 0, plsof.exitValue());
             }
+            return openFilesCount == 0;
         } finally {
             if (plsof != null)
                 plsof.destroy();
         }
-
-        return true;
     }
 
     private ChronicleQueue createQueue(final TimeProvider timeProvider) {


### PR DESCRIPTION
This is a leak identified by a client. Possibly related to #1073 

The problem seems to be in `ReferenceCountedCache`, it only purges the Xth `MappedFile` when the X+2nd `MappedFile` is retrieved.

queue -> WireStorePool -> WireStoreSupplier -> ReferenceCountedCache (mappedFileCache)

The Xth MappedFile is eligible to be cleaned up by `ReferenceCountedCache#bgCleanup` much earlier but there's nothing to trigger it. It only triggers again on the subsequent `ReferenceCountedCache#get`
