### PR TITLE
Deprecate acquire appender

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -194,9 +194,29 @@ public interface ChronicleQueue extends Closeable {
      * this method every time an appender is needed.
      *
      * @return Returns a ExcerptAppender for this ChronicleQueue that is local to the current Thread
+     * @deprecated It is recommended to use {@link #createAppender()} instead
      */
+    @Deprecated(/* To be removed in x.TBD */)
     @NotNull
     ExcerptAppender acquireAppender();
+
+    /**
+     * Creates and returns a new ExcerptAppender for this ChronicleQueue
+     * <p>
+     * An Appender can be used to store new excerpts sequentially to the queue.
+     * <p>
+     * <b>
+     * An Appender is <em>NOT thread-safe</em>, concurrent use of an Appender by multiple threads is unsafe
+     * and will inevitably lead to errors and unspecified behaviour.
+     * </b>
+     * <p>
+     * This method creates a new Appender on each call, it is up to the caller to manage the lifecycle of the
+     * returned Appender
+     *
+     * @return Returns a new ExcerptAppender for this ChronicleQueue
+     */
+    @NotNull
+    ExcerptAppender createAppender();
 
     /**
      * Returns the lowest valid index available for this ChronicleQueue, or {@link Long#MAX_VALUE}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -505,6 +505,17 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
         return res;
     }
 
+    @NotNull
+    @Override
+    public ExcerptAppender createAppender() {
+        throwExceptionIfClosed();
+
+        if (readOnly)
+            throw new IllegalStateException("Can't append to a read-only chronicle");
+
+        return createNewAppenderOnceConditionIsMet();
+    }
+
     /**
      * @return the {@link QueueLock} This lock is held while the queue replication cluster is back-filling.
      * By Back-filling we mean that, as part of the fail-over process a sink, may actually have more data than a source,

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -151,6 +151,27 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 appenderListenerDump.toString());
     }
 
+    @Test
+    public void createAppenderWillReturnANewAppenderEachTime() {
+        try (final ChronicleQueue queue = builder(getTmpDir(), wireType).build();
+             final ExcerptAppender appender1 = queue.createAppender();
+             final ExcerptAppender appender2 = queue.createAppender()) {
+            assertNotSame(appender1, appender2);
+        }
+    }
+
+    @Test
+    public void createAppenderWillThrowWhenQueueIsReadOnly() {
+        final File queueDir = getTmpDir();
+        try (final ChronicleQueue queue = builder(queueDir, wireType).build();
+             final ExcerptAppender appender = queue.createAppender()) {
+            appender.writeText("hello world");
+            try (final ChronicleQueue readOnlyQueue = builder(queueDir, wireType).readOnly(true).build()) {
+                assertThrows(IllegalStateException.class, readOnlyQueue::createAppender);
+            }
+        }
+    }
+
     @NotNull
     protected String expectedForTestAppend() {
         return "" +


### PR DESCRIPTION
Also made a start on removing its use from tests, but that's a bigger job. Just wanted to get some coverage of it being used. I would remove all the low-hanging-fruit uses of `acquireAppender` from tests before merging if this gets approved.

Also will follow with a PR to update demos once it's been released.

I also changed it so that Appenders that are `acquire`'d will throw `UnsupportedOperationException` when `singleThreadCheck(Disabled|Reset)` is called. This needs [a corresponding change](https://github.com/OpenHFT/Chronicle-Core/pull/532) in core to ignore that exception when we do `net.openhft.chronicle.core.io.AbstractCloseable#waitForCloseablesToClose`.