### PR TITLE
Tweak C++ and Java interop tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M7</version>
                 <configuration>
+                    <argLine>-Dchronicle.test.env=from-cpp</argLine>
                     <forkCount>1</forkCount>
                     <!--                    <reuseForks>false</reuseForks>-->
                     <runOrder>hourly</runOrder>

--- a/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
@@ -36,7 +36,7 @@ public class RawAccessJavaTest extends QueueTestCommon {
 
     boolean assert_from_cpp() {
         String env = System.getProperty("chronicle.test.env");
-        return env != null && env.equals("from-cpp");
+        return (env != null && env.equals("from-cpp"));
     }
 
     @Test
@@ -62,8 +62,8 @@ public class RawAccessJavaTest extends QueueTestCommon {
                     // document length, inc 4-byte length
                     int length = Wires.lengthOf(header);
 
-                    // actual length of data
-                    int data_length = bytes.readInt();
+//                    // actual length of data
+//                    int data_length = bytes.readInt();
 
                     assertEquals(bytes.readByte(), (byte) 0xab);
                     assertEquals(bytes.readShort(), (short) 12);
@@ -98,9 +98,9 @@ public class RawAccessJavaTest extends QueueTestCommon {
 
                     Bytes<?> bytes = dc.wire().bytes();
 
-                    // will contain the size of the blob
-                    long start = bytes.writePosition();
-                    bytes.writeSkip(RAW_SIZE_PREFIX);
+//                    // will contain the size of the blob
+//                    long start = bytes.writePosition();
+//                    bytes.writeSkip(RAW_SIZE_PREFIX);
 
                     {
                         bytes.writeByte((byte) 0xab);
@@ -113,8 +113,9 @@ public class RawAccessJavaTest extends QueueTestCommon {
                         bytes.write8bit("Hello World");
                     }
 
-                    long end = bytes.writePosition();
-                    bytes.writeInt(start, (int) (end - start - RAW_SIZE_PREFIX));
+//                    
+//                    long end = bytes.writePosition();
+//                    bytes.writeInt(start, (int) (end - start - RAW_SIZE_PREFIX));
                 }
             }
         }


### PR DESCRIPTION
Remove explicit length for scoped bytes.
Add required argLine to surefire (previously passed as an option to mvn test, but no longer supported it seems)