### PR TITLE
QUEUE-50 Allow ChronicleReader to continue reading beyond empty messages using MethodReader

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/MethodReaderQueueEntryReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/MethodReaderQueueEntryReader.java
@@ -61,7 +61,7 @@ public final class MethodReaderQueueEntryReader implements QueueEntryReader {
         }
         if (bytes.isEmpty()) {
             // we read something from the queue but the MR filtered it i.e. did not dispatch
-            return false;
+            return true;
         }
         messageConsumer.consume(tailer.lastReadIndex(), bytes.toString());
         bytes.clear();


### PR DESCRIPTION
Allow ChronicleReader to continue reading beyond empty messages encountered while reading through queue when using a MethodReader.