### PR TITLE
Use /proc/self/maps instead of lsof for AppenderFileHandleLeakTest

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/MappedFileUtil.java
+++ b/src/test/java/net/openhft/chronicle/queue/MappedFileUtil.java
@@ -1,0 +1,66 @@
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.core.Jvm;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public enum MappedFileUtil {
+    ;
+    private static final Path PROC_SELF_MAPS = Paths.get("/proc/self/maps");
+
+    // See https://man7.org/linux/man-pages/man5/proc.5.html
+    private static final Pattern LINE_PATTERN = Pattern.compile("([\\p{XDigit}\\-]+)\\s+([rwxsp\\-]+)\\s+(\\p{XDigit}+)\\s+(\\p{XDigit}{2}:\\p{XDigit}{2})\\s+(\\d+)\\s*(.*)?");
+    private static final int ADDRESS_INDEX = 1;
+    private static final int PERMS_INDEX = 2;
+    private static final int OFFSET_INDEX = 3;
+    private static final int DEV_INDEX = 4;
+    private static final int INODE_INDEX = 5;
+    private static final int PATH_INDEX = 6;
+
+    /**
+     * Get the distinct files that are currently mapped to the current process
+     * <p>
+     * NOTE: this is only likely to work on linux or linux-like environments
+     *
+     * @return A set of the distinct files listed in /proc/self/maps
+     */
+    public static Set<String> getAllMappedFiles() {
+        final Set<String> fileList = new HashSet<>();
+
+        if (Files.exists(PROC_SELF_MAPS) && Files.isReadable(PROC_SELF_MAPS)) {
+            try (final BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(PROC_SELF_MAPS)))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    final Matcher matcher = LINE_PATTERN.matcher(line);
+                    if (matcher.matches()) {
+                        String filename = matcher.group(PATH_INDEX);
+                        if (filename.startsWith("/")) {
+                            fileList.add(filename);
+                        } else {
+                            if (!filename.trim().isEmpty()) {
+                                Jvm.debug().on(MappedFileUtil.class, "Ignoring non-file " + filename);
+                            }
+                        }
+                    } else {
+                        Jvm.warn().on(MappedFileUtil.class, "Found non-matching line in /proc/self/maps: " + line);
+                    }
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException("Getting mapped files failed", e);
+            }
+            return fileList;
+        } else {
+            throw new UnsupportedOperationException("This only works on systems that have a /proc/self/maps (exists="
+                    + Files.exists(PROC_SELF_MAPS) + ", isReadable=" + Files.isReadable(PROC_SELF_MAPS) + ")");
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -41,7 +41,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -90,23 +92,10 @@ public class SingleChronicleQueueTest extends ChronicleQueueTestBase {
         );
     }
 
-    private static List<String> getMappedQueueFileCount() throws IOException, InterruptedException {
-
-        final int processId = OS.getProcessId();
-        final List<String> fileList = new ArrayList<>();
-
-        final Process pmap = new ProcessBuilder("pmap", Integer.toString(processId)).start();
-        pmap.waitFor();
-        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(pmap.getInputStream()))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                if (line.contains(SUFFIX)) {
-                    fileList.add(line);
-                }
-            }
-        }
-
-        return fileList;
+    private static List<String> getMappedQueueFiles() {
+        return MappedFileUtil.getAllMappedFiles().stream()
+                .filter(filename -> filename.contains(SUFFIX))
+                .collect(Collectors.toList());
     }
 
     private static long countEntries(final ChronicleQueue queue, boolean named) {
@@ -3650,7 +3639,7 @@ public class SingleChronicleQueueTest extends ChronicleQueueTestBase {
 
             boolean passed = true;
             if (OS.isLinux()) {
-                List<String> openFiles = getMappedQueueFileCount();
+                List<String> openFiles = getMappedQueueFiles();
                 int filesOpen = openFiles.size();
                 if (filesOpen >= 50) {
                     passed = false;


### PR DESCRIPTION
`lsof` seems to block inexplicably sometimes, `pmap` does as well and the output is different on every version/distro. `/proc/self/maps` seems like a much more reliable way to determine mapped files.