### PR TITLE
Implement better fix for leaking file handles #1148

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCache.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCache.java
@@ -39,12 +39,13 @@ public class ReferenceCountedCache<K, T extends ReferenceCounted & Closeable, V,
     private final Map<K, T> cache = new LinkedHashMap<>();
     private final Function<T, V> transformer;
     private final ThrowingFunction<K, T, E> creator;
-    private final Runnable bgCleanup = this::bgCleanup;
+    private final ReferenceChangeListener referenceChangeListener;
 
     public ReferenceCountedCache(final Function<T, V> transformer,
                                  final ThrowingFunction<K, T, E> creator) {
         this.transformer = transformer;
         this.creator = creator;
+        this.referenceChangeListener = new TriggerFlushOnLastReferenceRemoval();
 
         singleThreadedCheckDisabled(true);
     }
@@ -60,6 +61,7 @@ public class ReferenceCountedCache<K, T extends ReferenceCounted & Closeable, V,
             if (value == null) {
                 value = creator.apply(key);
                 value.reserveTransfer(INIT, this);
+                value.addReferenceChangeListener(referenceChangeListener);
                 //System.err.println("Reserved " + value.toString() + " by " + this);
                 cache.put(key, value);
             }
@@ -67,8 +69,6 @@ public class ReferenceCountedCache<K, T extends ReferenceCounted & Closeable, V,
             // this will add to the ref count and so needs to be done inside of sync block
             rv = transformer.apply(value);
         }
-
-        triggerExpiry();
 
         return rv;
     }
@@ -117,29 +117,29 @@ public class ReferenceCountedCache<K, T extends ReferenceCounted & Closeable, V,
         }
     }
 
-    /**
-     * This is part of a temporary fix for https://github.com/OpenHFT/Chronicle-Queue/issues/1148
-     * <p>
-     * It will be removed
-     *
-     * @deprecated This should not be used
-     */
-    @Deprecated
-    public void triggerExpiry() {
-        BackgroundResourceReleaser.run(bgCleanup);
-    }
+    private class TriggerFlushOnLastReferenceRemoval implements ReferenceChangeListener {
 
-    void bgCleanup() {
-        // remove all which have been de-referenced by other than me. Garbagy but rare
-        synchronized (cache) {
-            cache.entrySet().removeIf(entry -> {
-                T value = entry.getValue();
-                int refCount = value.refCount();
-                if (refCount == 1) {
-                    value.release(this);
-                }
-                return refCount <= 1;
-            });
+        private final Runnable bgCleanup = this::bgCleanup;
+
+        @Override
+        public void onReferenceRemoved(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
+            if (referenceOwner != ReferenceCountedCache.this && referenceCounted.refCount() == 1) {
+                BackgroundResourceReleaser.run(bgCleanup);
+            }
+        }
+
+        private void bgCleanup() {
+            // remove all which have been de-referenced by other than me. Garbagy but rare
+            synchronized (cache) {
+                cache.entrySet().removeIf(entry -> {
+                    T value = entry.getValue();
+                    int refCount = value.refCount();
+                    if (refCount == 1) {
+                        value.release(ReferenceCountedCache.this);
+                    }
+                    return refCount <= 1;
+                });
+            }
         }
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -238,19 +238,6 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         }
     }
 
-    /**
-     * This is a brittle, ugly and temporary fix for https://github.com/OpenHFT/Chronicle-Queue/issues/1148
-     * <p>
-     * We will fast-follow with a proper fix whereby the cache is made aware when references are released,
-     * so it can flush itself
-     *
-     * @deprecated This should not be used
-     */
-    @Deprecated
-    public void flushMappedFileCache_temporaryFix() {
-        storeSupplier.mappedFileCache.triggerExpiry();
-    }
-
     protected void createAppenderCondition(@NotNull Condition createAppenderCondition) {
         this.createAppenderCondition = createAppenderCondition;
     }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -307,7 +307,6 @@ class StoreAppender extends AbstractCloseable
             assert wire != old || wire == null;
             releaseBytesFor(old);
         }
