### PR TITLE
Lock a map that might be updated concurrently

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
@@ -74,12 +74,15 @@ public class NormaliseEOFsTest extends QueueTestCommon {
                 excerptAppender.normaliseEOFs();
             }
             final Pattern logPattern = Pattern.compile("Normalising from cycle (\\d+)");
-            // Note a defensive copy of exceptionMap is used as this code has yielded concurrent modification exceptions leading to flakiness under load
-            final List<Integer> startIndices = new LinkedHashMap<>(exceptionMap).keySet().stream()
-                    .map(exceptionKey -> logPattern.matcher(exceptionKey.message))
-                    .filter(Matcher::matches)
-                    .map(matcher -> Integer.parseInt(matcher.group(1)))
-                    .collect(Collectors.toList());
+            // Note: lock the exceptionMap to avoid a concurrent modification exceptions leading to flakiness under load
+            final List<Integer> startIndices;
+            synchronized (exceptionMap) {
+                startIndices = exceptionMap.keySet().stream()
+                        .map(exceptionKey -> logPattern.matcher(exceptionKey.message))
+                        .filter(Matcher::matches)
+                        .map(matcher -> Integer.parseInt(matcher.group(1)))
+                        .collect(Collectors.toList());
+            }
 
             // There is at least 5 calls to normaliseEOF and the start index increases each time
             assertTrue(startIndices.size() >= 5);


### PR DESCRIPTION
`NormaliseEOFsTest.normaliseShouldResumeFromPreviousNormalisation()` was **flaky under load**. The test scans `exceptionMap` for log entries like `Normalising from cycle N`. While the test was running, other threads could mutate `exceptionMap`, occasionally triggering `ConcurrentModificationException` (CME) or producing partial/incorrect reads during the stream traversal.

The previous “defensive copy” (`new LinkedHashMap<>(exceptionMap)`) reduced but did **not eliminate** the race window — if the map was modified during the copy, a CME could still occur, and on some map implementations the copy itself is not atomic with respect to concurrent updates.

## What changed

* Replace the defensive copy with a **synchronised block** around the traversal of `exceptionMap`:

  ```java
  final List<Integer> startIndices;
  synchronized (exceptionMap) {
      startIndices = exceptionMap.keySet().stream()
              .map(exceptionKey -> logPattern.matcher(exceptionKey.message))
              .filter(Matcher::matches)
              .map(matcher -> Integer.parseInt(matcher.group(1)))
              .collect(Collectors.toList());
  }
  ```
* Keep the parsing and collection logic identical; only the access is now guarded.

## Impact

* **Reliability:** Eliminates CMEs and read skew in this test, removing flakiness under stress.
* **Scope:** Test-only change; **no production code impacted**.
* **Performance:** Negligible; the critical section is small and bounded by a simple stream iteration.

## Rationale

* Synchronising on the same `exceptionMap` instance ensures **exclusive, consistent iteration** over keys while other threads may be appending exceptions.
* This is safer than shallow-copying a potentially mutating map, which can still fail or produce partial snapshots.
* The lock duration is minimal and occurs only within the test, so deadlock risk is effectively zero (no nested locks, single monitor).
