### PR TITLE
Deploy docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,5 @@
-FROM node AS base
+FROM node:alpine AS base
+RUN apk --update add git
 RUN npm install -g gitlab:antora/xref-validator
 
 FROM base AS docs

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,9 @@
+FROM node AS base
+RUN npm install -g gitlab:antora/xref-validator
+
+FROM base AS docs
+COPY . /repo
+WORKDIR /repo/docs/antora
+RUN npm ci && npm run build-portal
+RUN find . -type f -print0 | xargs -0 sed -i /prism\.js/d
+ENTRYPOINT tar -C/repo/docs/antora/build/site -cf- .

--- a/docs/deploy-docs.sh
+++ b/docs/deploy-docs.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-docker build --network=host . -f docs/Dockerfile -t docker.chronicle.software:8083/queue-docs-tar
+set -e
+
+docker build --network=host . -f docs/Dockerfile -t docker.chronicle.software:8083/queue-docs-tar && \
 docker push docker.chronicle.software:8083/queue-docs-tar

--- a/docs/deploy-docs.sh
+++ b/docs/deploy-docs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build --network=host . -f docs/Dockerfile -t docker.chronicle.software:8083/queue-docs-tar
+docker push docker.chronicle.software:8083/queue-docs-tar


### PR DESCRIPTION
Move docs build step to the respective repository in order to improve Web redeployment pipeline's resiliency and speed.
See https://github.com/ChronicleSoftware/Chronicle-Web/pull/676