### PR TITLE
Set Drainer priority to HandlerPriority.CONCURRENT

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -109,7 +109,7 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     private Boolean ringBufferForceCreateReader;
     private Boolean ringBufferReopenReader;
     private Supplier<Pauser> ringBufferPauserSupplier;
-    private HandlerPriority drainerPriority;
+    private HandlerPriority drainerPriority = HandlerPriority.CONCURRENT;
     private int drainerTimeoutMS = -1;
 
     @Nullable
@@ -919,7 +919,7 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     /**
      * Priority for async mode drainer handler
      *
-     * @return drainerPriority, default is null
+     * @return drainerPriority
      */
     public HandlerPriority drainerPriority() {
         return drainerPriority;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -191,4 +191,13 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
             // This will throw if we attempt to create the createAppender condition
         }
     }
+
+    /**
+     * Ensure that drainer priority is set to default value on constructing a SingleChronicleQueueBuilder
+     */
+    @Test
+    public void drainerPriorityIsSetByDefault() {
+        SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.single();
+        assertNotNull(builder.drainerPriority()); // priority may change from CONCURRENT in future
+    }
 }


### PR DESCRIPTION
Drainer priority is now set to default value on construction of SingleChronicleQueueBuilder.