### PR TITLE
Deprecate InternalAppender#unsafeWriteBytes, remove performance test for it 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -631,7 +631,7 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>InternalAppenderJLBH-SAFE</id>
+                                <id>InternalAppenderJLBH</id>
                                 <phase>test</phase>
                                 <goals>
                                     <goal>exec</goal>
@@ -639,18 +639,6 @@
                                 <configuration>
                                     <executable>${java.home}/bin/java</executable>
                                     <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath %classpath net.openhft.chronicle.queue.bench.InternalAppenderJLBH
-                                    </commandlineArgs>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>InternalAppenderJLBH-UNSAFE</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${java.home}/bin/java</executable>
-                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -DunsafeAppends -classpath %classpath net.openhft.chronicle.queue.bench.InternalAppenderJLBH
                                     </commandlineArgs>
                                 </configuration>
                             </execution>

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
@@ -62,6 +62,8 @@ public interface InternalAppender extends ExcerptAppender {
      * @param index index the index to append at
      * @param bytes bytes the contents of the excerpt to write
      * @throws IllegalIndexException if the index specified is larger than the valid next indices of the queue
+     * @deprecated Use {@link #writeBytes(long, BytesStore)} instead
      */
+    @Deprecated(/* For removal in x.26 */)
     void unsafeWriteBytes(long index, BytesStore bytes);
 }

--- a/src/test/java/net/openhft/chronicle/queue/bench/InternalAppenderJLBH.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/InternalAppenderJLBH.java
@@ -1,7 +1,6 @@
 package net.openhft.chronicle.queue.bench;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.io.IOTools;
@@ -19,7 +18,6 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 public class InternalAppenderJLBH implements JLBHTask {
 
     private static final String QUEUE_PATH = "internalAppend";
-    private static final boolean UNSAFE_APPENDS = Jvm.getBoolean("unsafeAppends", false);
 
     static {
         System.setProperty("jvm.resource.tracing", "false");
@@ -66,18 +64,15 @@ public class InternalAppenderJLBH implements JLBHTask {
     @Override
     public void run(long startTimeNS) {
         long index = rollCycle.toIndex(0, sequenceNumber);
-        if (UNSAFE_APPENDS) {
-            appender.unsafeWriteBytes(index, payload);
-        } else {
-            appender.writeBytes(index, payload);
-        }
+        appender.writeBytes(index, payload);
         jlbh.sample(System.nanoTime() - startTimeNS);
         sequenceNumber++;
     }
 
     @Override
     public void complete() {
-        TeamCityHelper.teamCityStatsLastRun(InternalAppenderJLBH.class.getSimpleName() + (UNSAFE_APPENDS ? "-UNSAFE" : "-SAFE"), jlbh, ITERATIONS, System.out);
+        // The `-SAFE` suffix is a hangover from when there was a safe and unsafe version of this benchmark. Keep it for continuity in the charts.
+        TeamCityHelper.teamCityStatsLastRun(InternalAppenderJLBH.class.getSimpleName() + "-SAFE", jlbh, ITERATIONS, System.out);
         Closeable.closeQuietly(appender, queue);
         BackgroundResourceReleaser.releasePendingResources();
         IOTools.deleteDirWithFiles(QUEUE_PATH);


### PR DESCRIPTION
no longer needed after fix for #1538

Will remove charts from TC as well