### PR TITLE
force unlocking an append lock if process is dead should not show a stack trace in its log message

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/table/AbstractTSQueueLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/AbstractTSQueueLock.java
@@ -116,7 +116,7 @@ public abstract class AbstractTSQueueLock extends AbstractCloseable implements C
             int realPid = (int) pid;
             if (!Jvm.isProcessAlive(realPid)) {
                 Jvm.warn().on(this.getClass(), format("Forced unlocking `%s` in lock file:%s, as this was locked by: %d which is now dead",
-                        lockKey, this.path, realPid), new StackTrace("Forced unlock"));
+                        lockKey, this.path, realPid));
                 if (lock.compareAndSwapValue(pid, UNLOCKED))
                     return true;
             } else


### PR DESCRIPTION
Backporting to 24. @tgd if you are OK to approve please feel free to merge