### PR TITLE
added threadLocalAppender

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -197,7 +197,7 @@ public interface ChronicleQueue extends Closeable {
      *
      * @return Returns a ExcerptAppender for this ChronicleQueue that is local to the current Thread
      * @deprecated It is recommended to use {@link #createAppender()} instead or for a SingleChronicleQueue you can use the utility method
-     * net.openhft.chronicle.queue.impl.single.ThreadLocalAppender#acquireThreadLocalAppender(net.openhft.chronicle.queue.impl.single.SingleChronicleQueue) instead
+     * net.openhft.chronicle.queue.impl.single.ThreadLocalAppender#acquireThreadLocalAppender(net.openhft.chronicle.queue.impl.single.SingleChronicleQueue) which gives you a thread local appender
      */
     @Deprecated(/* To be removed in x.27 */)
     @NotNull

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -196,7 +196,10 @@ public interface ChronicleQueue extends Closeable {
      * this method every time an appender is needed.
      *
      * @return Returns a ExcerptAppender for this ChronicleQueue that is local to the current Thread
+     * @deprecated It is recommended to use {@link #createAppender()} instead or for a SingleChronicleQueue you can use the utility method
+     * net.openhft.chronicle.queue.impl.single.ThreadLocalAppender#acquireThreadLocalAppender(net.openhft.chronicle.queue.impl.single.SingleChronicleQueue) instead
      */
+    @Deprecated(/* To be removed in x.27 */)
     @NotNull
     ExcerptAppender acquireAppender();
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -507,8 +507,13 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
     @NotNull
     @Override
     public ExcerptAppender acquireAppender() {
-        throwExceptionIfClosed();
-        if (readOnly)
+        return ThreadLocalAppender.acquireThreadLocalAppender(this);
+    }
+
+    @NotNull
+    ExcerptAppender acquireThreadLocalAppender(@NotNull SingleChronicleQueue queue) {
+        queue.throwExceptionIfClosed();
+        if (queue.readOnly)
             throw new IllegalStateException("Can't append to a read-only chronicle");
 
         ExcerptAppender res = strongExcerptAppenderThreadLocal.get();

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ThreadLocalAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ThreadLocalAppender.java
@@ -1,0 +1,16 @@
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.queue.ExcerptAppender;
+
+public class ThreadLocalAppender {
+
+    /**
+     * A thread local appender for the SingleChronicleQueue, this will give you the same thread local instance per thread.
+     *
+     * @param queue the SingleChronicleQueue
+     * @return a thread local appender
+     */
+    public static ExcerptAppender acquireThreadLocalAppender(SingleChronicleQueue queue) {
+        return queue.acquireThreadLocalAppender(queue);
+    }
+}


### PR DESCRIPTION
This PR puts back the deprecation of net.openhft.chronicle.queue.ChronicleQueue#acquireAppender and instead introduces a utility class.

relates to https://github.com/ChronicleEnterprise/Chronicle-Services-Enterprise/pull/599