-        ((SingleChronicleQueue)queue).flushMappedFileCache_temporaryFix();
     }
 
     private Wire createWire(@NotNull final WireType wireType) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -838,7 +838,6 @@ class StoreTailer extends AbstractCloseable
 
         if (wireForIndexOld != null) {
             wireForIndexOld.bytes().releaseLast();
-            queue.flushMappedFileCache_temporaryFix();
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
@@ -1,0 +1,165 @@
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.AbstractReferenceCounted;
+import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.core.io.ReferenceCounted;
+import net.openhft.chronicle.core.io.ReferenceOwner;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertTrue;
+
+class ReferenceCountedCacheTest extends QueueTestCommon {
+
+    public static final int MAX_THREADS_TO_RUN = 6;
+    public static final int MIN_THREADS_TO_RUN = 3;
+    public static final int NUM_RESOURCES = 50;
+    private AtomicInteger createdCount;
+    private AtomicInteger releasedCount;
+    private ReferenceCountedCache<Integer, TestReferenceCounted, Reservation, RuntimeException> cache;
+
+    @BeforeEach
+    void setUp() {
+        createdCount = new AtomicInteger(0);
+        releasedCount = new AtomicInteger(0);
+        cache = new ReferenceCountedCache<>(Reservation::new, id -> new TestReferenceCounted());
+    }
+
+    @AfterEach
+    void closeCache() {
+        Closeable.closeQuietly(cache);
+    }
+
+    @Test
+    void shouldNeverGiveOutReleasedReferences() {
+        final ExecutorService executorService = Executors.newCachedThreadPool();
+        int numThreads = Math.min(MAX_THREADS_TO_RUN, Math.max(MIN_THREADS_TO_RUN, Runtime.getRuntime().availableProcessors()));
+        AtomicBoolean running = new AtomicBoolean(true);
+        List<Future<?>> executors = new ArrayList<>();
+        for (int i = 0; i < numThreads; i++) {
+            executors.add(executorService.submit(new ReferenceGetter(NUM_RESOURCES, cache, running)));
+        }
+        Jvm.pause(5_000);
+        running.set(false);
+        executors.forEach(f -> {
+            try {
+                f.get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        Closeable.closeQuietly(cache);
+        Jvm.startup().on(ReferenceCountedCache.class, "Created " + createdCount.get() + ", released " + releasedCount.get());
+    }
+
+    @Test
+    void shouldReturnSameObjectWhileNotReleased() {
+        final Reservation reservation = cache.get(1);
+        final Reservation otherReservation = cache.get(1);
+        Assertions.assertSame(reservation.referenceCounted, otherReservation.referenceCounted);
+        reservation.release();
+        otherReservation.release();
+    }
+
+    @Test
+    void shouldExpireObjectsWhenReferenceCountGoesToZero() {
+        final Reservation reservation = cache.get(1);
+        reservation.release();
+        Jvm.pause(100);
+        final Reservation otherReservation = cache.get(1);
+        Assertions.assertNotSame(reservation.referenceCounted, otherReservation.referenceCounted);
+        otherReservation.release();
+    }
+
+    private static class ReferenceGetter implements Runnable, ReferenceOwner {
+
+        private final int numResources;
+        private final ReferenceCountedCache<Integer, TestReferenceCounted, Reservation, RuntimeException> cache;
+        private final AtomicBoolean running;
+        private final Random random;
+        private final Reservation[] reservations;
+
+        public ReferenceGetter(int numResources, ReferenceCountedCache<Integer, TestReferenceCounted, Reservation, RuntimeException> referenceId, AtomicBoolean running) {
+            this.numResources = numResources;
+            this.cache = referenceId;
+            this.running = running;
+            this.random = ThreadLocalRandom.current();
+            this.reservations = new Reservation[numResources];
+        }
+
+        @Override
+        public void run() {
+            int reservationCount = 0;
+            while (running.get()) {
+                int nextResource = random.nextInt(numResources);
+                if (reservations[nextResource] != null) {
+                    reservations[nextResource].release();
+                    reservations[nextResource] = null;
+                } else {
+                    reservations[nextResource] = cache.get(nextResource);
+                    reservations[nextResource].assertNotReleased();
+                    reservationCount++;
+                }
+            }
+            for (int i = 0; i < reservations.length; i++) {
+                if (reservations[i] != null) {
+                    reservations[i].release();
+                }
+            }
+            Jvm.startup().on(ReferenceGetter.class, "Made " + reservationCount + " reservations");
+        }
+    }
+
+    private static class Reservation {
+
+        private final ReferenceCounted referenceCounted;
+        private final ReferenceOwner referenceOwner;
+
+        public Reservation(ReferenceCounted referenceCounted) {
+            this.referenceOwner = ReferenceOwner.temporary("reservation");
+            this.referenceCounted = referenceCounted;
+            referenceCounted.reserve(referenceOwner);
+        }
+
+        public void release() {
+            this.referenceCounted.release(referenceOwner);
+        }
+
+        public void assertNotReleased() {
+            final int referenceCount = this.referenceCounted.refCount();
+            assertTrue("Expected reference count of at least 2, got " + referenceCount, referenceCount > 1);
+        }
+    }
+
+    private class TestReferenceCounted extends AbstractReferenceCounted implements ReferenceOwner, Closeable {
+
+        public TestReferenceCounted() {
+            createdCount.incrementAndGet();
+        }
+
+        @Override
+        protected void performRelease() throws IllegalStateException {
+            releasedCount.incrementAndGet();
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This uses OpenHFT/Chronicle-Core#444 `ReferenceChangeListener`s to trigger cache flushes whenever a release occurs that reduces the reference count of a managed object to 1 (i.e. when the cache is the only remaining reference).

It replaces the temporary hack fix of manually triggering a flush in the places we knew we leaked resources.