### PR TITLE
Remove unused code - throwExceptionIfClosed

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -270,15 +270,11 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
      */
     @Override
     public long lastAcknowledgedIndexReplicated() {
-        // throwExceptionIfClosed();
-
         return lastAcknowledgedIndexReplicated == null ? -1 : lastAcknowledgedIndexReplicated.getVolatileValue(-1);
     }
 
     @Override
     public void lastAcknowledgedIndexReplicated(long newValue) {
-        // throwExceptionIfClosed();
-
         if (lastAcknowledgedIndexReplicated != null)
             lastAcknowledgedIndexReplicated.setMaxValue(newValue);
     }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -146,8 +146,6 @@ class StoreTailer extends AbstractCloseable
     @Override
     @NotNull
     public DocumentContext readingDocument() {
-//        throwExceptionIfClosed();
-
         // trying to create an initial document without a direction should not consume a message
         final long index = index();
         if (direction == NONE && (index == indexAtCreation || index == 0) && !readingDocumentFound) {


### PR DESCRIPTION
Removes commented out calls to `throwExceptionIfClosed` in `SingleChronicleQueue` and `StoreTailer`.