### PR TITLE
Unordered calls to close() correctly on a SingleTableStore and it's resources in the Finalizer

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -229,7 +229,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
     @Override
     protected void performClose() {
-        mappedBytes.releaseLast();
+        mappedBytes.close();
     }
 
     /**
@@ -250,14 +250,6 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                 "wireType=" + wireType +
                 ", mappedFile=" + mappedFile +
                 '}';
-    }
-
-    // *************************************************************************
-    // Marshalling
-    // *************************************************************************
-
-    private void onCleanup() {
-        mappedBytes.releaseLast();
     }
 
     /**


### PR DESCRIPTION
`SingleTableStore` previously called `mappedBytes.releaseLast()` during shutdown, which is *by design* a one-shot operation. In real use, `close()` can be invoked multiple times and even concurrently (e.g., application shutdown + finalizer), causing a second `releaseLast()` to throw `ClosedIllegalStateException`. This PR replaces `releaseLast()` with `close()` and removes a redundant cleanup path so shutdown is idempotent and safe under multiple `close()` calls.

## Root cause

* `performClose()` called `mappedBytes.releaseLast()`.
* A separate `onCleanup()` method also called `releaseLast()`.
* `close()` can be called more than once (and from different threads), but `releaseLast()` is only valid once. Re-entering shutdown attempted a second `releaseLast()`, triggering:

```
ClosedIllegalStateException: ... ChunkedMappedBytes already released INIT location
  at ... TracingReferenceCounted.releaseLast(...)
```

(See stack trace in the issue description.)

## The fix

* Replace `mappedBytes.releaseLast()` with `mappedBytes.close()` inside `performClose()`.
* Remove the unused/duplicated `onCleanup()` that also called `releaseLast()`.
* Rationale: `close()` is idempotent and safe for repeated calls; it encapsulates the correct reference-count/cleanup semantics without double-release.

### Diff (high level)

* `SingleTableStore.performClose()`:

  * `mappedBytes.releaseLast();` → `mappedBytes.close();`
* Remove `onCleanup()` method that invoked `releaseLast()`.

## Behavioural changes

* Repeated or concurrent calls to `SingleTableStore.close()` no longer surface `ClosedIllegalStateException` due to a double `releaseLast()`.
* No change to steady-state performance or normal I/O behaviour; only shutdown semantics are affected.

## Risk and compatibility

* **Low risk**: `close()` is the intended idempotent shutdown API for `ReferenceCounted` resources, whereas `releaseLast()` is a single-use terminal release.
* Removing `onCleanup()` eliminates a redundant path that could double-release; no external API change.
* Applies only to shutdown; runtime read/write paths are untouched.

## Motivation (stack trace excerpt)

The change addresses repeated errors like:

```
WARN SingleTableStore - Error occurred in close method
ClosedIllegalStateException: ... ChunkedMappedBytes already released INIT location
  at ... TracingReferenceCounted.releaseLast(...)
  at ... SingleTableStore.performClose(SingleTableStore.java:232)
  ...
Caused by: StackTrace: ChunkedMappedBytes@20 Finalizer release INIT on Finalizer
```
