### PR TITLE
Backport ExcerptTailer#approximateExcerptsInCycle

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
@@ -223,6 +223,35 @@ public interface ExcerptTailer extends ExcerptCommon<ExcerptTailer>, Marshallabl
     }
 
     /**
+     * Returns a number of excerpts in a cycle. May use a fast path to return the cycle length cached in indexing,
+     * which is updated last during append operation so may be possible that a single entry is available for reading
+     * but not acknowledged by this method yet.
+     * <p>
+     * Calling this method may move ExcerptTailer to the specified cycle and release its store.
+     *
+     * @return the approximate number of excerpts in a cycle.
+     */
+    default long approximateExcerptsInCycle(int cycle) {
+        try (ExcerptTailer tailer = queue().createTailer()) {
+            return tailer.approximateExcerptsInCycle(cycle);
+        }
+    }
+
+    /**
+     * Returns an exact number of excerpts in a cycle available for reading. This may be a computationally
+     * expensive operation.
+     * <p>
+     * Calling this method may move ExcerptTailer to the specified cycle and release its store.
+     *
+     * @return the exact number of excerpts in a cycle.
+     */
+    default long exactExcerptsInCycle(int cycle) {
+        try (ExcerptTailer tailer = queue().createTailer()) {
+            return tailer.exactExcerptsInCycle(cycle);
+        }
+    }
+
+    /**
      * Returns the {@link TailerState} of this Tailer.
      *
      * @return the {@link TailerState} of this Tailer

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -601,7 +601,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * Returns a number of excerpts in a cycle. May use a fast path to return the cycle length cached in indexing,
      * which is updated last during append operation so may be possible that a single entry is available for reading
      * but not acknowledged by this method yet.
+     *
+     * @deprecated
+     * @see ExcerptTailer#approximateExcerptsInCycle(int)
      */
+    @Deprecated(/* To be removed in x.25 */)
     public long approximateExcerptsInCycle(int cycle) {
         throwExceptionIfClosed();
         // TODO: this function may require some re-work now that acquireTailer has been deprecated
@@ -618,7 +622,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     /**
      * Returns an exact number of excerpts in a cycle available for reading. This may be a computationally
      * expensive operation.
+     *
+     * @deprecated
+     * @see ExcerptTailer#exactExcerptsInCycle(int)
      */
+    @Deprecated(/* To be removed in x.25 */)
     public long exactExcerptsInCycle(int cycle) {
         throwExceptionIfClosed();
         // TODO: this function may require some re-work now that acquireTailer has been deprecated


### PR DESCRIPTION
to remove use of SingleChronicleQueue#acquireTailer()

This commit includes changes cherry-picked from https://github.com/OpenHFT/Chronicle-Queue/commit/bfcf600f317898e7bcdbab312604a302ff8411d7 

and also the use of `StoreTailer#exactExcerptsInCycle` in `StoreTailer#tryWindBack`