### PR TITLE
WIP: use weak references for Queue close listeners

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -47,6 +47,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
+import java.lang.ref.WeakReference;
 import java.security.SecureRandom;
 import java.text.ParseException;
 import java.time.ZoneId;
@@ -110,7 +111,7 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
     private final TimeProvider time;
     @NotNull
     private final BiFunction<RollingChronicleQueue, Wire, SingleChronicleQueueStore> storeFactory;
-    private final Set<Closeable> closers = Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Set<WeakReference<Closeable>> closers = Collections.newSetFromMap(new IdentityHashMap<>());
     private final boolean readOnly;
     @NotNull
     private final CycleCalculator cycleCalculator;
@@ -716,8 +717,11 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
     public <T> void addCloseListener(Closeable key) {
         synchronized (closers) {
             if (!closers.isEmpty())
-                closers.removeIf(Closeable::isClosed);
-            closers.add(key);
+                closers.removeIf(wrc -> {
+                    final Closeable closeable = wrc.get();
+                    return closeable != null || closeable.isClosed();
+                });
+            closers.add(new WeakReference<>(key));
         }
     }
 
@@ -725,7 +729,7 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
     @Override
     protected void performClose() {
         synchronized (closers) {
-            metaStoreMap.values().forEach(Closeable::closeQuietly);
+            Closeable.closeQuietly(metaStoreMap.values());
             metaStoreMap.clear();
             closers.forEach(Closeable::closeQuietly);
             closers.clear();
@@ -746,7 +750,7 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
 
         // close it if we created it.
         if (eventLoop instanceof OnDemandEventLoop)
-            eventLoop.close();
+            Closeable.closeQuietly(eventLoop);
     }
 
     @Override
@@ -911,9 +915,14 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
         return name -> dateCache.parseCount(name.substring(0, name.length() - SUFFIX.length()));
     }
 
