### PR TITLE
Experiment: Prevent writes before last cycle in queue

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -755,11 +755,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
     @Override
     public final int cycle() {
-        return cycleCalculator.currentCycle(rollCycle, time, epoch);
+        return Math.max(cycleCalculator.currentCycle(rollCycle, time, epoch), directoryListing.getMaxCreatedCycle());
     }
 
     public final int cycle(TimeProvider timeProvider) {
-        return cycleCalculator.currentCycle(rollCycle, timeProvider, epoch);
+        return Math.max(cycleCalculator.currentCycle(rollCycle, timeProvider, epoch), directoryListing.getMaxCreatedCycle());
     }
 
     @Override


### PR DESCRIPTION
#1323 was reported. It's possible to write to arbitrary cycles in the past if you set the system clock to point to those cycles. This is an experiment that forces writes to the end of the queue when there are any roll cycles present.