### PR TITLE
Backport "Prevent Reads from Extending the Roll File" and "Avoid unsafe chunked mapped bytes in `SingleTableBuilder`" to 26

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
@@ -117,6 +117,7 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
             if (!readOnly && file.createNewFile() && !file.canWrite()) {
                 throw new IllegalStateException("Cannot write to tablestore file " + file);
             }
+            // TODO Change this to a single chunk file in x.28
             bytes = MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, readOnly);
             // these MappedBytes are shared, but the assumption is they shouldn't grow. Supports 2K entries.
             bytes.singleThreadedCheckDisabled(true);

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -256,7 +256,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             mappedBytes.writeLimit(mappedBytes.realCapacity());
             long start = mappedBytes.readPosition();
             mappedBytes.writePosition(start);
-            final long pos = mappedWire.enterHeader(128L);
+            final long pos = mappedWire.enterHeader(256L);
             final LongValue longValue = wireType.newLongReference().get();
             mappedWire.writeEventName(key).int64forBinding(defaultValue, longValue);
             mappedWire.writeAlignTo(Integer.BYTES, 0);

--- a/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
@@ -147,7 +147,7 @@ public class TableStorePutGetTest extends QueueTestCommon {
                 .rollCycle(TEST_DAILY)
                 .testBlockSize()
                 .build()) {
-            for (int j = 0; j < 4_000; j++) {
+            for (int j = 0; j < 1_800; j++) {
                 cq.tableStorePut("=this_is_a_long_key_to_try_and_consume_space_quicker_" + j, j);
             }
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
@@ -61,7 +61,7 @@ public class SingleTableStoreIntegrationTests extends QueueTestCommon {
     public void largeNumberOfKeyValuePairs() {
         finishedNormally = false;
         SingleChronicleQueue queue1 = context.newQueueInstance();
-        int count = 5_000;
+        int count = 4_000;
         for (int i = 0; i < count; i++) {
             queue1.tableStorePut("key.prefix." + i, i);
         }
@@ -74,10 +74,10 @@ public class SingleTableStoreIntegrationTests extends QueueTestCommon {
     @Test
     public void longKeyPutAndGet() {
         SingleChronicleQueue queue1 = context.newQueueInstance();
-        StringBuilder keyBuffer = new StringBuilder();
+        StringBuilder keyBuffer = new StringBuilder("AAAA");
         Random random = new Random();
-        for (int i = 0; i < 121; i++) {
-            keyBuffer.append(random.nextInt(10));
+        while(keyBuffer.length() < 100) {
+            keyBuffer.append(random.nextInt());
         }
         String key = keyBuffer.toString();
         queue1.tableStorePut(key, 1);

--- a/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
@@ -1,0 +1,69 @@
+package net.openhft.chronicle.queue.issue;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
+import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileLock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReaderResizesFileTest {
+    private static final File QUEUE_DIR = new File(OS.getTarget(), "ReaderResizesFileTest-" + System.nanoTime());
+
+    @After
+    public void cleanup() {
+        IOTools.deleteDirWithFiles(QUEUE_DIR);
+    }
+
+    @Test
+    public void testReaderResizesFile() throws IOException {
+        int blockSize = 64 << 10;
+        try (ChronicleQueue queue = ChronicleQueue.singleBuilder(QUEUE_DIR).rollCycle(TestRollCycles.TEST4_DAILY).blockSize(blockSize).build();
+             ExcerptAppender appender = queue.createAppender();
+             ExcerptTailer tailer = queue.createTailer()) {
+            appender.writeText("Hello World");
+
+            File[] files = QUEUE_DIR.listFiles((d, n) -> n.endsWith(".cq4"));
+            assertNotNull(files, "Queue directory must exist");
+            assertEquals(1, files.length, "Expected exactly one cycle file");
+            File firstFile = files[0];
+
+            assertEquals(blockSize * 2, firstFile.length());
+
+            // Trigger a potential resize by writing more data
+            try (DocumentContext dc = appender.writingDocument()) {
+                Bytes<?> bytes = dc.wire().bytes();
+                bytes.append("More data to increase file size");
+                for (int i = 0; i < blockSize; i += 8)
+                    bytes.writeLong(i);
+            }
+            assertEquals(blockSize * 2, firstFile.length());
+
+            try (RandomAccessFile raf = new RandomAccessFile(firstFile, "rw");
+                 FileLock lockFile = raf.getChannel().lock()) {
+                assertNotNull(lockFile);
+                for (int i = 1; i <= 2; i++) {
+                    try (DocumentContext dc = tailer.readingDocument()) {
+                        assertTrue(dc.isPresent(), "Document should be present");
+                    }
+                    assertEquals(blockSize * 2, firstFile.length());
+                }
+
+                try (DocumentContext dc = tailer.readingDocument()) {
+                    assertFalse(dc.isPresent(), "Document should not be present");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/OpenHFT/Chronicle-Queue/pull/1667 and https://github.com/OpenHFT/Chronicle-Queue/pull/1668 to 2.26