### PR TITLE
POC consistency check (DO NOT MERGE)

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/MetaDataField.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/MetaDataField.java
@@ -34,7 +34,8 @@ public enum MetaDataField implements WireKey {
     lastIndexReplicated,
     sourceId,
     dataFormat,
-    metadata;
+    metadata,
+    writeInProgress;
 
     @Nullable
     @Override

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -379,6 +379,7 @@ class StoreAppender extends AbstractCloseable
         try {
             if (store == null || wire == null)
                 return false;
+            store.performConsistencyCheck(this);
             long position = store.writePosition();
             position(position, position);
 
@@ -537,6 +538,8 @@ class StoreAppender extends AbstractCloseable
     }
 
     private long writeHeader(@NotNull final Wire wire, final long safeLength) {
+        store.performConsistencyCheck(this);
+        store.startWrite();
         Bytes<?> bytes = wire.bytes();
         // writePosition points at the last record in the queue, so we can just skip it and we're ready for write
         long pos = positionOfHeader;
@@ -1008,6 +1011,7 @@ class StoreAppender extends AbstractCloseable
                         wire = StoreAppender.this.wire;
                     }
                 }
+                store.completeWrite();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new InterruptedRuntimeException(e);
@@ -1021,6 +1025,7 @@ class StoreAppender extends AbstractCloseable
         private boolean handleRollbackOnClose() {
             if (rollbackOnClose) {
                 doRollback();
+                store.completeWrite();
                 return true;
             }
             return false;


### PR DESCRIPTION
This implements a prototype approach for detecting and correcting partial updates that can occur as a result of an abrupt termination

Summary

If we acquire a write lock and `writeInProgress` is true it means the last lock holder did not complete the write, we then do a scan of the roll cycle to ensure the `writePositionAndSequence` table store header and index is consistent with the roll cycle state.

If we knew when the write lock was force-acquired we could probably do away with the `writeInProgress` flag, as a lingering write lock is a good indication that a consistency check is required.