### PR TITLE
Remove old check.thread.safety property

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/bench/ByteArrayJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/ByteArrayJLBHBenchmark.java
@@ -33,7 +33,6 @@ public class ByteArrayJLBHBenchmark implements JLBHTask {
     static {
         System.setProperty("disable.thread.safety", "true");
         System.setProperty("jvm.resource.tracing", "false");
-        System.setProperty("check.thread.safety", "false");
     }
 
     public static void main(String[] args) {

--- a/src/test/java/net/openhft/chronicle/queue/bench/MethodReaderBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/MethodReaderBenchmark.java
@@ -66,7 +66,6 @@ public class MethodReaderBenchmark implements JLBHTask {
     static {
         System.setProperty("disable.thread.safety", "true");
         System.setProperty("jvm.resource.tracing", "false");
-        System.setProperty("check.thread.safety", "false");
     }
 
     private volatile boolean stopped = false;

--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueLargeMessageJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueLargeMessageJLBHBenchmark.java
@@ -50,7 +50,6 @@ public class QueueLargeMessageJLBHBenchmark implements JLBHTask {
     static {
         System.setProperty("disable.thread.safety", "true");
         System.setProperty("jvm.resource.tracing", "false");
-        System.setProperty("check.thread.safety", "false");
     }
 
     public static void main(String[] args) {

--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueSingleThreadedJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueSingleThreadedJLBHBenchmark.java
@@ -50,7 +50,6 @@ public class QueueSingleThreadedJLBHBenchmark implements JLBHTask {
     static {
         System.setProperty("disable.thread.safety", "true");
         System.setProperty("jvm.resource.tracing", "false");
-        System.setProperty("check.thread.safety", "false");
     }
 
     public static void main(String[] args) {

--- a/system.properties
+++ b/system.properties
@@ -19,7 +19,6 @@
 # Tracing if resources are closed/released correctly.
 jvm.resource.tracing=true
 disable.resource.warning=true
-check.thread.safety=true
 disable.discard.warning=false
 # for profiling
 jvm.safepoint.enabled=false


### PR DESCRIPTION
The check.thread.saftety property has not been used for a while. Removing references to it.