### PR TITLE
added a subscription index controller for chronicle channels

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/RollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/RollCycles.java
@@ -155,7 +155,6 @@ public enum RollCycles implements RollCycle {
      *
      * @deprecated Use {@link net.openhft.chronicle.queue.rollcycles.TestRollCycles#TEST_SECONDLY} instead
      */
-    @Deprecated(/* For removal in x.26 */)
     TEST_SECONDLY(/*---*/"yyyyMMdd-HHmmss'T'", 1000, MAX_INDEX_COUNT, 4),
     /**
      * 0x1000 entries - Only good for testing

--- a/src/main/java/net/openhft/chronicle/queue/RollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/RollCycles.java
@@ -155,6 +155,7 @@ public enum RollCycles implements RollCycle {
      *
      * @deprecated Use {@link net.openhft.chronicle.queue.rollcycles.TestRollCycles#TEST_SECONDLY} instead
      */
+    @Deprecated(/* For removal in x.26 */)
     TEST_SECONDLY(/*---*/"yyyyMMdd-HHmmss'T'", 1000, MAX_INDEX_COUNT, 4),
     /**
      * 0x1000 entries - Only good for testing

--- a/src/main/java/net/openhft/chronicle/queue/channel/SubscribeHandler.java
+++ b/src/main/java/net/openhft/chronicle/queue/channel/SubscribeHandler.java
@@ -23,14 +23,14 @@ import static net.openhft.chronicle.queue.channel.PipeHandler.newQueue;
 
 public class SubscribeHandler extends AbstractHandler<SubscribeHandler> {
 
-    public static class NoOp extends SelfDescribingMarshallable implements Consumer {
+    private static class NoOp extends SelfDescribingMarshallable implements Consumer {
         @Override
         public void accept(Object o) {
             return;
         }
     }
 
-    public static Consumer NO_OP = new NoOp();
+    public final static Consumer NO_OP = new NoOp();
 
     private String subscribe;
     private transient boolean closeWhenRunEnds = true;

--- a/src/main/java/net/openhft/chronicle/queue/channel/SubscribeHandler.java
+++ b/src/main/java/net/openhft/chronicle/queue/channel/SubscribeHandler.java
@@ -10,14 +10,28 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.channel.impl.SubscribeQueueChannel;
 import net.openhft.chronicle.threads.Pauser;
 import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.channel.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import static net.openhft.chronicle.queue.channel.PipeHandler.newQueue;
 
 public class SubscribeHandler extends AbstractHandler<SubscribeHandler> {
+
+    public static class NoOp extends SelfDescribingMarshallable implements Consumer {
+        @Override
+        public void accept(Object o) {
+            return;
+        }
+    }
+
+    public static Consumer NO_OP = new NoOp();
+
     private String subscribe;
     private transient boolean closeWhenRunEnds = true;
 
@@ -26,10 +40,20 @@ public class SubscribeHandler extends AbstractHandler<SubscribeHandler> {
     private Predicate<Wire> filter;
     private int sourceId;
 
-    static void queueTailer(Pauser pauser, ChronicleChannel channel, ChronicleQueue subscribeQueue, Predicate<Wire> filter) {
+    private Consumer<ExcerptTailer> subscriptionIndexController = NO_OP;
+
+
+    static void queueTailer(@NotNull Pauser pauser,
+                            @NotNull ChronicleChannel channel,
+                            @NotNull ChronicleQueue subscribeQueue,
+                            @Nullable Predicate<Wire> filter,
+                            @NotNull Consumer<ExcerptTailer> subscriptionIndexController) {
         try (ChronicleQueue subscribeQ = subscribeQueue; // leave here so it gets closed
              ExcerptTailer tailer = subscribeQ.createTailer()) {
+
             tailer.singleThreadedCheckDisabled(true);  // assume we are thread safe
+            subscriptionIndexController.accept(tailer);
+
             while (!channel.isClosing()) {
                 if (copyOneMessage(channel, tailer, filter))
                     pauser.reset();
@@ -116,7 +140,7 @@ public class SubscribeHandler extends AbstractHandler<SubscribeHandler> {
                 closeWhenRunEnds = false;
             } else {
                 try (AffinityLock lock = context.affinityLock()) {
-                    queueTailer(pauser, channel, newQueue(context, subscribe, syncMode, sourceId), filter);
+                    queueTailer(pauser, channel, newQueue(context, subscribe, syncMode, sourceId), filter, subscriptionIndexController);
                 }
                 closeWhenRunEnds = true;
             }
@@ -163,6 +187,16 @@ public class SubscribeHandler extends AbstractHandler<SubscribeHandler> {
      */
     public SubscribeHandler subscribeSourceId(int sourceId) {
         this.sourceId = sourceId;
+        return this;
+    }
+
+
+    /**
+     * @param subscriptionIndexController controls where the subscriptions will start to read from, by allowing the caller to
+     *                                    {@link net.openhft.chronicle.queue.ExcerptTailer#moveToIndex(long) to control the first read location
+     */
+    public SubscribeHandler subscriptionIndexController(Consumer<ExcerptTailer> subscriptionIndexController) {
+        this.subscriptionIndexController = subscriptionIndexController;
         return this;
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
@@ -1,0 +1,109 @@
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.util.Time;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.threads.Threads;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MoveToCycleMultiThreadedStressTest extends ChronicleQueueTestBase {
+
+    private ThreadLocal<ExcerptTailer> tailer;
+    private final AtomicLong last = new AtomicLong();
+    private long firstCycle;
+
+    private static final int READ_THREADS = 10;
+    private ChronicleQueue queue;
+
+    private AtomicBoolean shutDown = new AtomicBoolean();
+
+    @Test(timeout = 60000)
+    public void test() throws ExecutionException, InterruptedException {
+
+
+        final String path = OS.getTarget() + "/stressMoveToCycle-" + Time.uniqueId();
+        final ExecutorService es = Executors.newCachedThreadPool();
+
+        try (ChronicleQueue q = SingleChronicleQueueBuilder.binary(path)
+                .testBlockSize()
+                .rollCycle(RollCycles.TEST_SECONDLY)
+                .build()) {
+            this.queue = q;
+            tailer = ThreadLocal.withInitial(q::createTailer);
+            ExcerptAppender excerptAppender = q.acquireAppender();
+            excerptAppender.writeText("first");
+            updateLast(excerptAppender);
+
+            firstCycle = excerptAppender.queue().rollCycle().toCycle(q.firstIndex());
+
+            final Future<Void> appender = es.submit(this::append);
+            final List<Future<Void>> f = new ArrayList<>();
+
+            for (int i = 0; i < READ_THREADS; i++) {
+                f.add(es.submit(this::randomMove));
+            }
+
+
+            appender.get();
+            shutDown.set(true);
+            Thread.sleep(100);
+
+            f.forEach(c -> {
+                try {
+                    c.get(1, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    Assert.fail();
+                }
+            });
+
+        }
+
+
+        Threads.shutdown(es);
+
+    }
+
+    private Void append() {
+
+        final ExcerptAppender excerptAppender = queue.acquireAppender();
+
+        for (int i = 0; i < 50; i++) {
+            excerptAppender.writeText("hello");
+            updateLast(excerptAppender);
+            Jvm.pause(100);
+        }
+        return null;
+
+    }
+
+    private void updateLast(ExcerptAppender excerptAppender) {
+        long lastIndex = excerptAppender.lastIndexAppended();
+        long lastCycle = excerptAppender.queue().rollCycle().toCycle(lastIndex);
+        long expect;
+        do {
+            expect = this.last.get();
+        } while (!this.last.compareAndSet(expect, lastCycle));
+    }
+
+    private Void randomMove() {
+        final ExcerptTailer tailer = this.tailer.get();
+        while (!shutDown.get()) {
+
+            long span = last.get() - firstCycle;
+            int cycle = (int) ((Math.random() * span) + firstCycle);
+            tailer.moveToCycle(cycle);
+        }
+        tailer.close();
+        return null;
+    }
+
+}

--- a/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
@@ -34,7 +34,7 @@ public class MoveToCycleMultiThreadedStressTest extends ChronicleQueueTestBase {
 
         try (ChronicleQueue q = SingleChronicleQueueBuilder.binary(path)
                 .testBlockSize()
-                .rollCycle(RollCycles.TEST_SECONDLY)
+                .rollCycle(net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY)
                 .build()) {
             this.queue = q;
             tailer = ThreadLocal.withInitial(q::createTailer);

--- a/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
@@ -205,8 +205,9 @@ public class PipeHandlerTest extends QueueTestCommon {
 
 
     /**
-     * tests setting the index upon subscription, by in this case setting the subscriptionIndexController to the
-     * last message in the queue, effectively bootstrapping that last message for consumers.
+     * tests setting the index upon subscription, move to the
+     * last message in the queue, effectively bootstrapping that last message  ( and only the last message ) for
+     * consumers.
      */
     @Test(timeout = 20000)
     public void fromIndex() {

--- a/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
@@ -145,18 +145,13 @@ public class PipeHandlerTest extends QueueTestCommon {
 
         @Override
         public void accept(ExcerptTailer excerptTailer) {
-            excerptTailer.toEnd();
-            excerptTailer.direction(BACKWARD);
-
-            try (DocumentContext ignore = excerptTailer.readingDocument()) {
+            try (DocumentContext ignore = excerptTailer.toEnd().direction(BACKWARD).readingDocument()) {
                 // read one
             }
 
-            excerptTailer.direction(FORWARD);
-            try (DocumentContext ignore = excerptTailer.readingDocument()) {
+            try (DocumentContext ignore =   excerptTailer.direction(FORWARD).direction(FORWARD).readingDocument()) {
                 // read one
             }
-
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
@@ -205,15 +205,18 @@ public class PipeHandlerTest extends QueueTestCommon {
 
 
     /**
-     * tests setting the index upon subscription, move to the
-     * last message in the queue, effectively bootstrapping that last message  ( and only the last message ) for
-     * consumers.
+     * This test verifies the functionality of setting the index upon subscription, which moves to
+     * the last message in the queue. It effectively bootstraps only the last message for consumers.
      */
     @Test(timeout = 20000)
     public void fromIndex() {
         String url = "tcp://:0";
         IOTools.deleteDirWithFiles("target/fromIndex");
 
+        /**
+         * Creates a new {@link ChronicleContext} with the specified URL and names the context "target/fromIndex".
+         * The context is buffered if the 'buffered' flag is set.
+         */
         try (ChronicleContext context = ChronicleContext.newContext(url).name("target/fromIndex").buffered(buffered);
              ChronicleQueue cq =
                      ChronicleQueue.singleBuilder(context.toFile("test-q")).blockSize(OS.isSparseFileSupported() ?
@@ -224,6 +227,10 @@ public class PipeHandlerTest extends QueueTestCommon {
             says.say("2 Hi two");
             says.say("3 Hi three");
 
+            /**
+             * Creates a new {@link ChronicleChannel} using the provided channel supplier, which is
+             * configured with a {@link ToLastMessage} subscription index controller.
+             */
             try (ChronicleChannel channel1 =
                          context.newChannelSupplier(createPipeHandler().subscriptionIndexController(new ToLastMessage())).get()) {
                 BlockingQueue<String> q = new LinkedBlockingQueue<>();
@@ -233,7 +240,6 @@ public class PipeHandlerTest extends QueueTestCommon {
             }
         }
     }
-
 
     private static PipeHandler createPipeHandler() {
         return new PipeHandler().subscribe("test-q").publish("test-q").publishSourceId(1).subscribeSourceId(1);

--- a/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
@@ -209,7 +209,7 @@ public class PipeHandlerTest extends QueueTestCommon {
      * the last message in the queue. It effectively bootstraps only the last message for consumers.
      */
     @Test(timeout = 20000)
-    public void fromIndex() {
+    public void testsSubscriptionIndexController() {
         String url = "tcp://:0";
         IOTools.deleteDirWithFiles("target/fromIndex");
 

--- a/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/channel/PipeHandlerTest.java
@@ -3,8 +3,11 @@ package net.openhft.chronicle.queue.channel;
 import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Mocker;
+import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.time.SystemTimeProvider;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
@@ -17,16 +20,17 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.io.PrintStream;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static net.openhft.chronicle.queue.TailerDirection.BACKWARD;
+import static net.openhft.chronicle.queue.TailerDirection.FORWARD;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 
@@ -137,6 +141,25 @@ public class PipeHandlerTest extends QueueTestCommon {
         assertEquals(now, channel.lastTestMessage());
     }
 
+    public static class ToLastMessage extends SelfDescribingMarshallable implements Consumer<ExcerptTailer> {
+
+        @Override
+        public void accept(ExcerptTailer excerptTailer) {
+            excerptTailer.toEnd();
+            excerptTailer.direction(BACKWARD);
+
+            try (DocumentContext ignore = excerptTailer.readingDocument()) {
+                // read one
+            }
+
+            excerptTailer.direction(FORWARD);
+            try (DocumentContext ignore = excerptTailer.readingDocument()) {
+                // read one
+            }
+
+        }
+    }
+
     @Test(timeout = 20000)
     public void filtered() {
         String url = "tcp://:0";
@@ -179,6 +202,37 @@ public class PipeHandlerTest extends QueueTestCommon {
                     new TreeSet<>(q).stream().collect(Collectors.joining("\n")));
         }
     }
+
+
+    /**
+     * tests setting the index upon subscription, by in this case setting the subscriptionIndexController to the
+     * last message in the queue, effectively bootstrapping that last message for consumers.
+     */
+    @Test(timeout = 20000)
+    public void fromIndex() {
+        String url = "tcp://:0";
+        IOTools.deleteDirWithFiles("target/fromIndex");
+
+        try (ChronicleContext context = ChronicleContext.newContext(url).name("target/fromIndex").buffered(buffered);
+             ChronicleQueue cq =
+                     ChronicleQueue.singleBuilder(context.toFile("test-q")).blockSize(OS.isSparseFileSupported() ?
+                             512L << 30 : 64L << 20).sourceId(1).build();) {
+
+            Says says = cq.methodWriter(Says.class);
+            says.say("1 Hi one");
+            says.say("2 Hi two");
+            says.say("3 Hi three");
+
+            try (ChronicleChannel channel1 =
+                         context.newChannelSupplier(createPipeHandler().subscriptionIndexController(new ToLastMessage())).get()) {
+                BlockingQueue<String> q = new LinkedBlockingQueue<>();
+                MethodReader reader1 = channel1.methodReader(Mocker.queuing(Says.class, "", q));
+                readN(reader1, 1);
+                assertEquals("[say[3 Hi three]]", q.toString());
+            }
+        }
+    }
+
 
     private static PipeHandler createPipeHandler() {
         return new PipeHandler().subscribe("test-q").publish("test-q").publishSourceId(1).subscribeSourceId(1);


### PR DESCRIPTION
This pull request introduces a subscription index controller to facilitate the control of the tailer's index for new subscriptions in Chronicle channels during the bootstrap process.

Additionally, a new test has been added to validate the functionality. This test focuses on setting the index during subscription, effectively moving to the last message in the queue. This feature is handy for consumers as it enables the seamless bootstrapping of only the last message in the queue.