### PR TITLE
De-flake EmptyRollCycleTest

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
@@ -34,6 +34,7 @@ public class EmptyRollCycleTest extends QueueTestCommon {
 
     @Test
     public void tailerShouldTolerateEmptyRollCycleAtEnd() throws IOException {
+        ignoreException("Channel closed while unlocking");
         expectException("Recovering header");
         createQueueWithEmptyRollCycleAtEnd();
 
@@ -58,6 +59,7 @@ public class EmptyRollCycleTest extends QueueTestCommon {
 
     @Test
     public void appenderShouldTolerateEmptyRollCycleAtEnd() throws IOException {
+        ignoreException("Channel closed while unlocking");
         expectException("Recovering header");
         createQueueWithEmptyRollCycleAtEnd();
 


### PR DESCRIPTION
Saw this one, it's a race with the background resource releaser, so will happen occasionally.