### PR TITLE
Backport stabilisation of UngracefulShutdownTests fix

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -564,7 +564,7 @@ class SCQIndexing extends AbstractCloseable implements Demarshallable, WriteMars
     }
 
     static int getUsedAsInt(LongArrayValues index2indexArr) {
-        if (((Byteable) index2indexArr).bytesStore() != null)
+        if (((Byteable) index2indexArr).bytesStore() == null)
             return 0;
 
         final long used = index2indexArr.getUsed();

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -981,23 +981,28 @@ class StoreTailer extends AbstractCloseable
                 break;
 
             case FOUND:
-                if (direction == FORWARD) {
+                LoopForward: while (true) {
                     final ScanResult result = moveToIndexResult(++index);
                     switch (result) {
                         case NOT_REACHED:
                             throw new NotReachedException("NOT_REACHED after FOUND");
                         case FOUND:
                             // the end moved!!
+                            continue;
                         case NOT_FOUND:
                             state = FOUND_IN_CYCLE;
-                            break;
+                            break LoopForward;
                         case END_OF_FILE:
                             state = END_OF_CYCLE;
-                            break;
+                            break LoopForward;
                         default:
                             throw new IllegalStateException("Unknown ScanResult: " + result);
                     }
                 }
+
+                if (direction == BACKWARD)
+                    moveToIndexResult(--index);
+
                 break;
             case NOT_REACHED:
                 throw new NotReachedException("NOT_REACHED index: " + Long.toHexString(index));


### PR DESCRIPTION
closes #1273

There was a single conflict due to a call to `resetPosition` in the constructor introduced in d3f46ce5ae8410af3fc3b1900659d3b6f5520475 which isn't on this branch. But otherwise a seamless cherry-pick.