### PR TITLE
Cache `maxMessagesPerCycle` per `RollCycle` to cut hot-path calls

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/RollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/RollCycles.java
@@ -88,6 +88,7 @@ public enum RollCycles implements RollCycle {
     private final int lengthInMillis;
     private final int defaultEpoch;
     private final RollCycleArithmetic arithmetic;
+    private final long maxMessagesPerCycle;
 
     RollCycles(String format, int lengthInMillis, int indexCount, int indexSpacing) {
         this(format, lengthInMillis, indexCount, indexSpacing, 0);
@@ -97,6 +98,7 @@ public enum RollCycles implements RollCycle {
         this.lengthInMillis = lengthInMillis;
         this.defaultEpoch = defaultEpoch;
         this.arithmetic = RollCycleArithmetic.of(indexCount, indexSpacing);
+        maxMessagesPerCycle = arithmetic.maxMessagesPerCycle();
     }
 
     public static Iterable<RollCycle> all() {
@@ -104,7 +106,7 @@ public enum RollCycles implements RollCycle {
     }
 
     public long maxMessagesPerCycle() {
-        return arithmetic.maxMessagesPerCycle();
+        return maxMessagesPerCycle;
     }
 
     @Override


### PR DESCRIPTION
Cache a commonly accessed, per-`RollCycle` invariant—`maxMessagesPerCycle`—as a `final long` computed in the enum constructor. The public API stays the same; the method now returns the cached value.

In one benchmark this improved the p99 by around 10%

## Rationale (root cause → fix → impact)

* **Root cause:** `RollCycles.maxMessagesPerCycle()` delegated to `arithmetic.maxMessagesPerCycle()` on every call. This value is fully determined by the immutable `indexCount`/`indexSpacing` chosen for each enum constant and does not change at runtime, yet it is recalculated in hot paths (e.g. indexing and bounds checks).
* **Fix:** Introduce `private final long maxMessagesPerCycle;` and assign it once in the enum constructor from `arithmetic.maxMessagesPerCycle()`. The getter simply returns the cached field.
* **Impact:** Removes repeated method dispatch and recomputation on the hot path with **no functional change**. Tiny increase in per-enum memory (8 bytes), negligible overall.