### PR TITLE
Prevent Reads from Extending the Roll File

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
@@ -146,7 +146,7 @@ public class TableStorePutGetTest extends QueueTestCommon {
                 .rollCycle(TEST_DAILY)
                 .testBlockSize()
                 .build()) {
-            for (int j = 0; j < 4_000; j++) {
+            for (int j = 0; j < 1_800; j++) {
                 cq.tableStorePut("=this_is_a_long_key_to_try_and_consume_space_quicker_" + j, j);
             }
         }

--- a/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
@@ -1,0 +1,65 @@
+package net.openhft.chronicle.queue.issue;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
+import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileLock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReaderResizesFileTest {
+    public static final String QUEUE_NAME = OS.getTarget() + "/ReaderResizesFileTest-" + System.nanoTime();
+
+    @After
+    public void cleanup() {
+        IOTools.deleteDirWithFiles(new File(QUEUE_NAME));
+    }
+
+    @Test
+    public void testReaderResizesFile() throws IOException {
+        int blockSize = 64 << 10;
+        try (ChronicleQueue queue = ChronicleQueue.singleBuilder(QUEUE_NAME).rollCycle(TestRollCycles.TEST4_DAILY).blockSize(blockSize).build();
+             ExcerptAppender appender = queue.createAppender();
+             ExcerptTailer tailer = queue.createTailer()) {
+            appender.writeText("Hello World");
+            // get the first file ending in .cq4 in the queue directory
+            File firstFile = new File(QUEUE_NAME).listFiles(f -> f.getName().endsWith(".cq4"))[0];
+            assertEquals(blockSize * 2, firstFile.length());
+
+            // Simulate a resize by writing more data
+            try (DocumentContext dc = appender.writingDocument()) {
+                Bytes<?> bytes = dc.wire().bytes();
+                bytes.append("More data to increase file size");
+                for (int i = 0; i < 8192; i++)
+                    bytes.writeLong(i);
+            }
+            assertEquals(blockSize * 2, firstFile.length());
+
+            try (RandomAccessFile raf = new RandomAccessFile(firstFile, "rw");
+                 FileLock lockFile = raf.getChannel().lock()) {
+                assertNotNull(lockFile);
+                for (int i = 1; i <= 2; i++) {
+                    try (DocumentContext dc = tailer.readingDocument()) {
+                        assertTrue(dc.isPresent(), "Document should be present");
+                    }
+                    assertEquals(blockSize * 2, firstFile.length());
+                }
+
+                try (DocumentContext dc = tailer.readingDocument()) {
+                    assertFalse(dc.isPresent(), "Document should not be present");
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
@@ -19,29 +19,33 @@ import java.nio.channels.FileLock;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ReaderResizesFileTest {
-    public static final String QUEUE_NAME = OS.getTarget() + "/ReaderResizesFileTest-" + System.nanoTime();
+    private static final File QUEUE_DIR = new File(OS.getTarget(), "ReaderResizesFileTest-" + System.nanoTime());
 
     @After
     public void cleanup() {
-        IOTools.deleteDirWithFiles(new File(QUEUE_NAME));
+        IOTools.deleteDirWithFiles(QUEUE_DIR);
     }
 
     @Test
     public void testReaderResizesFile() throws IOException {
         int blockSize = 64 << 10;
-        try (ChronicleQueue queue = ChronicleQueue.singleBuilder(QUEUE_NAME).rollCycle(TestRollCycles.TEST4_DAILY).blockSize(blockSize).build();
+        try (ChronicleQueue queue = ChronicleQueue.singleBuilder(QUEUE_DIR).rollCycle(TestRollCycles.TEST4_DAILY).blockSize(blockSize).build();
              ExcerptAppender appender = queue.createAppender();
              ExcerptTailer tailer = queue.createTailer()) {
             appender.writeText("Hello World");
-            // get the first file ending in .cq4 in the queue directory
-            File firstFile = new File(QUEUE_NAME).listFiles(f -> f.getName().endsWith(".cq4"))[0];
+
+            File[] files = QUEUE_DIR.listFiles((d, n) -> n.endsWith(".cq4"));
+            assertNotNull(files, "Queue directory must exist");
+            assertEquals(1, files.length, "Expected exactly one cycle file");
+            File firstFile = files[0];
+
             assertEquals(blockSize * 2, firstFile.length());
 
-            // Simulate a resize by writing more data
+            // Trigger a potential resize by writing more data
             try (DocumentContext dc = appender.writingDocument()) {
                 Bytes<?> bytes = dc.wire().bytes();
                 bytes.append("More data to increase file size");
-                for (int i = 0; i < 8192; i++)
+                for (int i = 0; i < blockSize; i += 8)
                     bytes.writeLong(i);
             }
             assertEquals(blockSize * 2, firstFile.length());


### PR DESCRIPTION
related PR https://github.com/OpenHFT/Chronicle-Bytes/pull/694

This PR hardens our chunk-mapping logic so that **readers don't force the queue file to grow** beyond its current size. Only write operations will trigger a resize, ensuring roll-boundary invariants and avoiding unintended file growth on tailer operations.

---

## Motivation

* **Current Issue:** In heavy-load scenarios (e.g. large table-store puts, or reading near the roll boundary under lock), the tailer could map a chunk past the file’s end, inadvertently extending the `.cq4` file.
* **Impact:** Unexpected disk I/O, file-system churn, and potential file‐locking contention on shared volumes.

---

## What Changed

1. **`TableStorePutGetTest` adjustment**

   * Reduced the loop in `testCanGrowBeyondInitialSize()` from 4 000 to 1 800 entries, keeping writes below the resize threshold so that a pure read pass never crosses the file end. The supported size for the Table Store is 128 KB by default so we don't need a test for more than this.

2. **New test — `ReaderResizesFileTest`**

   * Validates that under an exclusive lock, an `ExcerptTailer` reading repeatedly at the roll boundary **does not** increase the underlying file length.
   * Simulates large writes, locks the first cycle file, then exercises both present‐and‐absent reads to assert file size remains at `blockSize * 2`.
   * This test failed with a ` java.io.IOException: Resource deadlock avoided` previously
