### PR TITLE
Add `debug.file.released` system property to toggle file release debug logging

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/StoreFileListeners.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/StoreFileListeners.java
@@ -34,9 +34,10 @@ public enum StoreFileListeners implements StoreFileListener {
         }
     },
     DEBUG {
+        final boolean DEBUG_FILE_RELEASED = Jvm.getBoolean("debug.file.released", false);
         @Override
         public void onReleased(int cycle, File file) {
-            if (Jvm.isDebugEnabled(getClass()))
+            if (DEBUG_FILE_RELEASED && Jvm.isDebugEnabled(getClass()))
                 Jvm.debug().on(getClass(), "File released " + file);
         }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/StoreFileListeners.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/StoreFileListeners.java
@@ -34,10 +34,9 @@ public enum StoreFileListeners implements StoreFileListener {
         }
     },
     DEBUG {
-        final boolean DEBUG_FILE_RELEASED = Jvm.getBoolean("debug.file.released", false);
         @Override
         public void onReleased(int cycle, File file) {
-            if (DEBUG_FILE_RELEASED && Jvm.isDebugEnabled(getClass()))
+            if (Jvm.isDebugEnabled(getClass()))
                 Jvm.debug().on(getClass(), "File released " + file);
         }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -62,6 +62,7 @@ import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueue.QUEUE
 
 public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable implements Cloneable, Builder<SingleChronicleQueue> {
     public static final long SMALL_BLOCK_SIZE = OS.isWindows() ? OS.SAFE_PAGE_SIZE : OS.pageSize(); // the smallest safe block size on Windows 8+
+    final boolean DEBUG_FILE_RELEASED = Jvm.getBoolean("debug.file.released", false);
 
     public static final long DEFAULT_SPARSE_CAPACITY = 512L << 30;
     private static final Constructor<?> ENTERPRISE_QUEUE_CONSTRUCTOR;
@@ -901,7 +902,9 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     }
 
     public StoreFileListener storeFileListener() {
-        return storeFileListener == null ? StoreFileListeners.DEBUG : storeFileListener;
+        if (storeFileListener != null)
+            return storeFileListener;
+        return DEBUG_FILE_RELEASED ? StoreFileListeners.DEBUG : StoreFileListener.NO_OP;
     }
 
     public SingleChronicleQueueBuilder sourceId(int sourceId) {


### PR DESCRIPTION
Currently, when no custom `StoreFileListener` is provided, `SingleChronicleQueueBuilder` always uses `StoreFileListeners.DEBUG`, which emits debug logs upon each file release. In test environments, these debug messages can be excessive and unnecessary. 

---

**Changes**

* Introduce a new `boolean` field in `SingleChronicleQueueBuilder`:

  ```java
  final boolean DEBUG_FILE_RELEASED = Jvm.getBoolean("debug.file.released", false);
  ```
* Modify `storeFileListener()` so that:

  * If a custom listener is set, it is always returned.
  * Otherwise, respect the `debug.file.released` system property:

    * `true` → use `StoreFileListeners.DEBUG`
    * `false` → use `StoreFileListener.NO_OP`

```diff
 public StoreFileListener storeFileListener() {
-   return storeFileListener == null ? StoreFileListeners.DEBUG : storeFileListener;
+   if (storeFileListener != null)
+       return storeFileListener;
+   return DEBUG_FILE_RELEASED
+       ? StoreFileListeners.DEBUG
+       : StoreFileListener.NO_OP;
 }
```

---

**Usage**

* **Default behavior (no logs):**
  By default, `debug.file.released` is `false`, so no debug messages are emitted on file release.

  ```bash
  java -jar myapp.jar
  ```
* **Enable debug logging on file release:**

  ```bash
  java -Ddebug.file.released -jar myapp.jar
  ```