### PR TITLE
Attempt to de-flake AppenderFileHandleLeakTest

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 
@@ -47,7 +49,7 @@ public final class EntryCountNotBehindReadTest extends QueueTestCommon {
             final CyclicBarrier startBarrier = new CyclicBarrier(3);
             final AtomicLong lastIndex = new AtomicLong();
             final Thread reader = new Thread
-                (() -> runReader(queue, startBarrier, lastIndex::set));
+                    (() -> runReader(queue, startBarrier, lastIndex::set));
 
             startWriter(queue, startBarrier);
             reader.start();
@@ -138,8 +140,8 @@ public final class EntryCountNotBehindReadTest extends QueueTestCommon {
 
     private static void waitOn(CyclicBarrier barrier) {
         try {
-            barrier.await();
-        } catch (InterruptedException | BrokenBarrierException e) {
+            barrier.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
             throw new IllegalStateException(e);
         }
     }


### PR DESCRIPTION
Not sure if this will do it, let's let it run a few times to see before we merge

It just waits up to 5 seconds for the leaked file handles to go away. Assuming the flakiness can be explained that way, but not sure. 5 seconds is an eternity so if it still fails it's something else.