### PR TITLE
ChronicleReader suppress empty message

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/reader/ChronicleReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/ChronicleReader.java
@@ -230,7 +230,8 @@ public class ChronicleReader implements Reader {
     private boolean writeToSink(long index, String text) {
         if (displayIndex)
             messageSink.accept("0x" + Long.toHexString(index) + ": ");
-        messageSink.accept(text);
+        if (!text.isEmpty())
+            messageSink.accept(text);
         return true;
     }
 


### PR DESCRIPTION
Right now if you try and read from a queue and filter with a method reader interface then you get a blank line for each entry that is not handled by the interface even if you use `suppressDisplayIndex`.