+    @Deprecated(/* to be removed in x.25 */)
     void removeCloseListener(final StoreTailer storeTailer) {
+        removeCloseListener((java.io.Closeable) storeTailer);
+    }
+
+    void removeCloseListener(final java.io.Closeable closeable) {
         synchronized (closers) {
-            closers.remove(storeTailer);
+            closers.removeIf(wrc -> wrc.get() == closeable);
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -225,6 +225,7 @@ class StoreAppender extends AbstractCloseable
 
     @Override
     protected void performClose() {
+//        queue.removeCloseListener(this);
         releaseBytesFor(wireForIndex);
         releaseBytesFor(wire);
         releaseBytesFor(bufferWire);

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -150,6 +150,7 @@ class StoreTailer extends AbstractCloseable
 
     @Override
     protected void performClose() {
+//        queue.removeCloseListener((java.io.Closeable) this);
         Closeable.closeQuietly(indexUpdater);
         // the wire ref count will be released here by setting it to null
         context.wire(null);

--- a/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
@@ -156,10 +156,6 @@ public class QueueTestCommon {
         for (String msg : "Shrinking ,Allocation of , ms to add mapping for ,jar to the classpath, ms to pollDiskSpace for , us to linearScan by position from ,File released ,Overriding roll length from existing metadata, was 3600000, overriding to 86400000   ".split(",")) {
             ignoreException(msg);
         }
-        // See https://github.com/OpenHFT/Chronicle-Queue/issues/1455. As many unit tests do not use try/finally
-        // to manage tailer or appender scope properly. we are ignoring this exception for now.
-        // TODO: remove the below line and run the tests many times to flush out the problematic tests (or else inspect the codebase)
-        ignoreException("Discarded without closing");
     }
 
     public void ignoreException(String message) {

--- a/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
@@ -156,6 +156,10 @@ public class QueueTestCommon {
         for (String msg : "Shrinking ,Allocation of , ms to add mapping for ,jar to the classpath, ms to pollDiskSpace for , us to linearScan by position from ,File released ,Overriding roll length from existing metadata, was 3600000, overriding to 86400000   ".split(",")) {
             ignoreException(msg);
         }
+        // See https://github.com/OpenHFT/Chronicle-Queue/issues/1455. As many unit tests do not use try/finally
+        // to manage tailer or appender scope properly. we are ignoring this exception for now.
+        // TODO: remove the below line and run the tests many times to flush out the problematic tests (or else inspect the codebase)
+        ignoreException("Discarded without closing");
     }
 
     public void ignoreException(String message) {

--- a/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
@@ -66,7 +66,8 @@ public class SingleChroniclePerfMainTest extends QueueTestCommon {
         Histogram readHdr = new Histogram(30, 7);
         String file = OS.getTarget() + "/deleteme-" + Time.uniqueId();
         try (ChronicleQueue chronicle = single(file).blockSize(64 << 20).build();
-             ExcerptAppender appender = chronicle.createAppender()) {
+             ExcerptAppender appender = chronicle.createAppender();
+              ExcerptTailer tailer = chronicle.createTailer()) {
             UncheckedBytes bytes = new UncheckedBytes(BytesStore.empty().bytesForRead());
             for (int i = 0; i < count; i++) {
                 long start = System.nanoTime();
@@ -82,7 +83,6 @@ public class SingleChroniclePerfMainTest extends QueueTestCommon {
                 writeHdr.sample(time);
             }
 
-            ExcerptTailer tailer = chronicle.createTailer();
             for (int i = 0; i < count; i++) {
                 long start2 = System.nanoTime();
                 try (DocumentContext dc = tailer.readingDocument()) {

--- a/src/test/java/net/openhft/chronicle/queue/StridingAQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/StridingAQueueTest.java
@@ -46,22 +46,23 @@ public class StridingAQueueTest extends QueueTestCommon {
 
             assertEquals(getExpected(), queue.dump().replaceAll("(?m)^#.+$\\n", ""));
             StringWriter sw = new StringWriter();
-            ExcerptTailer tailer = queue.createTailer().direction(TailerDirection.BACKWARD).toEnd().striding(true);
-            MethodReader reader = tailer.methodReader(Mocker.logging(SAQMessage.class, "", sw));
-            while (reader.readOne()) ;
-            assertEquals("hi[4, 9]\n" +
-                            "hi[4, 8]\n" +
-                            "hi[4, 4]\n" +
-                            "hi[4, 0]\n" +
-                            "hi[3, 8]\n" +
-                            "hi[3, 4]\n" +
-                            "hi[3, 0]\n" +
-                            "hi[2, 7]\n" +
-                            "hi[2, 5]\n" +
-                            "hi[2, 1]\n" +
-                            "hi[1, 4]\n" +
-                            "hi[1, 0]\n",
-                    sw.toString().replace("\r", ""));
+            try (ExcerptTailer tailer = queue.createTailer().direction(TailerDirection.BACKWARD).toEnd().striding(true)) {
+                MethodReader reader = tailer.methodReader(Mocker.logging(SAQMessage.class, "", sw));
+                while (reader.readOne()) ;
+                assertEquals("hi[4, 9]\n" +
+                                "hi[4, 8]\n" +
+                                "hi[4, 4]\n" +
+                                "hi[4, 0]\n" +
+                                "hi[3, 8]\n" +
+                                "hi[3, 4]\n" +
+                                "hi[3, 0]\n" +
+                                "hi[2, 7]\n" +
+                                "hi[2, 5]\n" +
+                                "hi[2, 1]\n" +
+                                "hi[1, 4]\n" +
+                                "hi[1, 0]\n",
+                        sw.toString().replace("\r", ""));
+            }
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/WriteReadTextTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WriteReadTextTest.java
@@ -81,9 +81,8 @@ public class WriteReadTextTest extends QueueTestCommon {
                 .blockSize(Maths.nextPower2(EXTREMELY_LARGE.length() * 4, 256 << 10))
                 // .testBlockSize() not suitable as large message sizes.
                 .build();
-             ExcerptAppender appender = theQueue.createAppender()) {
-
-            ExcerptTailer tailer = theQueue.createTailer();
+             ExcerptAppender appender = theQueue.createAppender();
+             ExcerptTailer tailer = theQueue.createTailer()) {
 
             StringBuilder tmpReadback = new StringBuilder();
 


### PR DESCRIPTION
Experiment with weak references in the Queue close-listener registry so that registering an appender or tailer does not itself retain that object. The diff also adds explicit resource closure in several tests and introduces a close-listener removal overload.

The current source has the appender/tailer calls to remove themselves from the registry commented out. The earlier description below records a two-part proposal; automatic removal on close is not delivered by this head.

WIP - do not merge. The discussion records failing or flaky leak checks after earlier revisions. Correct and test the weak-reference pruning predicate, including live and collected referents, then verify queue closure, explicit closure and leak detection together. Do not suppress discarded-resource warnings to make those checks pass.

Validation: the diff and recorded review/check history were inspected at `53d0e0e6d26b`. No build, test or benchmark was rerun for this metadata edit. No CI result was returned for this head.

---

## Existing author and review notes

WIP - **do not merge**

Fixes two problems:
1. makes sure that tailers and appenders remove themselves from SingleChronicleQueue.closers
2. makes closers a WeakReference so that the SCQ is no longer the only thing holding a reference to tailers & appenders after they would otherwise be candidates for GC

Second point above we should definitely discuss.

If we can reach consensus on this then after this change has been merged, it will be possible to set `disable.discard.warning=false` to register a finalizer for both appenders and tailers and ensure that if the finalizer is called, that they will warn and close themselves, thus releasing any resources. Backporting this to 23 will not be trivial as discard warnings/finalizers were different back then.
