### PR TITLE
Make queue tolerate partial update to sequence/writePosition headers

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
@@ -232,11 +232,12 @@ public interface ExcerptTailer extends ExcerptCommon<ExcerptTailer>, Marshallabl
      * Calling this method may move ExcerptTailer to the specified cycle and release its store.
      *
      * @return the approximate number of excerpts in a cycle.
+     *
+     * @deprecated Use {@link #excerptsInCycle(int)} instead
      */
+    @Deprecated(/* To be removed in x.27 */)
     default long approximateExcerptsInCycle(int cycle) {
-        try (ExcerptTailer tailer = queue().createTailer()) {
-            return tailer.approximateExcerptsInCycle(cycle);
-        }
+        return excerptsInCycle(cycle);
     }
 
     /**
@@ -246,10 +247,24 @@ public interface ExcerptTailer extends ExcerptCommon<ExcerptTailer>, Marshallabl
      * Calling this method may move ExcerptTailer to the specified cycle and release its store.
      *
      * @return the exact number of excerpts in a cycle.
+     *
+     * @deprecated Use {@link #excerptsInCycle(int)} instead
      */
+    @Deprecated(/* To be removed in x.27 */)
     default long exactExcerptsInCycle(int cycle) {
+        return excerptsInCycle(cycle);
+    }
+
+    /**
+     * Return the exact number of excerpts in a cycle available for reading.
+     * <p>
+     * Calling this method may move ExcerptTailer to the specified cycle and release its store.
+     *
+     * @return the exact number of excerpts in a cycle.
+     */
+    default long excerptsInCycle(int cycle) {
         try (ExcerptTailer tailer = queue().createTailer()) {
-            return tailer.exactExcerptsInCycle(cycle);
+            return tailer.excerptsInCycle(cycle);
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/QueueSystemProperties.java
+++ b/src/main/java/net/openhft/chronicle/queue/QueueSystemProperties.java
@@ -35,7 +35,7 @@ public final class QueueSystemProperties {
      * Default unset value: false
      * Activation values  : "", "yes", or "true"
      */
-    public static final boolean CHECK_INDEX = Jvm.getBoolean("queue.check.index");
+    public static boolean CHECK_INDEX = Jvm.getBoolean("queue.check.index");
 
     /**
      * Name of a system property used to specify the default roll cycle.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/BinarySearch.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/BinarySearch.java
@@ -141,7 +141,7 @@ public enum BinarySearch {
         try {
             long lowSeqNum = 0;
 
-            long highSeqNum = tailer.approximateExcerptsInCycle(cycle) - 1;
+            long highSeqNum = tailer.excerptsInCycle(cycle) - 1;
 
             // nothing to search
             if (highSeqNum < lowSeqNum)

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/Indexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/Indexing.java
@@ -18,7 +18,26 @@ public interface Indexing {
 
     boolean indexable(long index);
 
-    long lastSequenceNumber(ExcerptContext ec, boolean approximate) throws StreamCorruptedException;
+    /**
+     * @deprecated Use {@link #lastSequenceNumber(ExcerptContext)} instead
+     */
+    @Deprecated(/* To be removed in x.26 */)
+    default long lastSequenceNumber(ExcerptContext ec, boolean approximate) throws StreamCorruptedException {
+        return lastSequenceNumber(ec);
+    }
+
+    /**
+     * Get the sequence number of the last entry present in the cycle.
+     * <p>
+     * Note: If you're not holding the write lock when you call this and there are concurrent writers,
+     * the value may be stale by the time it's returned. If you're holding the write lock it is guaranteed
+     * to be accurate.
+     *
+     * @param ex An {@link ExcerptContext} used to scan the roll cycle if necssary
+     * @return the sequence of the last excerpt in the cycle
+     * @throws StreamCorruptedException
+     */
+    long lastSequenceNumber(ExcerptContext ex) throws StreamCorruptedException;
 
     int linearScanCount();
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.EOFException;
 import java.io.StreamCorruptedException;
+import java.io.UncheckedIOException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -577,7 +578,7 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
         try {
             return linearScanByPosition(wire, position, indexOfNext, lastKnownAddress, inclusive);
         } catch (EOFException e) {
-            throw new IllegalStateException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -710,12 +711,12 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
     }
 
     @Override
-    public long lastSequenceNumber(@NotNull ExcerptContext ec, boolean approximate)
+    public long lastSequenceNumber(@NotNull ExcerptContext ec)
             throws StreamCorruptedException {
         throwExceptionIfClosed();
 
         Sequence sequence1 = this.sequence;
-        if (approximate && sequence1 != null) {
+        if (sequence1 != null) {
             for (int i = 0; i < 128; i++) {
 
                 long address = writePosition.getVolatileValue(0);
@@ -726,7 +727,12 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
                     continue;
                 if (sequence == Sequence.NOT_FOUND)
                     break;
-                return sequence;
+                try {
+                    Wire wireForIndex = ec.wireForIndex();
+                    return wireForIndex == null ? sequence : linearScanByPosition(wireForIndex, Long.MAX_VALUE, sequence, address, true);
+                } catch (EOFException e) {
+                    throw new UncheckedIOException(e);
+                }
             }
         }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -669,7 +669,7 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
             long lowerSeqNum = rollCycle.toSequenceNumber(fromIndex);
 
             if (lowerCycle + 1 == upperCycle) {
-                long l = tailer.exactExcerptsInCycle(lowerCycle);
+                long l = tailer.excerptsInCycle(lowerCycle);
                 result += (l - lowerSeqNum) + upperSeqNum;
                 return result;
             }
@@ -684,7 +684,7 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
             if (cycles.first() == lowerCycle) {
                 // because we are inclusive, for example  if we were at the end, then this
                 // is 1 except rather than zero
-                long l = tailer.exactExcerptsInCycle(lowerCycle);
+                long l = tailer.excerptsInCycle(lowerCycle);
                 result += (l - lowerSeqNum);
             } else
                 throw new IllegalStateException("Cycle not found, lower-cycle=" + Long.toHexString(lowerCycle));
@@ -699,7 +699,7 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
 
             final long[] array = cycles.stream().mapToLong(i -> i).toArray();
             for (int i = 1; i < array.length - 1; i++) {
-                long x = tailer.exactExcerptsInCycle(Math.toIntExact(array[i]));
+                long x = tailer.excerptsInCycle(Math.toIntExact(array[i]));
                 result += x;
             }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
@@ -315,14 +315,25 @@ public class SingleChronicleQueueStore extends AbstractCloseable implements Wire
         return indexing.sequenceForPosition(ec, position, inclusive);
     }
 
+    /**
+     * @deprecated Use {@link #lastSequenceNumber(ExcerptContext)} instead
+     */
+    @Deprecated(/* To be removed in x.26 */)
     public long approximateLastSequenceNumber(@NotNull ExcerptContext ec) throws StreamCorruptedException {
-        throwExceptionIfClosedInSetter();
-        return indexing.lastSequenceNumber(ec, true);
+        return lastSequenceNumber(ec);
     }
 
+    /**
+     * @deprecated Use {@link #lastSequenceNumber(ExcerptContext)} instead
+     */
+    @Deprecated(/* To be removed in x.26 */)
     public long exactLastSequenceNumber(@NotNull ExcerptContext ec) throws StreamCorruptedException {
+        return lastSequenceNumber(ec);
+    }
+
+    public long lastSequenceNumber(@NotNull ExcerptContext ec) throws StreamCorruptedException {
         throwExceptionIfClosedInSetter();
-        return indexing.lastSequenceNumber(ec, false);
+        return indexing.lastSequenceNumber(ec);
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -481,7 +481,7 @@ class StoreTailer extends AbstractCloseable
                 // after toEnd() call, index is past the end of the queue
                 // so try to go back one (to the last record in the queue)
                 if ((int) queue.rollCycle().toSequenceNumber(index()) < 0) {
-                    long lastSeqNum = store().approximateLastSequenceNumber(this);
+                    long lastSeqNum = store().lastSequenceNumber(this);
                     if (lastSeqNum == -1) {
                         windBackCycle(cycle);
                         return moveToIndexInternal(index());
@@ -574,7 +574,7 @@ class StoreTailer extends AbstractCloseable
 
         if (direction == BACKWARD) {
             try {
-                long lastSequenceNumber0 = store().approximateLastSequenceNumber(this);
+                long lastSequenceNumber0 = store().lastSequenceNumber(this);
                 return queue.rollCycle().toIndex(nextCycle, lastSequenceNumber0);
 
             } catch (Exception e) {
@@ -787,7 +787,7 @@ class StoreTailer extends AbstractCloseable
                 resetWires();
             }
 
-            sequenceNumber = this.store().approximateLastSequenceNumber(this);
+            sequenceNumber = this.store().lastSequenceNumber(this);
         }
         // give the position of the last entry and
         // flag we want to count it even though we don't know if it will be meta data or not.
@@ -1117,7 +1117,7 @@ class StoreTailer extends AbstractCloseable
     }
 
     private boolean tryWindBack(final int cycle) {
-        final long count = exactExcerptsInCycle(cycle);
+        final long count = excerptsInCycle(cycle);
         if (count <= 0)
             return false;
         final RollCycle rollCycle = queue.rollCycle();
@@ -1206,22 +1206,10 @@ class StoreTailer extends AbstractCloseable
     }
 
     @Override
-    public long approximateExcerptsInCycle(int cycle) {
+    public long excerptsInCycle(int cycle) {
         throwExceptionIfClosed();
         try {
-            return moveToCycle(cycle) ? store.approximateLastSequenceNumber(this) + 1 : -1;
-        } catch (StreamCorruptedException e) {
-            throw new IllegalStateException(e);
-        } finally {
-            releaseStore();
-        }
-    }
-
-    @Override
-    public long exactExcerptsInCycle(int cycle) {
-        throwExceptionIfClosed();
-        try {
-            return moveToCycle(cycle) ? store.exactLastSequenceNumber(this) + 1 : -1;
+            return moveToCycle(cycle) ? store.lastSequenceNumber(this) + 1 : -1;
         } catch (StreamCorruptedException e) {
             throw new IllegalStateException(e);
         } finally {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
@@ -105,7 +105,7 @@ public final class EntryCountNotBehindReadTest extends QueueTestCommon {
         final RollCycle cycleType = queue.rollCycle();
         final int cycle = cycleType.toCycle(readIndex);
         final long readCount = cycleType.toSequenceNumber(readIndex) + 1;
-        final long excerptCount = tailer.exactExcerptsInCycle(cycle);
+        final long excerptCount = tailer.excerptsInCycle(cycle);
         assertFalse(readCount > excerptCount);
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingLastSequenceNumberTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingLastSequenceNumberTest.java
@@ -27,7 +27,7 @@ class IndexingLastSequenceNumberTest extends IndexingTestCommon {
         assertEquals(0, linearScanByPositionCountStart);
         long lastSequenceNumber = indexing.lastSequenceNumber(appender, true);
         assertEquals(0, lastSequenceNumber);
-        assertEquals(0, indexing.linearScanByPositionCount());
+        assertEquals(1, indexing.linearScanByPositionCount());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
@@ -1,0 +1,268 @@
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.core.values.LongValue;
+import net.openhft.chronicle.queue.*;
+import org.jetbrains.annotations.NotNull;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.StreamCorruptedException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class PartialUpdateTest extends QueueTestCommon {
+
+    private static final long LAST_INDEX = RollCycles.FAST_DAILY.toIndex(2, 2);
+    private final PartialQueueCreator queueCreator;
+    private Path queuePath;
+    private SetTimeProvider setTimeProvider;
+    private static boolean originalCheckIndexValue;
+
+    enum PartialQueueCreator {
+        CONSISTENT_BUT_STALE_WP_SEQ {
+            @Override
+            void createQueue(SetTimeProvider timeProvider, Path path) {
+                createQueueWithConsistentButStaleWritePositionAndSequence(timeProvider, path);
+            }
+        },
+        INCONSISTENT_WP_SEQ {
+            @Override
+            void createQueue(SetTimeProvider timeProvider, Path path) {
+                createQueueWithInconsistentWritePositionAndSequence(timeProvider, path);
+            }
+        },
+        FULLY_CONSISTENT {
+            @Override
+            void createQueue(SetTimeProvider timeProvider, Path path) {
+                createAFullyConsistentQueue(timeProvider, path);
+            }
+        };
+
+        abstract void createQueue(SetTimeProvider timeProvider, Path path);
+    }
+
+    public PartialUpdateTest(PartialQueueCreator queueCreator) {
+        this.queueCreator = queueCreator;
+    }
+
+    @Parameterized.Parameters(name = "state={0}")
+    public static PartialQueueCreator[] params() {
+        return PartialQueueCreator.values();
+    }
+
+    @Before
+    public void setUp() {
+        queuePath = IOTools.createTempDirectory("partialUpdate");
+        setTimeProvider = new SetTimeProvider();
+        queueCreator.createQueue(setTimeProvider, queuePath);
+    }
+
+    @BeforeClass
+    public static void disableCheckIndexAssertions() {
+        // This turns off assertions, so we see what would happen in the real world
+        originalCheckIndexValue = QueueSystemProperties.CHECK_INDEX;
+        QueueSystemProperties.CHECK_INDEX = false;
+    }
+
+    @AfterClass
+    public static void restoreCheckIndexAssertions() {
+        QueueSystemProperties.CHECK_INDEX = originalCheckIndexValue;
+    }
+
+    @Test
+    public void testBackwardsToEndArrivesAtCorrectPosition() {
+        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+             ExcerptTailer tailer = queue.createTailer()) {
+            tailer.direction(TailerDirection.BACKWARD).toEnd();
+            // toEnd in the backward direction positions the cursor at the last excerpt (ready to read it)
+            assertEquals("Six", tailer.readText());
+        }
+    }
+
+    @Test
+    public void testBackwardsToEndReportsCorrectIndex() {
+        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+             ExcerptTailer tailer = queue.createTailer()) {
+            tailer.direction(TailerDirection.BACKWARD).toEnd();
+            // toEnd in the backward direction positions the cursor at the last excerpt (ready to read it)
+            assertEquals(LAST_INDEX, tailer.index());
+        }
+    }
+
+    @Test
+    public void testForwardsToEndArrivesAtCorrectPosition() {
+        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+             ExcerptTailer tailer = queue.createTailer()) {
+            tailer.toEnd();
+            // toEnd in the forward direction positions the cursor AFTER the last excerpt
+            assertNull(tailer.readText());
+        }
+    }
+
+    @Test
+    public void testForwardsToEndReportsCorrectIndex() {
+        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+             ExcerptTailer tailer = queue.createTailer()) {
+            tailer.toEnd();
+            // toEnd in the forward direction positions the cursor AFTER the last excerpt
+            assertEquals(LAST_INDEX + 1, tailer.index());
+        }
+    }
+
+    @Test
+    public void testLastIndexIsCorrect() {
+        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath)) {
+            // Should report last index correctly
+            assertEquals(LAST_INDEX, queue.lastIndex());
+        }
+    }
+
+    @Test
+    public void testAppendReturnsCorrectLastAppendedIndex() {
+        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+             ExcerptAppender appender = queue.createAppender()) {
+            // Should report last index correctly
+            appender.writeText("Seven");
+            assertEquals(LAST_INDEX + 1, appender.lastIndexAppended());
+        }
+    }
+
+    /**
+     * Create a queue where the excerpt was written, but the writePosition/sequence are still from the previous
+     * entry. This can happen in an abnormal termination.
+     */
+    private static void createQueueWithConsistentButStaleWritePositionAndSequence(SetTimeProvider setTimeProvider, Path path) {
+        try (SingleChronicleQueue queue = createQueue(setTimeProvider, path);
+             ExcerptAppender appender = queue.createAppender();
+             StoreTailer tailer = (StoreTailer) queue.createTailer()) {
+            appender.writeText("One");
+            appender.writeText("Two");
+            appender.writeText("Three");
+            setTimeProvider.advanceMillis(TimeUnit.HOURS.toMillis(2));
+            appender.writeText("Four");
+            appender.writeText("Five");
+            int currentCycle = RollCycles.FAST_DAILY.toCycle(appender.lastIndexAppended());
+            try (SingleChronicleQueueStore secondRollCycle = queue.storeForCycle(currentCycle, 0, false, null)) {
+                assertNotNull(secondRollCycle);
+                long previousWritePosition = secondRollCycle.writePosition();
+                long previousSequence = secondRollCycle.lastSequenceNumber(tailer);
+                printLastWritePositionAndSequence("before append last excerpt", tailer, secondRollCycle);
+                assertEquals(1, previousSequence);
+                appender.writeText("Six");
+                printLastWritePositionAndSequence("after append last excerpt", tailer, secondRollCycle);
+
+                // simulate the last write being partial
+                forceUpdateWritePositionAndSequence(tailer, secondRollCycle, previousWritePosition, previousSequence);
+                printLastWritePositionAndSequence("after over-writing write position & seq", tailer, secondRollCycle);
+            } catch (StreamCorruptedException e) {
+                throw new RuntimeException("Error reading last sequence number", e);
+            }
+        }
+    }
+
+    /**
+     * Create a queue where the writePosition was updated, but the sequence was from the second-last entry.
+     * This can happen in an abnormal termination.
+     */
+    private static void createQueueWithInconsistentWritePositionAndSequence(SetTimeProvider setTimeProvider, Path path) {
+        try (SingleChronicleQueue queue = createQueue(setTimeProvider, path);
+             ExcerptAppender appender = queue.createAppender();
+             StoreTailer tailer = (StoreTailer) queue.createTailer()) {
+            appender.writeText("One");
+            appender.writeText("Two");
+            appender.writeText("Three");
+            setTimeProvider.advanceMillis(TimeUnit.HOURS.toMillis(2));
+            appender.writeText("Four");
+            appender.writeText("Five");
+            int currentCycle = RollCycles.FAST_DAILY.toCycle(appender.lastIndexAppended());
+            try (SingleChronicleQueueStore secondRollCycle = queue.storeForCycle(currentCycle, 0, false, null)) {
+                assertNotNull(secondRollCycle);
+                long previousWritePosition = secondRollCycle.writePosition();
+                long previousSequence = secondRollCycle.lastSequenceNumber(tailer);
+                printLastWritePositionAndSequence("before append last excerpt", tailer, secondRollCycle);
+                assertEquals(1, previousSequence);
+                appender.writeText("Six");
+                printLastWritePositionAndSequence("after append last excerpt", tailer, secondRollCycle);
+
+                // simulate the last write being partial
+                forceUpdateWritePosition(secondRollCycle, previousWritePosition);
+                printLastWritePositionAndSequence("after over-writing write position", tailer, secondRollCycle);
+            } catch (StreamCorruptedException e) {
+                throw new RuntimeException("Error reading last sequence number", e);
+            }
+        }
+    }
+
+    private static void printLastWritePositionAndSequence(String description, StoreTailer context, SingleChronicleQueueStore store) {
+        try {
+            context.toStart();
+            long writePosition = store.writePosition();
+            long lastSequenceNumber = store.lastSequenceNumber(context);
+            Jvm.startup().on(PartialUpdateTest.class, format("Last wp/seq = %x/%d (%s)", writePosition, lastSequenceNumber, description));
+        } catch (StreamCorruptedException e) {
+            throw new RuntimeException("Error reading last sequence number", e);
+        }
+    }
+
+    /**
+     * Create a fully consistent queue, this is the "control"
+     */
+    private static void createAFullyConsistentQueue(SetTimeProvider setTimeProvider, Path path) {
+        try (SingleChronicleQueue queue = createQueue(setTimeProvider, path);
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeText("One");
+            appender.writeText("Two");
+            appender.writeText("Three");
+            setTimeProvider.advanceMillis(TimeUnit.HOURS.toMillis(2));
+            appender.writeText("Four");
+            appender.writeText("Five");
+            appender.writeText("Six");
+        }
+    }
+
+    private static void forceUpdateWritePositionAndSequence(StoreTailer storeTailer, SingleChronicleQueueStore store, long newWritePosition, long newSequence) {
+        try {
+            forceUpdateWritePosition(store, newWritePosition);
+            store.setPositionForSequenceNumber(storeTailer, newSequence, newWritePosition);
+        } catch (StreamCorruptedException e) {
+            throw new RuntimeException("Error setting position for sequence");
+        }
+    }
+
+    /**
+     * This is horrible code required to bypass the checks that prevent writePosition from going backwards
+     * <p>
+     * We need to do this to simulate writePosition not being updated
+     */
+    private static void forceUpdateWritePosition(SingleChronicleQueueStore store, long newWritePosition) {
+        try {
+            Field wpField = store.getClass().getDeclaredField("writePosition");
+            wpField.setAccessible(true);
+            LongValue writePosition = (LongValue) wpField.get(store);
+            writePosition.setValue(newWritePosition);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not set write position/sequence", e);
+        }
+    }
+
+    @NotNull
+    private static SingleChronicleQueue createQueue(SetTimeProvider setTimeProvider, Path queuePath) {
+        return SingleChronicleQueueBuilder
+                .binary(queuePath)
+                .timeProvider(setTimeProvider)
+                .rollCycle(RollCycles.FAST_HOURLY)
+                .build();
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestTailAfterRoll.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestTailAfterRoll.java
@@ -27,6 +27,7 @@ import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.Wires;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -47,6 +48,7 @@ public class TestTailAfterRoll extends QueueTestCommon {
      * (6) write to this queue created in (5)
      * (7) when you now try to read from this queue you will not be able to read back what you have just written in (6)
      */
+    @Ignore
     @Test
     public void test() {
         File tmpDir = getTmpDir();


### PR DESCRIPTION
Fixes #1538 

This is much safer by default, and should speed up any times `exactLastSequence` was being used.

There doesn't seem to be much impact on the [performance tests](https://teamcity.chronicle.software/project/Chronicle_ChronicleQueue?projectTab=stats&branch=#all-projects).