### PR TITLE
Fix #1169. Remove reference to unavailable methods

### DIFF
--- a/docs/antora/modules/configuration/pages/roll-cycle.adoc
+++ b/docs/antora/modules/configuration/pages/roll-cycle.adoc
@@ -153,28 +153,7 @@ SingleChronicleQueue queue = ChronicleQueue.singleBuilder("/timezone")
 == Archiving Old Queue Files ★
 Over time, it may become necessary to automatically delete or archive old queue files. An automated process needs to ensure that there are no active file-handles open on a queue file before attempting to delete.
 
-To facilitate this operation, Chronicle Queue Enterprise tracks references to its _roll-cycle_ files internally. Ensuring there are no references to a given file it is done by checking that `ChronicleQueue.numberOfReferences()` returns zero.
-
-The suggested approach is to perform the maintenance operation from a separate JVM to the application, in the following manner:
-
-[source, java]
-----
-public void removeOldQueueFiles() throws IOException {
-    final Path queuePath = Paths.get("/path/to/queue");
-    try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.
-            binary(queuePath).build()) {
-
-        try (final Stream<Path> queueFiles = Files.list(queuePath).
-                filter(p -> p.toString().endsWith(SingleChronicleQueue.SUFFIX))) {
-
-            queueFiles.filter(p -> isReadyForDelete(p)).map(Path::toFile).
-                    filter(f -> queue.numberOfReferences(f) == 0).
-                    forEach(File::delete);
-
-        }
-    }
-}
-----
+To facilitate this operation, Chronicle Queue Enterprise tracks references to its _roll-cycle_ files internally.
 
 == General Advice on Rolling
 At roll-time, a few unavoidable objects and memory mappings are created, and the old memory mappings are released. This activity can introduce slight jitter to your application. Chronicle aim's to keep this to a minimum, and control when it occurs. However, it is still recommended avoiding rolling at critical points in time to the extent possible.


### PR DESCRIPTION
Remove reference to unavailable methods spotted by a customer in the support ticket https://support.chronicle.software/staff/ticket/779

isReadyForDelete 
and 
SingleChronicleQueue.numberOfReferences