### PR TITLE
Align tests with Windows handling of ReadOnly mode (no native support)

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
@@ -96,6 +96,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
         // Reader opens queues in read-only mode
         if (OS.isWindows())
             if (!(testName.getMethodName().equals("shouldThrowExceptionIfInputDirectoryDoesNotExist") ||
+                    testName.getMethodName().equals("shouldNotShowIndexForHistoryMessages") ||
                     testName.getMethodName().equals("shouldBeAbleToReadFromReadOnlyFile") ||
                     testName.getMethodName().equals("shouldPrintTimestampsToLocalTime") ||
                     testName.getMethodName().equals("namedTailerRequiresReadWrite") ||

--- a/src/test/java/net/openhft/chronicle/queue/issue/ChangeRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ChangeRollCycleTest.java
@@ -71,14 +71,14 @@ public class ChangeRollCycleTest {
                     // Write two messages to the queue
                     appender3.writeText("World");
 
-                    if (readOnly)
+                    if (readOnly && !OS.isWindows())
                            assertEquals("Roll cycle should match WEEKLY for read-only mode",
 RollCycles.WEEKLY, q3.rollCycle());
                 }
 
                 // If the tailer is read-only, the roll cycle cannot not be changed
                 // The read only case assumes there queue is historical and the roll cycle is fixed
-                assumeFalse(readOnly);
+                if (readOnly) return;
 
                 // Step 4: Verify the data can be read back correctly
                 assertEquals("First message should match", "Hello", tailer.readText());


### PR DESCRIPTION
Windows does not support our POSIX-style read-only semantics natively. Instead, it is simulated on a best effort basis. This PR adjusts unit tests to correctly reflect platform-specific behaviour: on Windows, we do not assert strict read-only guarantees, and we avoid roll-cycle mutations/assumptions that are only valid when true read-only is enforced—no production code changes.

## What changed

* **`ChronicleReaderTest`**

  * Expanded the Windows exception allow-list to include `shouldNotShowIndexForHistoryMessages`, so this test doesn't expect a warning

* **`ChangeRollCycleTest`**

  * Gates the read-only roll-cycle assertion behind `!OS.isWindows()`:

    ```java
    if (readOnly && !OS.isWindows()) {
        assertEquals("Roll cycle should match WEEKLY for read-only mode", RollCycles.WEEKLY, q3.rollCycle());
    }
    ```
  * Replaces `assumeFalse(readOnly)` with an early return when `readOnly` is true:

    ```java
    if (readOnly) return;
    ```

    This makes the intent explicit (do not attempt to change roll cycle in read-only scenarios) and avoids reporting an “assumption violated/skip” where the branch is not applicable on Windows.
