### PR TITLE
Backport InternalFileUtil enhancements to 2.25

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/util/FileUtil.java
+++ b/src/main/java/net/openhft/chronicle/queue/util/FileUtil.java
@@ -22,6 +22,8 @@ import net.openhft.chronicle.queue.internal.util.InternalFileUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -72,6 +74,19 @@ public final class FileUtil {
     @NotNull
     public static Stream<File> removableRollFileCandidates(@NotNull File baseDir) {
         return InternalFileUtil.removableRollFileCandidates(baseDir);
+    }
+
+    /**
+     * Returns all files currently opened by any process, including the PID of the process holding the file open.
+     * <p>
+     * Method is only supported currently on Linux operating systems.
+     *
+     * @return a {@link Map} of the absolute paths to all the open files on the system, mapped to the PID holding the file open
+     * @throws UnsupportedOperationException if getAllOpenFiles is not supported by the operating system
+     * @throws IOException if an error occurs while traversing filesystem metadata for open files
+     */
+    public static Map<String, String> getAllOpenFiles() throws IOException {
+        return InternalFileUtil.getAllOpenFiles();
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
@@ -29,6 +29,7 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.queue.internal.util.InternalFileUtil;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -37,6 +38,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
@@ -185,5 +187,25 @@ public class FileUtilTest extends QueueTestCommon {
     @NotNull
     protected SingleChronicleQueueBuilder builder(@NotNull File file, @NotNull WireType wireType) {
         return SingleChronicleQueueBuilder.builder(file, wireType).rollCycle(TEST4_DAILY).testBlockSize();
+    }
+
+    @Test
+    public void testOpenFilesWithPid() throws IOException {
+        assumeTrue(getAllOpenFilesIsSupportedOnOS());
+
+        // open file for writing, keeping file handle open
+        File temporaryFile = IOTools.createTempFile("testOpenFilesWithPid.txt");
+        FileWriter fstream = new FileWriter(temporaryFile);
+        BufferedWriter out = new BufferedWriter(fstream);
+        out.write("somedata");
+
+        Map<String, String> filesWithPid = FileUtil.getAllOpenFiles();
+        assertEquals(Integer.toString(Jvm.getProcessId()), filesWithPid.get(temporaryFile.getAbsolutePath()));
+
+        // close file
+        out.close();
+
+        filesWithPid = FileUtil.getAllOpenFiles();
+        assertFalse(filesWithPid.keySet().contains(temporaryFile.getAbsolutePath()));
     }
 }


### PR DESCRIPTION
InternalFileUtil.getAllOpenFiles now returns map of open files to PID holding files open.
FileUtil now exposes a getAllOpenFiles method to allow determinination of which process is holding a file open.