### PR TITLE
ReadOnly test fails on Windows

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -160,8 +160,13 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
+    /**
+     * readOnly=true is not supported on Windows so this test does not run on Windows targets, please see
+     * {@link SingleChronicleQueueBuilder#readOnly(boolean)}.
+     */
     @Test
     public void createAppenderWillThrowWhenQueueIsReadOnly() {
+        assumeFalse(OS.isWindows());
         final File queueDir = getTmpDir();
         try (final ChronicleQueue queue = builder(queueDir, wireType).build();
              final ExcerptAppender appender = queue.createAppender()) {


### PR DESCRIPTION
See the following issue for details: https://github.com/OpenHFT/Chronicle-Queue/issues/1388