### PR TITLE
Make SingleChronicleQueueStore handle the case where we're closing a partially initialised instance

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
@@ -278,11 +278,14 @@ public class SingleChronicleQueueStore extends AbstractCloseable implements Wire
         Closeable.closeQuietly(writePosition);
         Closeable.closeQuietly(indexing);
 
-        mappedBytes.release(INIT);
-        try {
-            mappedFile.release(this);
-        } catch (IllegalStateException e) {
-            Jvm.warn().on(getClass(), "trouble releasing " + mappedFile, e);
+        // this can be null if we're partially initialised
+        if (mappedBytes != null) {
+            mappedBytes.release(INIT);
+            try {
+                mappedFile.release(this);
+            } catch (IllegalStateException e) {
+                Jvm.warn().on(getClass(), "trouble releasing " + mappedFile, e);
+            }
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
@@ -38,11 +38,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Locale;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.DAILY;


### PR DESCRIPTION
If the constructor throws, close gets called in the constructor. That can mean the `mappedBytes` field can be null.

Revealed due to fix for https://github.com/OpenHFT/Chronicle-Core/issues/499