### PR TITLE
Multiple empty cycle files with no EOF markers and pretoucher may cause tailer stall 

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -779,6 +779,9 @@ class StoreAppender extends AbstractCloseable
                 for (int eofCyle = cycle - 1; eofCyle >= queue.firstCycle(); eofCyle--) {
 
                     try (SingleChronicleQueueStore st = queue.storeForCycle(eofCyle, queue.epoch(), false, null)) {
+
+                        if (st == null)
+                            continue;
                         wire = queue.wireType().apply(st.bytes());
                         wire.usePadding(st.dataVersion() > 0);
                         if (!st.writeEOF(wire, timeoutMS())) {


### PR DESCRIPTION
relates to https://github.com/ChronicleEnterprise/Chronicle-Queue-Enterprise/pull/563

Introduction

When a queue contains multiple empty cycle files that (erroneously) contain no EOF markers then any tailer beginning to read from the beginning of the queue will stall in the first empty cycle without the EOF marker.

Two key things have to align in order to reproduce this issue:

The pretoucher must be in use - this is what will ensure that empty cycle files are created
There must be at least 2 cycles that do not contain any data
Impacted branches

develop, ea, release.*
Steps to reproduce

Sample code to reproduce this can be found here: https://github.com/OpenHFT/Chronicle-Queue/pull/1437/files#diff-86a449a50c5152bc5ef5198d1659d8720c2f5ffd667991ced965b173345edb00

Create a queue using a roll cycle that will create many cycles for testing purposes (e.g. TEST_SECONDLY)
Instantiate a pretoucher that will pretouch this queue in the background and will also precreate cycle files that do not already exist
Create an appender that will append to this queue
Append some initial data
Wait for some period of time until multiple rolls have occurred
Ensure that for at least 2 rolls you do not append any data to the queue
Append another entry in the queue - you will never be able to reach this entry with the tailer
Next, create a tailer and tail through the queue from the beginning. The tailer should get stuck on one of the cycle files.
Background

A large amount of work has gone into the normaliseEOFs feature to ensure that all cycles contain a valid EOF marker
In this particular scenario we hit a specific code path where the EOF marker is not stamped in successive cycle files
Workarounds

It is possible to move the tailer on by calling moveToIndex to move it past the cycle on which it is stuck.