### PR TITLE
Add support for WEEKLY rolling on Sunday 00:00 #1549

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/RollCycle.java
+++ b/src/main/java/net/openhft/chronicle/queue/RollCycle.java
@@ -52,6 +52,13 @@ public interface RollCycle {
     int lengthInMillis();
 
     /**
+     * @return the default epoch offset if one is not set
+     */
+    default int defaultEpoch() {
+        return 0;
+    }
+
+    /**
      * @return the size of each index array, note: indexCount^2 is the maximum number of index queue entries.
      */
     int defaultIndexCount();

--- a/src/main/java/net/openhft/chronicle/queue/RollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/RollCycles.java
@@ -68,7 +68,7 @@ public enum RollCycles implements RollCycle {
     /**
      * 0xffffffff entries per week, indexing every 256th entry, leave as 4K and 256 for historical reasons. Cycle starts Sunday 00:00
      */
-    WEEKLY(/*-----------*/"yyyy'W'ww", 7 * 24 * 60 * 60 * 1000, 4 << 10, 256, Constants.SUNDAY_00_00),
+    WEEKLY(/*-----------*/"YYYY'W'ww", 7 * 24 * 60 * 60 * 1000, 4 << 10, 256, RollCycleArithmetic.SUNDAY_00_00),
 
     // these are kept for historical reasons
     /**
@@ -373,12 +373,5 @@ public enum RollCycles implements RollCycle {
         mappings.put(RollCycles.HUGE_DAILY, LargeRollCycles.HUGE_DAILY);
 
         return Collections.unmodifiableMap(mappings);
-    }
-
-    static class Constants {
-        /**
-         * Sunday 1970 Jan 4th 00:00:00 UTC
-         */
-        public static final int SUNDAY_00_00 = 259_200_000;
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/RollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/RollCycles.java
@@ -65,6 +65,10 @@ public enum RollCycles implements RollCycle {
      * 0xffffffff entries per day, indexing every 256th entry, leave as 4K and 256 for historical reasons.
      */
     FAST_DAILY(/*-----------*/"yyyyMMdd'F'", 24 * 60 * 60 * 1000, 4 << 10, 256),
+    /**
+     * 0xffffffff entries per week, indexing every 256th entry, leave as 4K and 256 for historical reasons. Cycle starts Sunday 00:00
+     */
+    WEEKLY(/*-----------*/"yyyy'W'ww", 7 * 24 * 60 * 60 * 1000, 4 << 10, 256, Constants.SUNDAY_00_00),
 
     // these are kept for historical reasons
     /**
@@ -220,11 +224,16 @@ public enum RollCycles implements RollCycle {
 
     private final String format;
     private final int lengthInMillis;
+    private final int defaultEpoch;
     private final RollCycleArithmetic arithmetic;
 
     RollCycles(String format, int lengthInMillis, int indexCount, int indexSpacing) {
+        this(format, lengthInMillis, indexCount, indexSpacing, 0);
+    }
+    RollCycles(String format, int lengthInMillis, int indexCount, int indexSpacing, int defaultEpoch) {
         this.format = format;
         this.lengthInMillis = lengthInMillis;
+        this.defaultEpoch = defaultEpoch;
         this.arithmetic = RollCycleArithmetic.of(indexCount, indexSpacing);
     }
 
@@ -262,6 +271,11 @@ public enum RollCycles implements RollCycle {
     @Override
     public int lengthInMillis() {
         return this.lengthInMillis;
+    }
+
+    @Override
+    public int defaultEpoch() {
+        return this.defaultEpoch;
     }
 
     /**
@@ -359,5 +373,12 @@ public enum RollCycles implements RollCycle {
         mappings.put(RollCycles.HUGE_DAILY, LargeRollCycles.HUGE_DAILY);
 
         return Collections.unmodifiableMap(mappings);
+    }
+
+    static class Constants {
+        /**
+         * Sunday 1970 Jan 4th 00:00:00 UTC
+         */
+        public static final int SUNDAY_00_00 = 259_200_000;
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -148,7 +148,8 @@ SingleChronicleQueue extends AbstractCloseable implements RollingChronicleQueue 
         try {
             rollCycle = builder.rollCycle();
             cycleCalculator = cycleCalculator(builder.rollTimeZone());
-            epoch = builder.epoch();
+            long epoch0 = builder.epoch();
+            epoch = epoch0 == 0 ? rollCycle.defaultEpoch() : epoch0;
             dateCache = new RollingResourcesCache(rollCycle, epoch, textToFile(builder), fileToText());
 
             storeFileListener = builder.storeFileListener();

--- a/src/main/java/net/openhft/chronicle/queue/rollcycles/RollCycleArithmetic.java
+++ b/src/main/java/net/openhft/chronicle/queue/rollcycles/RollCycleArithmetic.java
@@ -8,6 +8,10 @@ import static net.openhft.chronicle.queue.RollCycle.MAX_INDEX_COUNT;
  * Reusable optimised arithmetic for converting between cycles/indices/sequenceNumbers
  */
 public final class RollCycleArithmetic {
+    /**
+     * Sunday 1970 Jan 4th 00:00:00 UTC
+     */
+    public static final int SUNDAY_00_00 = 259_200_000;
     private final int cycleShift;
     private final int indexCount;
     private final int indexSpacing;

--- a/src/test/java/net/openhft/chronicle/queue/WeeklyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WeeklyRollCycleTest.java
@@ -1,0 +1,31 @@
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class WeeklyRollCycleTest {
+
+    @Test
+    public void testWeekly() {
+        @NotNull String tmpDir = OS.getTarget()+"/testWeekly";
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(tmpDir).rollCycle(RollCycles.WEEKLY).build()) {
+            // 1970-02-01 is a Sunday
+            assertEquals(4, queue.cycle(new SetTimeProvider("1970/02/01T00:00:00")));
+            assertEquals(4, queue.cycle(new SetTimeProvider("1970/02/02T00:00:00")));
+            assertEquals(4, queue.cycle(new SetTimeProvider("1970/02/03T00:00:00")));
+            assertEquals(4, queue.cycle(new SetTimeProvider("1970/02/04T00:00:00")));
+            assertEquals(4, queue.cycle(new SetTimeProvider("1970/02/05T00:00:00")));
+            assertEquals(4, queue.cycle(new SetTimeProvider("1970/02/06T00:00:00")));
+            // 1970-02-07 is a Saturday
+            assertEquals(4, queue.cycle(new SetTimeProvider("1970/02/07T00:00:00")));
+            assertEquals(4, queue.cycle(new SetTimeProvider("1970/02/07T23:59:59")));
+            assertEquals(5, queue.cycle(new SetTimeProvider("1970/02/08T00:00:00")));
+        }
+    }
+}


### PR DESCRIPTION
This supports the case where a client doesn't want the queue to roll all week, and 4 billion entries are more than enough.
The roll file might get large, e.g. 1 TB, but avoids any rolling during the week.
This will roll on Sunday at 00:00:00 UTC unless the epoch has been specified.