### PR TITLE
Fix FileUtil(Test), Fixes #1234

### DIFF
--- a/docs/managing_roll_files_directly.adoc
+++ b/docs/managing_roll_files_directly.adoc
@@ -90,7 +90,7 @@ It is possible to obtain removable roll file candidates directly from the comman
 
 [source, sh]
 ----
-mvn exec:java -Dexec.mainClass="net.openhft.chronicle.queue.util.FileUtil" -Dexec.classScope=compile -Dexec.args="my_queue_dir"
+mvn exec:java -Dexec.mainClass="net.openhft.chronicle.queue.internal.main.InternalRemovableRollFileCandidatesMain" -Dexec.classScope=compile -Dexec.args="my_queue_dir"
 ----
 
 This will produce a list of removable roll file candidates listed per line.

--- a/src/main/java/net/openhft/chronicle/queue/internal/util/InternalFileUtil.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/util/InternalFileUtil.java
@@ -18,16 +18,20 @@
 
 package net.openhft.chronicle.queue.internal.util;
 
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.util.FileState;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
-import java.util.Comparator;
-import java.util.List;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static java.util.Comparator.comparing;
@@ -43,7 +47,8 @@ public final class InternalFileUtil {
 
     private static final Comparator<File> EARLIEST_FIRST = comparing(File::getName);
 
-    private InternalFileUtil() {}
+    private InternalFileUtil() {
+    }
 
     /**
      * Returns a Stream of roll Queue files that are likely removable
@@ -74,11 +79,11 @@ public final class InternalFileUtil {
      *
      * @param baseDir containing queue file removal candidates
      * @return a Stream of roll Queue files that are likely removable
-     *         from the given {@code baseDir} without affecting any Queue
-     *         process that is currently active in the given {@code baseDir}
-     *         reading data sequentially
+     * from the given {@code baseDir} without affecting any Queue
+     * process that is currently active in the given {@code baseDir}
+     * reading data sequentially
      * @throws UnsupportedOperationException if this operation is not
-     *         supported for the current platform (e.g. Windows).
+     *                                       supported for the current platform (e.g. Windows).
      */
     @NotNull
     public static Stream<File> removableRollFileCandidates(@NotNull File baseDir) {
@@ -88,26 +93,30 @@ public final class InternalFileUtil {
             return Stream.empty();
 
         final List<File> sortedInitialCandidates = Stream.of(files)
-            .sorted(EARLIEST_FIRST)
-            .collect(toList());
+                .sorted(EARLIEST_FIRST)
+                .collect(toList());
 
         final Stream.Builder<File> builder = Stream.builder();
-        for (File file : sortedInitialCandidates) {
-            // If one file is not closed, discard it and the rest in the sequence
-            if (state(file) != FileState.CLOSED) break;
-            builder.accept(file);
+        try {
+            final Set<String> allOpenFiles = getAllOpenFiles();
+            for (File file : sortedInitialCandidates) {
+                // If one file is not closed, discard it and the rest in the sequence
+                if (state(file, allOpenFiles) != FileState.CLOSED) break;
+                builder.accept(file);
+            }
+            return builder.build();
+        } catch (IOException e) {
+            Jvm.warn().on(InternalFileUtil.class, "Error getting removable candidates", e);
+            return Stream.empty();
         }
-
-        return builder.build();
     }
 
     /**
      * Returns if the provided {@code file} has the Chronicle Queue file
      * suffix. The current file suffix is ".cq4".
      *
-     * @param     file to check
-     * @return    if the provided {@code file} has the ChronicleQueue file
-     *            suffix
+     * @param file to check
+     * @return true if the provided {@code file} has the ChronicleQueue file suffix
      */
     public static boolean hasQueueSuffix(@NotNull File file) {
         return file.getName().endsWith(SingleChronicleQueue.SUFFIX);
@@ -120,26 +129,15 @@ public final class InternalFileUtil {
      * If the open state of the given {@code file} can not be determined, {@code true }
      * is returned.
      *
-     * @param    file to check
-     * @return   if the given {@code file } is used by any process
-     * @throws   UnsupportedOperationException if this operation is not
-     *           supported for the current platform (e.g. Windows).
+     * @param file to check
+     * @return true if the given {@code file } is used by any process
+     * @throws UnsupportedOperationException if this operation is not
+     *                                       supported for the current platform (e.g. Windows).
      */
     public static FileState state(@NotNull File file) {
-        assertOsSupported();
-        if (!file.exists()) return FileState.NON_EXISTENT;
-        final String absolutePath = file.getAbsolutePath();
         try {
-            final Process process = new ProcessBuilder("lsof", "|", "grep", absolutePath).start();
-            try  (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                return reader.lines()
-                    .anyMatch(l -> l.contains(absolutePath))
-                    ? FileState.OPEN
-                    : FileState.CLOSED;
-            } finally {
-                process.destroyForcibly();
-            }
-        } catch(IOException ignored) {
+            return state(file, getAllOpenFiles());
+        } catch (IOException e) {
             // Do nothing
         }
         return FileState.UNDETERMINED;
@@ -148,9 +146,31 @@ public final class InternalFileUtil {
     /**
      * Returns if the given {@code file } is used by any process (i.e.
      * has the file open for reading or writing).
+     * <p>
+     * If the open state of the given {@code file} can not be determined, {@code true }
+     * is returned.
      *
-     * @param    file to check
-     * @return   if the given {@code file } is used by any process
+     * @param file         to check
+     * @param allOpenFiles The set of all open files retrieve from {@link #getAllOpenFiles()}
+     * @return true if the given {@code file } is used by any process
+     * @throws UnsupportedOperationException if this operation is not
+     *                                       supported for the current platform (e.g. Windows).
+     */
+    public static FileState state(@NotNull File file, Set<String> allOpenFiles) {
+        assertOsSupported();
+        if (!file.exists()) return FileState.NON_EXISTENT;
+        final String absolutePath = file.getAbsolutePath();
+        return allOpenFiles.contains(absolutePath)
+                ? FileState.OPEN
+                : FileState.CLOSED;
+    }
+
+    /**
+     * Returns if the given {@code file } is used by any process (i.e.
+     * has the file open for reading or writing).
+     *
+     * @param file to check
+     * @return true if the given {@code file } is used by any process
      */
     // Todo: Here is a candidate for Windows. Verify that it works
     private static FileState stateWindows(@NotNull File file) {
@@ -173,6 +193,57 @@ public final class InternalFileUtil {
     private static void assertOsSupported() {
         if (OS.isWindows()) {
             throw new UnsupportedOperationException("This operation is not supported under Windows.");
+        }
+    }
+
+    /**
+     * Get the distinct files currently open by any process
+     *
+     * @return a {@link Set} of the absolute paths to all the open files on the system
+     * @throws IOException if we can't get the open files
+     */
+    public static Set<String> getAllOpenFiles() throws IOException {
+        assertOsSupported();
+        final ProcFdWalker visitor = new ProcFdWalker();
+        Files.walkFileTree(Paths.get("/proc/"), Collections.emptySet(), 3, visitor);
+        return visitor.openFiles;
+    }
+
+    private static class ProcFdWalker extends SimpleFileVisitor<Path> {
+
+        private final Set<String> openFiles = new HashSet<>();
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (file.toAbsolutePath().toString().matches("/proc/\\d+/fd/\\d+")) {
+                try {
+                    final String e = file.toRealPath().toAbsolutePath().toString();
+                    openFiles.add(e);
+                } catch (NoSuchFileException e) {
+                    // Ignore, sometimes they disappear
+                } catch (IOException e) {
+                    Jvm.warn().on(ProcFdWalker.class, "Error resolving " + file, e);
+                }
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            // we definitely won't be able to access all the files, and it's common for a file to go missing mid-traversal
+            // so don't log when one of those things happens
+            if (!((exc instanceof AccessDeniedException) || (exc instanceof NoSuchFileException))) {
+                Jvm.warn().on(ProcFdWalker.class, "Error visiting file", exc);
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            if (!dir.toAbsolutePath().toString().matches("/proc(/\\d+(/fd)?)?")) {
+                return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
@@ -32,7 +32,10 @@ import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -50,17 +53,6 @@ import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 public class FileUtilTest extends QueueTestCommon {
-
-    @Test(timeout = 30_000)
-    public void assertLsofPresent() throws IOException {
-        assumeFalse(OS.isWindows());
-        final Process process = new ProcessBuilder("which", "lsof").start();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-            assertTrue("make sure \"lsof\" is installed on your target machine", reader.lines().anyMatch(l -> l.contains("lsof")));
-        } finally {
-            process.destroyForcibly();
-        }
-    }
 
     @Test(timeout = 30_000)
     public void stateNonExisting() {


### PR DESCRIPTION
Traverse `/proc/\d+/fd/\d+` to determine which files are currently open instead of `lsof`