### PR TITLE
Don't log a warning when we find a /proc/{pid}/fd/.. file we can't resolve

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/internal/util/InternalFileUtil.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/util/InternalFileUtil.java
@@ -227,8 +227,8 @@ public final class InternalFileUtil {
                 try {
                     final String e = file.toRealPath().toAbsolutePath().toString();
                     openFiles.add(e);
-                } catch (NoSuchFileException e) {
-                    // Ignore, sometimes they disappear
+                } catch (NoSuchFileException | AccessDeniedException e) {
+                    // Ignore, sometimes they disappear & we can't access all the files
                 } catch (IOException e) {
                     Jvm.warn().on(ProcFdWalker.class, "Error resolving " + file, e);
                 }


### PR DESCRIPTION
This caused a flappy test

See (rare) example of a flap [here](https://teamcity.chronicle.software/buildConfiguration/Chronicle_BuildAll_OpenHFTJava11Bumped/829249?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true)