### PR TITLE
Refresh copyright headers to 2016–2025 and tidy comment blocks (no functional changes)

### DIFF
--- a/docs/antora/supplemental_portal/js/vendor/lunr.js
+++ b/docs/antora/supplemental_portal/js/vendor/lunr.js
@@ -710,7 +710,6 @@ lunr.Pipeline.prototype.runString = function (str, metadata) {
 
 /**
  * Resets the pipeline by removing any existing processors.
- *
  */
 lunr.Pipeline.prototype.reset = function () {
   this._stack = []

--- a/docs/antora/supplemental_ui/js/vendor/lunr.js
+++ b/docs/antora/supplemental_ui/js/vendor/lunr.js
@@ -710,7 +710,6 @@ lunr.Pipeline.prototype.runString = function (str, metadata) {
 
 /**
  * Resets the pipeline by removing any existing processors.
- *
  */
 lunr.Pipeline.prototype.reset = function () {
   this._stack = []

--- a/src/main/java/net/openhft/chronicle/queue/AppenderListener.java
+++ b/src/main/java/net/openhft/chronicle/queue/AppenderListener.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/BufferMode.java
+++ b/src/main/java/net/openhft/chronicle/queue/BufferMode.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014 Higher Frequency Trading
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleReaderMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014 Higher Frequency Trading
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleWriterMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleWriterMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014 Higher Frequency Trading
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/CycleCalculator.java
+++ b/src/main/java/net/openhft/chronicle/queue/CycleCalculator.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/DefaultCycleCalculator.java
+++ b/src/main/java/net/openhft/chronicle/queue/DefaultCycleCalculator.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptCommon.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptCommon.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptTailer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/NoMessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/queue/NoMessageHistory.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/QueueSystemProperties.java
+++ b/src/main/java/net/openhft/chronicle/queue/QueueSystemProperties.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/RollCycle.java
+++ b/src/main/java/net/openhft/chronicle/queue/RollCycle.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/RollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/RollCycles.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/TailerDirection.java
+++ b/src/main/java/net/openhft/chronicle/queue/TailerDirection.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/TailerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/TailerState.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/CommonStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/CommonStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/ExcerptContext.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/ExcerptContext.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.impl;

--- a/src/main/java/net/openhft/chronicle/queue/impl/RollingChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/RollingChronicleQueue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/RollingResourcesCache.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/RollingResourcesCache.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/StoreFileListener.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/StoreFileListener.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.impl;

--- a/src/main/java/net/openhft/chronicle/queue/impl/StoreFileListeners.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/StoreFileListeners.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/WireStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/WireStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/WireStoreFactory.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/WireStoreFactory.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/WireStorePool.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/WireStorePool.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/WireStoreSupplier.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/WireStoreSupplier.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/package-info.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/package-info.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/AppendLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/AppendLock.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2024 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/AsyncBufferCreator.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/AsyncBufferCreator.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.bytes.BytesStore;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/BinarySearch.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/BinarySearch.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/DirectoryListing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/DirectoryListing.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/FileSystemDirectoryListing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/FileSystemDirectoryListing.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/IllegalIndexException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/IllegalIndexException.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import static java.lang.String.format;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/IndexNotAvailableException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/IndexNotAvailableException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/Indexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/Indexing.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.queue.impl.ExcerptContext;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/MetaDataField.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/MetaDataField.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/MetaDataKeys.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/MetaDataKeys.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/MicroToucher.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/MicroToucher.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/MissingStoreFileException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/MissingStoreFileException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/NamedTailerNotAvailableException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/NamedTailerNotAvailableException.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 public class NamedTailerNotAvailableException extends IllegalStateException {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/NoOpCondition.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/NoOpCondition.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/NotComparableException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/NotComparableException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/NotReachedException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/NotReachedException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/PrecreatedFiles.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/PrecreatedFiles.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/Pretoucher.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/Pretoucher.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ReadOnlyWriteLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ReadOnlyWriteLock.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCache.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCache.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/RollCycleEncodeSequence.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/RollCycleEncodeSequence.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.impl.single;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQMeta.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQMeta.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQRoll.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQRoll.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.impl.single;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQTools.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQTools.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ScanResult.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ScanResult.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListing.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingReadOnly.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingReadOnly.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLock.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ThreadLocalAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ThreadLocalAppender.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.queue.ChronicleQueue;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/WriteLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/WriteLock.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/namedtailer/IndexUpdater.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/namedtailer/IndexUpdater.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single.namedtailer;
 
 import net.openhft.chronicle.core.values.LongValue;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/namedtailer/IndexUpdaterFactory.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/namedtailer/IndexUpdaterFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single.namedtailer;
 
 import net.openhft.chronicle.core.values.LongValue;

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/AbstractTSQueueLock.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/AbstractTSQueueLock.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/Metadata.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/Metadata.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/ReadonlyTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/ReadonlyTableStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/TableStoreIterator.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/TableStoreIterator.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/UnlockMode.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/UnlockMode.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/AnalyticsHolder.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/AnalyticsHolder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpec.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpec.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/domestic/package-info.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/domestic/package-info.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/main/InternalBenchmarkMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/main/InternalBenchmarkMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/main/InternalDumpMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/main/InternalDumpMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 http://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/main/InternalPingPongMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/main/InternalPingPongMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/main/InternalRemovableRollFileCandidatesMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/main/InternalRemovableRollFileCandidatesMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/main/InternalUnlockMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/main/InternalUnlockMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/package-info.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/reader/InternalDummyMethodReaderQueueEntryHandler.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/reader/InternalDummyMethodReaderQueueEntryHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/reader/InternalMessageToTextQueueEntryHandler.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/reader/InternalMessageToTextQueueEntryHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/reader/MessageCountingMessageConsumer.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/reader/MessageCountingMessageConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/reader/PatternFilterMessageConsumer.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/reader/PatternFilterMessageConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/AbstractTailerPollingQueueEntryReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/AbstractTailerPollingQueueEntryReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/CustomPluginQueueEntryReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/CustomPluginQueueEntryReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/MethodReaderQueueEntryReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/MethodReaderQueueEntryReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/VanillaQueueEntryReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/reader/queueentryreaders/VanillaQueueEntryReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/util/InternalFileUtil.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/util/InternalFileUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriter.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriter.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014 Higher Frequency Trading
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/main/BenchmarkMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/BenchmarkMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/main/DumpMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/DumpMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 http://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/main/HistoryMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/HistoryMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014 Higher Frequency Trading
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +27,6 @@ import org.jetbrains.annotations.NotNull;
  * </ul>
  *
  * @author Jerry Shea
- *
  */
 public final class HistoryMain {
 

--- a/src/main/java/net/openhft/chronicle/queue/main/PingPongMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/PingPongMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/main/ReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/ReaderMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014 Higher Frequency Trading
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Display records in a queue in a text form.
- *
  */
 public final class ReaderMain {
 

--- a/src/main/java/net/openhft/chronicle/queue/main/RefreshMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/RefreshMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/main/RemovableRollFileCandidatesMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/RemovableRollFileCandidatesMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/main/UnlockMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/UnlockMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/main/package-info.java
+++ b/src/main/java/net/openhft/chronicle/queue/main/package-info.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/package-info.java
+++ b/src/main/java/net/openhft/chronicle/queue/package-info.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/ChronicleHistoryReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/ChronicleHistoryReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/ChronicleReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/ChronicleReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014 Higher Frequency Trading
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/ChronicleReaderPlugin.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/ChronicleReaderPlugin.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/ContentBasedLimiter.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/ContentBasedLimiter.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/HistoryReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/HistoryReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/MessageConsumer.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/MessageConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/QueueEntryHandler.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/QueueEntryHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/QueueEntryReader.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/QueueEntryReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/Reader.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/Reader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014 Higher Frequency Trading
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/reader/comparator/BinarySearchComparator.java
+++ b/src/main/java/net/openhft/chronicle/queue/reader/comparator/BinarySearchComparator.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/rollcycles/LargeRollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/rollcycles/LargeRollCycles.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.rollcycles;
 
 import net.openhft.chronicle.queue.RollCycle;

--- a/src/main/java/net/openhft/chronicle/queue/rollcycles/LegacyRollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/rollcycles/LegacyRollCycles.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.rollcycles;
 
 import net.openhft.chronicle.queue.RollCycle;

--- a/src/main/java/net/openhft/chronicle/queue/rollcycles/RollCycleArithmetic.java
+++ b/src/main/java/net/openhft/chronicle/queue/rollcycles/RollCycleArithmetic.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.rollcycles;
 
 import net.openhft.chronicle.core.Maths;

--- a/src/main/java/net/openhft/chronicle/queue/rollcycles/SparseRollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/rollcycles/SparseRollCycles.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.rollcycles;
 
 import net.openhft.chronicle.queue.RollCycle;

--- a/src/main/java/net/openhft/chronicle/queue/rollcycles/TestRollCycles.java
+++ b/src/main/java/net/openhft/chronicle/queue/rollcycles/TestRollCycles.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.rollcycles;
 
 import net.openhft.chronicle.queue.RollCycle;

--- a/src/main/java/net/openhft/chronicle/queue/util/FileState.java
+++ b/src/main/java/net/openhft/chronicle/queue/util/FileState.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/util/FileUtil.java
+++ b/src/main/java/net/openhft/chronicle/queue/util/FileUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/util/MicroTouched.java
+++ b/src/main/java/net/openhft/chronicle/queue/util/MicroTouched.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/util/PretouchUtil.java
+++ b/src/main/java/net/openhft/chronicle/queue/util/PretouchUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/util/PretoucherFactory.java
+++ b/src/main/java/net/openhft/chronicle/queue/util/PretoucherFactory.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/queue/util/ToolsUtil.java
+++ b/src/main/java/net/openhft/chronicle/queue/util/ToolsUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/AcquireReleaseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/AcquireReleaseTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/AppenderListenerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/AppenderListenerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/CheckHalfWrittenMsgNotSeenByTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CheckHalfWrittenMsgNotSeenByTailerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleAppenderCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleAppenderCycleTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueLatencyDistribution.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueLatencyDistribution.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMethodsWithoutParametersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMethodsWithoutParametersTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMicrobench.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMicrobench.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleRollingIssueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleRollingIssueTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue;

--- a/src/test/java/net/openhft/chronicle/queue/ChunkCountTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChunkCountTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue;

--- a/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/DirectoryUtils.java
+++ b/src/test/java/net/openhft/chronicle/queue/DirectoryUtils.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.queue;

--- a/src/test/java/net/openhft/chronicle/queue/DiskSpaceMonitoringIntegrationTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DiskSpaceMonitoringIntegrationTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.io.IOTools;

--- a/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/DumpQueueMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DumpQueueMainTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/HugetlbfsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/HugetlbfsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.io.IOTools;

--- a/src/test/java/net/openhft/chronicle/queue/IgnoreMethodBasedOnFirstArgTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/IgnoreMethodBasedOnFirstArgTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/IncompleteMessageTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/IncompleteMessageTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/LATMsg.java
+++ b/src/test/java/net/openhft/chronicle/queue/LATMsg.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/LastAcknowledgedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LastAcknowledgedTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/LastIndexAppendedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LastIndexAppendedTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue;

--- a/src/test/java/net/openhft/chronicle/queue/LatinCharTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LatinCharTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/LongRunTestMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/LongRunTestMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/MappedFileSafeLimitTooSmallTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MappedFileSafeLimitTooSmallTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/MarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MarshallableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/MessageReaderWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MessageReaderWriterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/MoveIndexAfterFailedTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveIndexAfterFailedTailerTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue;

--- a/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.Jvm;

--- a/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/NoDataIsSkippedWithInterruptTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/NoDataIsSkippedWithInterruptTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/OvertakeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/OvertakeTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ProxyTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/QueueAppendAfterRollReplayedIssueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueAppendAfterRollReplayedIssueTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/QueueReadBackwardsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueReadBackwardsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/QueueReadForwardSkippingACycleBiggerThanADayTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueReadForwardSkippingACycleBiggerThanADayTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/QueueWriteDocumentContextTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueWriteDocumentContextTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue;

--- a/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ReadOneBackwardsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadOneBackwardsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.bytes.MethodReader;

--- a/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ReadmeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadmeTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/RollCyclesDistinctnessTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCyclesDistinctnessTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue;
 
 import org.junit.Test;

--- a/src/test/java/net/openhft/chronicle/queue/RollCyclesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCyclesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/RunLargeQueueMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/RunLargeQueueMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/Stackoveflow52274284Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/Stackoveflow52274284Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/StoreTailerNotReachedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/StoreTailerNotReachedTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/StridingAQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/StridingAQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.queue;

--- a/src/test/java/net/openhft/chronicle/queue/SurefireInterruptFlagTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/SurefireInterruptFlagTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/TailerCloseInParallelTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerCloseInParallelTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/TestAppenderThreadSafe.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestAppenderThreadSafe.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/TestCallingToEndOnRoll.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestCallingToEndOnRoll.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/TestKey.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestKey.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ToEndPaddingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ToEndPaddingTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 Chronicle Software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ValueStringArray.java
+++ b/src/test/java/net/openhft/chronicle/queue/ValueStringArray.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/ValueStringArrayTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ValueStringArrayTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/VisibilityOfMessagesBetweenTailorsAndAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/VisibilityOfMessagesBetweenTailorsAndAppenderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/WeeklyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WeeklyRollCycleTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.OS;

--- a/src/test/java/net/openhft/chronicle/queue/WriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WriteBytesTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue;

--- a/src/test/java/net/openhft/chronicle/queue/WriteReadTextTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WriteReadTextTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue;

--- a/src/test/java/net/openhft/chronicle/queue/bench/BenchmarkUtils.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/BenchmarkUtils.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/bench/ByteArrayJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/ByteArrayJLBHBenchmark.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/bench/InternalAppenderJLBH.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/InternalAppenderJLBH.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.bench;
 
 import net.openhft.chronicle.bytes.Bytes;

--- a/src/test/java/net/openhft/chronicle/queue/bench/MethodReaderBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/MethodReaderBenchmark.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/bench/MethodReaderSkipBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/MethodReaderSkipBenchmark.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueContendedWritesJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueContendedWritesJLBHBenchmark.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueLargeMessageJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueLargeMessageJLBHBenchmark.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueSingleThreadedJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueSingleThreadedJLBHBenchmark.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/bench/ThroughputPerfMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/ThroughputPerfMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/cleanup/OnReleaseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/cleanup/OnReleaseTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/example/QueueExamples1.java
+++ b/src/test/java/net/openhft/chronicle/queue/example/QueueExamples1.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/example/QueueExamples2.java
+++ b/src/test/java/net/openhft/chronicle/queue/example/QueueExamples2.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/harness/WeeklyRollCycle.java
+++ b/src/test/java/net/openhft/chronicle/queue/harness/WeeklyRollCycle.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +16,7 @@
 
 package net.openhft.chronicle.queue.harness;
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingChronicleQueueTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CheckIndicesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CheckIndicesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ConcurrentAppendersOutOfSpaceMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ConcurrentAppendersOutOfSpaceMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 Chronicle Software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.io.IOTools;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.Jvm;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EofMarkerOnEmptyQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EofMarkerOnEmptyQueueTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ExcerptsSkippedWhenTailerDirectionNoneTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ExcerptsSkippedWhenTailerDirectionNoneTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/FileModificationTimeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/FileModificationTimeTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/HelloWorld.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/HelloWorld.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexOffsetTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexOffsetTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2015 Higher Frequency Trading
- *
- *       https://chronicle.software
+ * Copyright 2015-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingLastSequenceNumberTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingLastSequenceNumberTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.queue.impl.ExcerptContext;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingMoveToCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingMoveToCycleTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingMoveToIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingMoveToIndexTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingSpacingAndCountTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingSpacingAndCountTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.io.Closeable;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingToEndTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.queue.TailerDirection;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/InternalAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/InternalAppenderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MappedMemoryUnmappingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MappedMemoryUnmappingTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MetadataDeletionTests.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MetadataDeletionTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.OS;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MicroToucherTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MicroToucherTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToIndexTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToWrongIndexThenToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToWrongIndexThenToEndTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.Jvm;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/OnEvents.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/OnEvents.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.Jvm;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/QueueEpochTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/QueueEpochTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/QueueLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/QueueLockTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.Jvm;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RestartableTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RestartableTailerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollAtEndOfCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollAtEndOfCycleTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleEncodeSequenceTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleEncodeSequenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.impl.single;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SCQMsg.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SCQMsg.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCloseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCloseTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderDoubleBufferTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderDoubleBufferTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StuckQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StuckQueueTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerIndexingQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerIndexingQueueTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerPollingEmptyQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerPollingEmptyQueueTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerSequenceRaceConditionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerSequenceRaceConditionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndInvalidIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndInvalidIndexTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.bytes.Bytes;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue28Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue28Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue36Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue36Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressDoubleBufferTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressDoubleBufferTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchEATest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchEATest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressReadOnlyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressReadOnlyTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressSharedWriterQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressSharedWriterQueueTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerBoundaryTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single.stress.backwardstailer;
 
 import net.openhft.chronicle.core.io.IOTools;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerJmhState.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerJmhState.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single.stress.backwardstailer;
 
 import net.openhft.chronicle.core.OS;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndBoundaryJmhBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndBoundaryJmhBenchmark.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single.stress.backwardstailer;
 
 import net.openhft.chronicle.queue.RollCycle;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndBoundaryJmhBenchmarkEndSpacingMinusOne.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndBoundaryJmhBenchmarkEndSpacingMinusOne.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single.stress.backwardstailer;
 
 import net.openhft.chronicle.queue.RollCycle;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndPerfAcceptanceTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndPerfAcceptanceTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single.stress.backwardstailer;
 
 import net.openhft.chronicle.core.io.IOTools;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/LargeCycleFileToEndPerfMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/LargeCycleFileToEndPerfMain.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.single.stress.backwardstailer;
 
 import net.openhft.chronicle.bytes.Bytes;

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.impl.table;
 
 import net.openhft.chronicle.core.io.IOTools;

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.internal.reader;

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/FieldlessMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/FieldlessMethodReaderTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.internal.reader;
 
 import net.openhft.chronicle.bytes.MethodReader;

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 Chronicle Software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/Say.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/Say.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/SayWhen.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/SayWhen.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/TimestampComparator.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/TimestampComparator.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/issue/ChangeRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ChangeRollCycleTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.issue;
 
 import net.openhft.chronicle.core.OS;

--- a/src/test/java/net/openhft/chronicle/queue/issue/DeleteFileTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/DeleteFileTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.issue;
 
 import net.openhft.chronicle.core.OS;

--- a/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.issue;
 
 import net.openhft.chronicle.bytes.Bytes;

--- a/src/test/java/net/openhft/chronicle/queue/issue/TailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/TailerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/jitter/BareSyncTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/jitter/BareSyncTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/jitter/QueueReadJitterMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/jitter/QueueReadJitterMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/jitter/QueueWriteJitterMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/jitter/QueueWriteJitterMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/method/BrokenChainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/method/BrokenChainTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.method;
 
 import net.openhft.chronicle.bytes.MethodReader;

--- a/src/test/java/net/openhft/chronicle/queue/micros/MarketDataListener.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/MarketDataListener.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/Order.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/Order.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderIdea.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderIdea.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderIdeaListener.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderIdeaListener.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderListener.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderListener.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderManager.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderManager.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/Side.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/Side.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/SidedMarketDataCombiner.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/SidedMarketDataCombiner.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/SidedMarketDataListener.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/SidedMarketDataListener.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/SidedPrice.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/SidedPrice.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/micros/TopOfBookPrice.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/TopOfBookPrice.java
@@ -1,8 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.micros;

--- a/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerPreconditionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerPreconditionTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.namedtailer;
 
 import net.openhft.chronicle.core.io.IOTools;

--- a/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerVersioningTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerVersioningTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.namedtailer;
 
 import net.openhft.chronicle.bytes.PageUtil;

--- a/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/queue/util/HugetlbfsTestUtil.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/HugetlbfsTestUtil.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.util;
 
 import net.openhft.chronicle.bytes.PageUtil;

--- a/src/test/java/net/openhft/chronicle/queue/util/RollCyclesAsciiDocGeneratingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/RollCyclesAsciiDocGeneratingTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ */
+
 package net.openhft.chronicle.queue.util;
 
 import net.openhft.chronicle.core.Jvm;

--- a/src/test/java/net/openhft/chronicle/queue/util/StackSampler.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/StackSampler.java
@@ -1,10 +1,8 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
- *       https://chronicle.software
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -14,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package net.openhft.chronicle.queue.util;

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,8 +1,6 @@
 #
 # Copyright 2016-2022 chronicle.software
 #
-#       https://chronicle.software
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/system.properties
+++ b/system.properties
@@ -1,8 +1,6 @@
 #
 # Copyright 2016-2022 chronicle.software
 #
-#       https://chronicle.software
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
This PR standardizes copyright headers across the codebase and tidies a few comment blocks. It also removes obsolete URL lines from headers. There are **no behavior or API changes**.

## What changed

* **Headers updated** to `2016–2025 chronicle.software` (or `2014–2025` / `2015–2025` where historically applicable) across:

  * `src/main/java/**` (queue core, impl, single, internal, readers/writers, rollcycles, utils, etc.)
  * `src/test/java/**` and related test harness packages
  * Resource/property files (`src/test/resources/simplelogger.properties`, `system.properties`)
* **Obsolete URL lines** (`https://chronicle.software` or older domains) removed from header blocks.
* **License block formatting** normalized:

  * Consistent “Licensed under the Apache License, Version 2.0 …” lines (removed stray leading spaces).
  * Removed trailing empty `*` lines within headers.
  * Minor Javadoc cleanups (removed stray `*` lines in a few class headers and Javadocs).
* **Vendor doc comments**: in the two vendored `lunr.js` copies, removed a superfluous blank `*` line in the `reset` method’s docblock to appease linters.

## Functional impact

**None.** All code changes are within comments or documentation blocks only. The two `lunr.js` edits are comment-only. No JavaScript or Java logic was modified.

## Why this is useful

* Keeps legal notices current and consistent for 2025.
* Reduces header drift and lint noise (cleaner comment/Javadoc formatting).
* Removes stale domains from headers.

## Risks & compatibility

* **Low risk**: build/runtime behavior unchanged.
* CI and tests should remain unchanged.