### PR TITLE
queue.dont.recover.lock.timeout was deprecated. Now throw if used

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLock.java
@@ -37,8 +37,8 @@ import static net.openhft.chronicle.core.Jvm.warn;
 /**
  * Implements {@link WriteLock} using memory access primitives - see {@link AbstractTSQueueLock}.
  * <p>
- * WARNING: the default behaviour (see also {@code queue.dont.recover.lock.timeout} system property) is
- * for a timed-out lock to be overridden.
+ * The default behaviour (see also {@code queue.force.unlock.mode} system property) is
+ * for a timed-out lock to be overridden but only if the locking process is dead.
  */
 public class TableStoreWriteLock extends AbstractTSQueueLock implements WriteLock, Closeable {
     private static final String STORE_LOCK_THREAD = "chronicle.store.lock.thread";

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/QueueLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/QueueLockTest.java
@@ -45,7 +45,6 @@ public class QueueLockTest extends QueueTestCommon {
 
     @Test
     public void testTimeout() throws InterruptedException {
-        expectException("queue.dont.recover.lock.timeout property is deprecated and will be removed");
         check(true);
     }
 
@@ -69,7 +68,7 @@ public class QueueLockTest extends QueueTestCommon {
             expectException("Forced unlock for the lock");
 
         try {
-            System.setProperty("queue.dont.recover.lock.timeout", Boolean.toString(shouldThrowException));
+            System.setProperty("queue.force.unlock.mode", shouldThrowException ? "NEVER" : "ALWAYS" );
 
             final long timeoutMs = 2_000;
             final File queueDir = DirectoryUtils.tempDir("check");
@@ -122,7 +121,7 @@ public class QueueLockTest extends QueueTestCommon {
             }
             finishedNormally = true;
         } finally {
-            System.clearProperty("queue.dont.recover.lock.timeout");
+            System.clearProperty("queue.force.unlock.mode");
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
@@ -123,8 +123,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test(timeout = 5_000, expected = UnrecoverableTimeoutException.class)
     public void lockWillThrowExceptionAfterTimeoutWhenDontRecoverLockTimeoutIsTrue() throws InterruptedException {
-        expectException("queue.dont.recover.lock.timeout property is deprecated and will be removed");
-        System.setProperty("queue.dont.recover.lock.timeout", "true");
+        System.setProperty("queue.force.unlock.mode", "NEVER");
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
             Thread t = new Thread(testLock::lock);
             t.start();
@@ -132,7 +131,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
             testLock.lock();
             fail("Should have thrown trying to lock()");
         } finally {
-            System.clearProperty("queue.dont.recover.lock.timeout");
+            System.clearProperty("queue.force.unlock.mode");
         }
     }
 

--- a/systemProperties.adoc
+++ b/systemProperties.adoc
@@ -14,7 +14,7 @@ https://github.com/OpenHFT/Chronicle-Core/blob/351e79ed593fa656c21b4e5a540a3a583
 | chronicle.queue.rollingResourceCache.size | 128 | Determines how many information elements (at most) pertaining to rolled queue files that should be held in memory at any given moment | _CACHE_SIZE_ (int)
 | chronicle.queue.warnSlowAppenderMs | 100 | Triggers warning message if an appender takes longer than default time | _WARN_SLOW_APPENDER_MS_ (int)
 | chronicle.table.store.timeoutMS | 10000 ms | The maximum time allowed when trying to acquire the exclusive table store lock | timeoutMS (long)
-| queue.dont.recover.lock.timeout | `false` | Setting this property to "yes", "true" or "" throws an exception instead of forcibly unlocking the queue | dontRecoverLockTimeout (boolean)
+| queue.force.unlock.mode | `LOCKING_PROCESS_DEAD` | See `UnlockMode` enum for allowable values |
 | queue.ignoreIndexingFailure | `false` | Setting this property to "yes", "true" or "", an exception is not thrown if the number of entries exceeds the max number for the current rollcycle | _IGNORE_INDEXING_FAILURE_ (boolean)
 | queue.check.index | `false` | Setting this property to "yes", "true" or "" returns if Chronicle Queue shall assert certain index invariants on various occasions throughout the code. Setting this property to "", "yes" or "true" will enable this feature. Enabling the feature will slow down execution if assertions (-ea) are enabled. | _CHECK_INDEX_ (boolean)
 | SingleChronicleQueueExcerpts.earlyAcquireNextCycle | `false` | Used by the pretoucher to acquire the next cycle file, but does NOT do the roll. Setting this property to "yes", "true" or "" results in acquiring the cycle file early | _EARLY_ACQUIRE_NEXT_CYCLE_ (boolean)


### PR DESCRIPTION
[Build-all](https://teamcity.chronicle.software/project/Chronicle_BuildAll?branch=feature%2Fremove-queue.dont.recover.lock.timeout&mode=builds#all-projects)