### PR TITLE
Refactor StoreTailer.readingDocument

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -468,14 +468,14 @@ class StoreTailer extends AbstractCloseable
         bytes.readLimitToCapacity();
 
         switch (wire.readDataHeader(includeMetaData)) {
-            case DATA:
-                context.metaData(false);
-                break;
             case NONE:
                 // no more polling - appender will always write (or recover) EOF
                 return false;
             case META_DATA:
                 context.metaData(true);
+                break;
+            case DATA:
+                context.metaData(false);
                 break;
             case EOF:
                 throw EOF_EXCEPTION;


### PR DESCRIPTION
Refactoring made during benchmarking session focusing on tailer throughput. The following differences were observed between this branch and develop during benchmarking:

Case | L1 loads | L1 load misses | Total branch misses
-- | -- | -- | --
develop | 141000 | 17000 | 25.7%
feature branch | 141000 | 15000 | 22.64%

This feature branch does the following:

* Adds some javadoc
* Cleans up some methods and encapsulates some logic
* Moves some code off the hot path

https://github.com/OpenHFT/Chronicle-Queue/issues/1415
