### PR TITLE
Present portal search results as overlay

### DIFF
--- a/docs/antora/supplemental_portal/css/search.css
+++ b/docs/antora/supplemental_portal/css/search.css
@@ -13,6 +13,26 @@
   }
 }
 
+.panels {
+  overflow: visible;
+}
+
+.nav-panel-menu {
+  overflow: visible;
+}
+
+.nav-panel-explore {
+  position: unset;
+}
+
+.search-result-dataset {
+  max-height: inherit;
+}
+
+.search-result-dropdown-menu {
+  max-height: 400px;
+}
+
 #search-input {
   font-size: 16px;
   border: 1px solid lightgray;
@@ -165,7 +185,7 @@
 }
 
 .navbar-item {
-  padding: 2.5rem 0 0 0;
+  padding: 2rem 1.4em 0 1.4em;
   background: #181f4c;
   position: sticky;
   top: 0;
@@ -178,6 +198,7 @@ body {
 
 body .nav-menu {
   padding: 0 1.25rem;
+  overflow-y: scroll;
 }
 
 @media screen and (max-width: 1023px) {

--- a/docs/antora/supplemental_portal/partials/nav-menu.hbs
+++ b/docs/antora/supplemental_portal/partials/nav-menu.hbs
@@ -1,10 +1,10 @@
 {{#with page.navigation}}
     <div class="nav-panel-menu is-active" data-panel="menu">
+        <div class="navbar-item">
+            <input id="search-input" type="text" placeholder="Search docs">
+            <div id="search-icon"></div>
+        </div>
         <nav class="nav-menu">
-            <div class="navbar-item">
-                <input id="search-input" type="text" placeholder="Search docs">
-                <div id="search-icon"></div>
-            </div>
             {{#with @root.page.componentVersion}}
             {{/with}}
             {{> nav-tree navigation=this}}


### PR DESCRIPTION
Previously, search results were displayed like this:
<img width="421" alt="image" src="https://user-images.githubusercontent.com/26650460/214575577-3b330a85-e1e5-4867-aa4e-024119c0aa2c.png">

Now the results are shown as an overlay:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/26650460/214575445-8f47abba-b17c-47c5-9324-20dca402f4d1.png">
