### PR TITLE
Use ScopedThreadLocals for acquiring StringBuffers and Bytes.

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -28,6 +28,7 @@ import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.pool.StringBuilderPool;
+import net.openhft.chronicle.core.scoped.ScopedResourcePool;
 import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.queue.impl.ExcerptContext;
@@ -54,7 +55,7 @@ import static net.openhft.chronicle.wire.Wires.isEndOfFile;
 class StoreTailer extends AbstractCloseable
         implements ExcerptTailer, SourceContext, ExcerptContext {
     static final int INDEXING_LINEAR_SCAN_THRESHOLD = 70;
-    static final StringBuilderPool SBP = new StringBuilderPool();
+    static final ScopedResourcePool<StringBuilder> SBP = StringBuilderPool.createThreadLocal(1);
     static final EOFException EOF_EXCEPTION = new EOFException();
     @NotNull
     private final SingleChronicleQueue queue;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -1516,7 +1516,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
             final ExcerptTailer tailer = queue.createTailer(named ? "named" : null);
 
-            final StringBuilder sb = Wires.acquireStringBuilder();
+            final StringBuilder sb = new StringBuilder();
 
             try (final DocumentContext dc = tailer.readingDocument()) {
                 assert dc.isPresent();
@@ -1584,7 +1584,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             final ExcerptTailer tailer = queue.createTailer(named ? "named" : null);
             assertTrue(tailer.moveToIndex(queue.rollCycle().toIndex(cycle, 2)));
 
-            final StringBuilder sb = Wires.acquireStringBuilder();
+            final StringBuilder sb = new StringBuilder();
 
             try (final DocumentContext dc = tailer.readingDocument()) {
                 assert dc.isPresent();
@@ -1664,7 +1664,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             final ExcerptTailer tailer = queue.createTailer(named ? "named" : null);
             assertTrue(tailer.moveToIndex(queue.rollCycle().toIndex(cycle, 2)));
 
-            final StringBuilder sb = Wires.acquireStringBuilder();
+            final StringBuilder sb = new StringBuilder();
 
             try (final DocumentContext dc = tailer.readingDocument()) {
                 assert dc.isPresent();
@@ -2161,11 +2161,12 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 .direction(TailerDirection.FORWARD)
                 .toStart()) {
 
+            StringBuilder sb = new StringBuilder();
             for (int i = 0; i < entries; i++) {
                 try (DocumentContext documentContext = forwardTailer.readingDocument()) {
                     assertTrue(documentContext.isPresent());
                     assertEquals(i, DEFAULT.toSequenceNumber(documentContext.index()));
-                    StringBuilder sb = Wires.acquireStringBuilder();
+                    sb.setLength(0);
                     ValueIn valueIn = documentContext.wire().readEventName(sb);
                     assertTrue("hello".contentEquals(sb));
                     String actual = valueIn.text();
@@ -2183,6 +2184,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 .direction(TailerDirection.BACKWARD)
                 .toEnd();
 
+        StringBuilder sb = new StringBuilder();
         for (int i = entries - 1; i >= 0; i--) {
             try (DocumentContext documentContext = backwardTailer.readingDocument()) {
                 assertTrue(documentContext.isPresent());
@@ -2190,7 +2192,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 assertEquals("index: " + index, i, (int) index);
                 assertEquals(i, DEFAULT.toSequenceNumber(index));
                 assertTrue(documentContext.isPresent());
-                StringBuilder sb = Wires.acquireStringBuilder();
+                sb.setLength(0);
                 ValueIn valueIn = documentContext.wire().readEventName(sb);
                 assertTrue("hello".contentEquals(sb));
                 String actual = valueIn.text();
@@ -3571,7 +3573,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                      builder(file, wireType).testBlockSize().build();
              ExcerptTailer tailer1 = queue.createTailer(named ? "named" : null)) {
 
-            StringBuilder sb = Wires.acquireStringBuilder();
+            StringBuilder sb = new StringBuilder();
             try (DocumentContext documentContext = tailer1.readingDocument()) {
                 documentContext.wire().readEventName(sb);
                 assertEquals("hello", sb.toString());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
@@ -24,7 +24,6 @@ import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
-import net.openhft.chronicle.wire.Wires;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
@@ -308,10 +307,11 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
         finishedNormally = true;
     }
 
-    private class ParallelQueueObserver implements Callable {
+    private static class ParallelQueueObserver implements Callable<Integer> {
 
         @NotNull
         private final ExcerptTailer tailer;
+        private final StringBuilder sb = new StringBuilder();
         volatile int documentsRead;
 
         ParallelQueueObserver(@NotNull ChronicleQueue queue) {
@@ -329,7 +329,7 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
                 if (!dc.isPresent())
                     return -2;
 
-                StringBuilder sb = Wires.acquireStringBuilder();
+                sb.setLength(0);
                 dc.wire().read("say").text(sb);
 
                 if (sb.length() == 0) {


### PR DESCRIPTION
Depends on OpenHFT/Chronicle-Core#576