### PR TITLE
ensure deprecations applied to interfaces

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
@@ -192,7 +192,9 @@ public interface ExcerptTailer extends ExcerptCommon<ExcerptTailer>, Marshallabl
      * @return this ExcerptTailer
      * @throws IORuntimeException   if the provided {@code queue} couldn't be wound to the last index.
      * @throws NullPointerException if the provided {@code queue} is {@code null}
+     * @deprecated to be removed in x.27. Use CQE TailerUtil
      */
+    @Deprecated(/* to be removed in x.27. Use CQE TailerUtil */)
     @NotNull
     default ExcerptTailer afterLastWritten(ChronicleQueue queue) {
         return afterWrittenMessageAtIndex(queue, Long.MIN_VALUE);
@@ -318,7 +320,9 @@ public interface ExcerptTailer extends ExcerptCommon<ExcerptTailer>, Marshallabl
      * @return This ExcerptTailer instance.
      * @throws IORuntimeException   if the provided {@code queue} couldn't be wound to the last index.
      * @throws NullPointerException if the provided {@code queue} is null.
+     * @deprecated to be removed in x.27. Use CQE TailerUtil
      */
+    @Deprecated(/* to be removed in x.27. Use CQE TailerUtil */)
     default @NotNull ExcerptTailer afterWrittenMessageAtIndex(@NotNull ChronicleQueue queue, long index) {
         throw new UnsupportedOperationException("todo");
     }

--- a/src/test/java/net/openhft/chronicle/queue/LastAppendedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LastAppendedTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RequiredForClient
+@SuppressWarnings("deprecation")
 public class LastAppendedTest extends QueueTestCommon {
 
     public static final RollCycle ROLL_CYCLE = TEST4_SECONDLY;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
@@ -108,6 +108,7 @@ public class StoreTailerTest extends QueueTestCommon {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void shouldConsiderSourceIdWhenDeterminingLastWrittenIndex() {
         try (ChronicleQueue firstInputQueue =
@@ -152,6 +153,7 @@ public class StoreTailerTest extends QueueTestCommon {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void checkAfterWrittenMessageAtIndexMovesToTheCorrectIndex() {
 


### PR DESCRIPTION
deprecation had only been applied to one implementation

[build-all green](https://teamcity.chronicle.software/project/Chronicle_BuildAll?branch=feature%2Fextra-deprecations&mode=builds#all-projects)