### PR TITLE
Test hygiene: tighten visibility, encapsulate helpers, and quiet static-analysis noise (no functional changes)

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
@@ -91,7 +91,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
         }
     }
 
-    protected boolean hasEOFAtEndOfFile(final File file) {
+    private boolean hasEOFAtEndOfFile(final File file) {
 
         try (ChronicleQueue queue123 = SingleChronicleQueueBuilder.builder()
                 .path(file).build()) {

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueLatencyDistribution.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueLatencyDistribution.java
@@ -101,7 +101,7 @@ public class ChronicleQueueLatencyDistribution extends QueueTestCommon {
         new ChronicleQueueLatencyDistribution().run(args);
     }
 
-    private void run(String[] args) throws Exception {
+    protected void run(String[] args) throws Exception {
         // use CQ dir in current directory, not tmp as that is often tmpfs
         final File tmpDir = new File(this.getClass().getSimpleName() + "_" + System.currentTimeMillis());
         tmpDir.deleteOnExit();
@@ -114,7 +114,7 @@ public class ChronicleQueueLatencyDistribution extends QueueTestCommon {
         }
     }
 
-    private void runTest(@NotNull ChronicleQueue queue, int throughput) throws InterruptedException {
+    protected void runTest(@NotNull ChronicleQueue queue, int throughput) throws InterruptedException {
 /*
         Jvm.setExceptionHandlers(PrintExceptionHandler.ERR,
                 PrintExceptionHandler.OUT,

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueLatencyDistribution.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueLatencyDistribution.java
@@ -101,7 +101,7 @@ public class ChronicleQueueLatencyDistribution extends QueueTestCommon {
         new ChronicleQueueLatencyDistribution().run(args);
     }
 
-    public void run(String[] args) throws Exception {
+    private void run(String[] args) throws Exception {
         // use CQ dir in current directory, not tmp as that is often tmpfs
         final File tmpDir = new File(this.getClass().getSimpleName() + "_" + System.currentTimeMillis());
         tmpDir.deleteOnExit();
@@ -114,7 +114,7 @@ public class ChronicleQueueLatencyDistribution extends QueueTestCommon {
         }
     }
 
-    protected void runTest(@NotNull ChronicleQueue queue, int throughput) throws InterruptedException {
+    private void runTest(@NotNull ChronicleQueue queue, int throughput) throws InterruptedException {
 /*
         Jvm.setExceptionHandlers(PrintExceptionHandler.ERR,
                 PrintExceptionHandler.OUT,

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMethodsWithoutParametersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMethodsWithoutParametersTest.java
@@ -44,7 +44,7 @@ public class ChronicleQueueMethodsWithoutParametersTest extends QueueTestCommon 
         }
     }
 
-    public interface SomeListener {
+    interface SomeListener {
 
         void methodWithoutParams();
 
@@ -53,8 +53,8 @@ public class ChronicleQueueMethodsWithoutParametersTest extends QueueTestCommon 
 
     public static class SomeManager implements SomeListener {
 
-        public boolean methodWithoutParamsInvoked = false;
-        public boolean methodWithOneParamInvoked = false;
+        boolean methodWithoutParamsInvoked = false;
+        boolean methodWithOneParamInvoked = false;
 
         @Override
         public void methodWithoutParams() {

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("deprecation")
 public class ChronicleQueueTest extends QueueTestCommon {
 
-    static final String PATH_NAME = OS.getTarget() + "/test-path";
+    private static final String PATH_NAME = OS.getTarget() + "/test-path";
 
     @AfterClass
     public static void cleanup() {

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
@@ -38,7 +38,7 @@ public class ChronicleQueueTwoThreadsTest extends QueueTestCommon {
         doTest(false);
     }
 
-    void doTest(boolean buffered) throws InterruptedException {
+    private void doTest(boolean buffered) throws InterruptedException {
         File name = getTmpDir();
 
         AtomicLong counter = new AtomicLong();

--- a/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
@@ -181,7 +181,7 @@ public class ContendedWriterTest extends QueueTestCommon {
     private class StartAndMonitor {
         Histogram histo = new Histogram();
 
-        public StartAndMonitor(ChronicleQueue queue, String name, int writePauseMs, int sleepBetweenMillis) {
+        StartAndMonitor(ChronicleQueue queue, String name, int writePauseMs, int sleepBetweenMillis) {
             final SlowToSerialiseAndDeserialise object = new SlowToSerialiseAndDeserialise(writePauseMs);
             Thread thread = new Thread(() -> {
                 try (final ExcerptAppender appender = queue.createAppender()) {

--- a/src/test/java/net/openhft/chronicle/queue/DirectoryUtils.java
+++ b/src/test/java/net/openhft/chronicle/queue/DirectoryUtils.java
@@ -39,7 +39,7 @@ public class DirectoryUtils {
         return tmpDir;
     }
 
-    public static String uniqueId() {
+    private static String uniqueId() {
         long l;
         try {
             l = MappedUniqueTimeProvider.INSTANCE.currentTimeMicros();

--- a/src/test/java/net/openhft/chronicle/queue/DiskSpaceMonitoringIntegrationTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DiskSpaceMonitoringIntegrationTest.java
@@ -33,7 +33,7 @@ class DiskSpaceMonitoringIntegrationTest extends QueueTestCommon {
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void beforeEach() throws NoSuchFieldException, IllegalAccessException {
+    void beforeEach() throws NoSuchFieldException, IllegalAccessException {
         Field fileStoreCacheMap = DiskSpaceMonitor.class.getDeclaredField("fileStoreCacheMap");
         fileStoreCacheMap.setAccessible(true);
         monitoredPaths = (Map<String, FileStore>) fileStoreCacheMap.get(DiskSpaceMonitor.INSTANCE);

--- a/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
@@ -74,7 +74,7 @@ public class DtoBytesMarshallableTest extends QueueTestCommon {
         }
     }
 
-    public static class DtoBytesMarshallable extends BytesInBinaryMarshallable {
+    static class DtoBytesMarshallable extends BytesInBinaryMarshallable {
 
         StringBuilder name = new StringBuilder();
         int age;
@@ -91,7 +91,7 @@ public class DtoBytesMarshallableTest extends QueueTestCommon {
         }
     }
 
-    public static class DtoAbstractMarshallable extends SelfDescribingMarshallable {
+    static class DtoAbstractMarshallable extends SelfDescribingMarshallable {
         StringBuilder name = new StringBuilder();
         int age;
 

--- a/src/test/java/net/openhft/chronicle/queue/ExcerptAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ExcerptAppenderTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.*;
  */
 public class ExcerptAppenderTest extends QueueTestCommon {
 
-    static final String TEST_QUEUE = OS.getTarget() + "/ExcerptAppenderTest";
+    private static final String TEST_QUEUE = OS.getTarget() + "/ExcerptAppenderTest";
 
     class ExcerptAppenderImpl implements ExcerptAppender {
 

--- a/src/test/java/net/openhft/chronicle/queue/ExcerptCommonTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ExcerptCommonTest.java
@@ -16,14 +16,14 @@ import static org.junit.Assert.assertNull;
  */
 public class ExcerptCommonTest extends QueueTestCommon {
 
-    static final String TEST_QUEUE = OS.getTarget() + "/ExcerptCommonTest";
+    private static final String TEST_QUEUE = OS.getTarget() + "/ExcerptCommonTest";
 
     class ExcerptCommonImpl implements ExcerptCommon<ExcerptCommonImpl> {
         private final int sourceId;
         private final ChronicleQueue queue;
         private final File currentFile;
 
-        public ExcerptCommonImpl(int sourceId, ChronicleQueue queue, File currentFile) {
+        ExcerptCommonImpl(int sourceId, ChronicleQueue queue, File currentFile) {
             this.sourceId = sourceId;
             this.queue = queue;
             this.currentFile = currentFile;

--- a/src/test/java/net/openhft/chronicle/queue/LongRunTestMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/LongRunTestMain.java
@@ -54,43 +54,43 @@ public class LongRunTestMain {
         private long posixTimestamp;
         private CharSequence message;
 
-        public long getSessionId() {
+        long getSessionId() {
             return sessionId;
         }
 
-        public void setSessionId(long sessionId) {
+        void setSessionId(long sessionId) {
             this.sessionId = sessionId;
         }
 
-        public int getLogLevel() {
+        int getLogLevel() {
             return logLevel;
         }
 
-        public void setLogLevel(int logLevel) {
+        void setLogLevel(int logLevel) {
             this.logLevel = logLevel;
         }
 
-        public int getSecurityLevel() {
+        int getSecurityLevel() {
             return securityLevel;
         }
 
-        public void setSecurityLevel(int securityLevel) {
+        void setSecurityLevel(int securityLevel) {
             this.securityLevel = securityLevel;
         }
 
-        public long getPosixTimestamp() {
+        long getPosixTimestamp() {
             return posixTimestamp;
         }
 
-        public void setPosixTimestamp(long posixTimestamp) {
+        void setPosixTimestamp(long posixTimestamp) {
             this.posixTimestamp = posixTimestamp;
         }
 
-        public CharSequence getMessage() {
+        CharSequence getMessage() {
             return message;
         }
 
-        public void setMessage(CharSequence message) {
+        void setMessage(CharSequence message) {
             this.message = message;
         }
     }
@@ -103,7 +103,7 @@ public class LongRunTestMain {
             this.maxMessageSize = maxMessageSize;
         }
 
-        public void setMarshallable(final TLogEntry logEntry) {
+        void setMarshallable(final TLogEntry logEntry) {
             this.logEntry = logEntry;
         }
 

--- a/src/test/java/net/openhft/chronicle/queue/ProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ProxyTest.java
@@ -83,11 +83,11 @@ public class ProxyTest extends QueueTestCommon {
                 "}\n", result.toString());
     }
 
-    public interface TestMessageListener {
+    interface TestMessageListener {
         void onMessage(ProxyTest.Message message);
     }
 
-    public static class Message extends SelfDescribingMarshallable {
+    static class Message extends SelfDescribingMarshallable {
 
         private final StringBuilder message = new StringBuilder();
 

--- a/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
@@ -5,11 +5,11 @@ package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
-import net.openhft.chronicle.core.internal.JvmExceptionTracker;
 import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.AbstractReferenceCounted;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.onoes.ExceptionKey;
+import net.openhft.chronicle.core.onoes.LogLevel;
 import net.openhft.chronicle.core.threads.CleaningThread;
 import net.openhft.chronicle.core.threads.ThreadDump;
 import net.openhft.chronicle.core.time.SystemTimeProvider;
@@ -31,9 +31,12 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static net.openhft.chronicle.core.onoes.LogLevel.DEBUG;
+import static net.openhft.chronicle.core.onoes.LogLevel.PERF;
 import static org.junit.Assert.fail;
 
 public class QueueTestCommon {
+    private static final Set<LogLevel> IGNORED_LOG_LEVELS = EnumSet.of(DEBUG, PERF);
     private static final boolean TRACE_TEST_EXECUTION = Jvm.getBoolean("queue.traceTestExecution");
     private final List<File> tmpDirs = new ArrayList<>();
 
@@ -149,7 +152,15 @@ public class QueueTestCommon {
 
     @Before
     public void recordExceptions() {
-        exceptionTracker = JvmExceptionTracker.create(false);
+        Map<ExceptionKey, Integer> recordedExceptions = Jvm.recordExceptions(false);
+        exceptionTracker = ExceptionTracker.create(
+                ExceptionKey::message,
+                ExceptionKey::throwable,
+                Jvm::resetExceptionHandlers,
+                recordedExceptions,
+                key -> IGNORED_LOG_LEVELS.contains(key.level()),
+                key -> key.level() + " " + key.clazz().getSimpleName() + " " + key.message()
+        );
         if (OS.isWindows())
             ignoreException("Read-only mode is not supported on Windows® platforms, defaulting to read/write");
         for (String msg : Arrays.asList(

--- a/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
@@ -37,7 +37,7 @@ public class QueueTestCommon {
     private static final boolean TRACE_TEST_EXECUTION = Jvm.getBoolean("queue.traceTestExecution");
     private final List<File> tmpDirs = new ArrayList<>();
 
-    protected ThreadDump threadDump;
+    private ThreadDump threadDump;
     protected boolean finishedNormally;
     protected ExceptionTracker<ExceptionKey> exceptionTracker;
 
@@ -76,7 +76,7 @@ public class QueueTestCommon {
     // *************************************************************************
     //
     // *************************************************************************
-    static AtomicLong counter = new AtomicLong();
+    private static AtomicLong counter = new AtomicLong();
     private Set<String> targetAllowList;
     private long freeSpace;
 
@@ -142,7 +142,7 @@ public class QueueTestCommon {
         threadDump = new ThreadDump();
     }
 
-    public void checkThreadDump() {
+    private void checkThreadDump() {
         if (threadDump != null)
             threadDump.assertNoNewThreads();
     }
@@ -167,15 +167,15 @@ public class QueueTestCommon {
         }
     }
 
-    public void ignoreException(String message) {
+    protected void ignoreException(String message) {
         exceptionTracker.ignoreException(message);
     }
 
-    public void expectException(String message) {
+    protected void expectException(String message) {
         exceptionTracker.expectException(message);
     }
 
-    public void ignoreException(Predicate<ExceptionKey> predicate, String description) {
+    protected void ignoreException(Predicate<ExceptionKey> predicate, String description) {
         exceptionTracker.ignoreException(predicate, description);
     }
 
@@ -183,7 +183,7 @@ public class QueueTestCommon {
         exceptionTracker.expectException(predicate, description);
     }
 
-    public void checkExceptions() {
+    private void checkExceptions() {
         exceptionTracker.checkExceptions();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/QueueWriteDocumentContextTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueWriteDocumentContextTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 public class QueueWriteDocumentContextTest extends QueueTestCommon {
 
-    static void writeThreeKeys(MarshallableOut wire) {
+    private static void writeThreeKeys(MarshallableOut wire) {
         try (DocumentContext dc0 = wire.acquireWritingDocument(false)) {
             for (int i = 0; i < 3; i++) {
                 try (DocumentContext dc = wire.acquireWritingDocument(false)) {
@@ -33,7 +33,7 @@ public class QueueWriteDocumentContextTest extends QueueTestCommon {
         }
     }
 
-    static void writeThreeChainedKeys(MarshallableOut wire) {
+    private static void writeThreeChainedKeys(MarshallableOut wire) {
         for (int i = 0; i < 3; i++) {
             try (WriteDocumentContext dc = (WriteDocumentContext) wire.acquireWritingDocument(false)) {
                 dc.wire().write("key").int32(i);
@@ -204,7 +204,7 @@ public class QueueWriteDocumentContextTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected SingleChronicleQueue createQueue(String s) {
+    private SingleChronicleQueue createQueue(String s) {
         final SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.binary(tempDir(s))
                 .rollCycle(TEST_DAILY)
                 .timeProvider(new SetTimeProvider("2020/10/19T01:01:01"))

--- a/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
@@ -132,7 +132,7 @@ public class RareAppenderLatencyTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected String getText() {
+    private String getText() {
         final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < 10; i++) sb.append(UUID.randomUUID());
         return sb.toString();

--- a/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
@@ -14,12 +14,12 @@ import static org.junit.Assert.assertEquals;
 // For use with C++ RawAccessJava. Called from C++
 public class RawAccessJavaTest extends QueueTestCommon {
 
-    final long QUEUE_HEADER_SIZE = 4;
-    final long RAW_SIZE_PREFIX = 4;
+    private final long QUEUE_HEADER_SIZE = 4;
+    private final long RAW_SIZE_PREFIX = 4;
 
-    final long COUNT = 10;
+    private final long COUNT = 10;
 
-    boolean assert_from_cpp() {
+    private boolean assert_from_cpp() {
         String env = System.getProperty("chronicle.test.env");
         return env != null && env.equals("from-cpp");
     }

--- a/src/test/java/net/openhft/chronicle/queue/ReadOneBackwardsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadOneBackwardsTest.java
@@ -31,7 +31,7 @@ public class ReadOneBackwardsTest extends QueueTestCommon {
         doTest(true);
     }
 
-    public void doTest(boolean scanning) {
+    private void doTest(boolean scanning) {
 
         final BlockingQueue<SnapshotDTO> blockingQueue = new ArrayBlockingQueue<>(128);
 
@@ -100,7 +100,7 @@ public class ReadOneBackwardsTest extends QueueTestCommon {
     static class SnapshotDTO extends SelfDescribingMarshallable {
         String data;
 
-        public SnapshotDTO(String data) {
+        SnapshotDTO(String data) {
             this.data = data;
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 public class RollCycleDefaultingTest extends QueueTestCommon {
 
-    static final String BASE_PATH = OS.getTarget() + "/rollCycleDefaultingTest";
+    private static final String BASE_PATH = OS.getTarget() + "/rollCycleDefaultingTest";
 
     @Test
     public void alias() {

--- a/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
@@ -25,14 +25,14 @@ import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class SingleChroniclePerfMainTest extends QueueTestCommon {
-    static final int count = 1_000_000;
-    static final int size = 4 << 10;
+    private static final int count = 1_000_000;
+    private static final int size = 4 << 10;
     // blackholes to avoid code elimination.
-    static int s32;
-    static long s64;
-    static float f32;
-    static double f64;
-    static String s;
+    private static int s32;
+    private static long s64;
+    private static float f32;
+    private static double f64;
+    private static String s;
 
     static {
         System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "INFO");
@@ -47,7 +47,7 @@ public class SingleChroniclePerfMainTest extends QueueTestCommon {
         }
     }
 
-    static void doPerfTest(TestWriter<Bytes<?>> writer, TestReader<Bytes<?>> reader, int count, boolean print) throws IOException {
+    private static void doPerfTest(TestWriter<Bytes<?>> writer, TestReader<Bytes<?>> reader, int count, boolean print) throws IOException {
         Histogram writeHdr = new Histogram(30, 7);
         Histogram readHdr = new Histogram(30, 7);
         String file = OS.getTarget() + "/deleteme-" + Time.uniqueId();
@@ -88,7 +88,7 @@ public class SingleChroniclePerfMainTest extends QueueTestCommon {
         IOTools.deleteDirWithFiles(file, 3);
     }
 
-    static void writeMany(Bytes<?> bytes, int size) {
+    private static void writeMany(Bytes<?> bytes, int size) {
         for (int i = 0; i < size; i += 32) {
             bytes.writeInt(i); // 4 bytes
             bytes.writeFloat(i); // 4 bytes
@@ -98,7 +98,7 @@ public class SingleChroniclePerfMainTest extends QueueTestCommon {
         }
     }
 
-    static void readMany(Bytes<?> bytes, int size) {
+    private static void readMany(Bytes<?> bytes, int size) {
         for (int i = 0; i < size; i += 32) {
             s32 = bytes.readInt(); // 4 bytes
             f32 = bytes.readFloat(); // 4 bytes

--- a/src/test/java/net/openhft/chronicle/queue/SurefireInterruptFlagTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/SurefireInterruptFlagTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SurefireInterruptFlagTest extends QueueTestCommon {
+class SurefireInterruptFlagTest extends QueueTestCommon {
 
     /**
      * Test for https://issues.apache.org/jira/browse/SUREFIRE-1863

--- a/src/test/java/net/openhft/chronicle/queue/TailerCloseInParallelTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerCloseInParallelTest.java
@@ -27,16 +27,16 @@ import static org.junit.Assume.assumeTrue;
 
 // Run until failure (several thousand times) to detect tailer parallel closing issues
 public class TailerCloseInParallelTest extends QueueTestCommon {
-    static String file = OS.getTarget() + "/deleteme-" + Time.uniqueId();
+    private static String file = OS.getTarget() + "/deleteme-" + Time.uniqueId();
 
-    static final int size = 1 << 10;
+    private static final int size = 1 << 10;
     // blackholes to avoid code elimination.
-    static int s32;
-    static long s64;
-    static float f32;
-    static double f64;
-    static String s;
-    static Random random = new Random();
+    private static int s32;
+    private static long s64;
+    private static float f32;
+    private static double f64;
+    private static String s;
+    private static Random random = new Random();
 
     @Override
     @Before
@@ -70,7 +70,7 @@ public class TailerCloseInParallelTest extends QueueTestCommon {
         finishedNormally = true;
     }
 
-    static void doPerfTest(String file, TestWriter<Bytes<?>> writer, TestReader<Bytes<?>> reader, int count, boolean print) throws InterruptedException {
+    private static void doPerfTest(String file, TestWriter<Bytes<?>> writer, TestReader<Bytes<?>> reader, int count, boolean print) throws InterruptedException {
         Histogram writeHdr = new Histogram(30, 7);
         Histogram readHdr = new Histogram(30, 7);
         try (ChronicleQueue chronicle = single(file).testBlockSize().rollCycle(RollCycles.FIVE_MINUTELY).build();
@@ -132,7 +132,7 @@ public class TailerCloseInParallelTest extends QueueTestCommon {
         }
     }
 
-    static void writeMany(Bytes<?> bytes, int size) {
+    private static void writeMany(Bytes<?> bytes, int size) {
         for (int i = 0; i < size; i += 32) {
             bytes.writeInt(i); // 4 bytes
             bytes.writeFloat(i); // 4 bytes
@@ -142,7 +142,7 @@ public class TailerCloseInParallelTest extends QueueTestCommon {
         }
     }
 
-    static void readMany(Bytes<?> bytes, int size) {
+    private static void readMany(Bytes<?> bytes, int size) {
         for (int i = 0; i < size; i += 32) {
             s32 = bytes.readInt(); // 4 bytes
             f32 = bytes.readFloat(); // 4 bytes

--- a/src/test/java/net/openhft/chronicle/queue/TestAppenderThreadSafe.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestAppenderThreadSafe.java
@@ -6,6 +6,6 @@ package net.openhft.chronicle.queue;
 import net.openhft.chronicle.core.annotation.RequiredForClient;
 
 @RequiredForClient("Even though it's empty")
-public class TestAppenderThreadSafe {
+class TestAppenderThreadSafe {
 
 }

--- a/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
@@ -249,7 +249,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
         deleteFileFromUnderTailerTest(10, 8);
     }
 
-    public void deleteFileFromUnderTailerTest(int numberOfCycles, int currentCycleIndex) throws IOException {
+    private void deleteFileFromUnderTailerTest(int numberOfCycles, int currentCycleIndex) throws IOException {
         assumeFalse(OS.isWindows());
         ignoreException("The current cycle seems to have been deleted from under the queue, scanning to find the next remaining cycle");
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(numberOfCycles, null)) {
@@ -467,7 +467,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
         }
     }
 
-    public void tailingThroughDeletedCyclesWillRefreshThenRetry(Function<QueueWithCycleDetails, SingleChronicleQueue> queueCreator) throws IOException {
+    private void tailingThroughDeletedCyclesWillRefreshThenRetry(Function<QueueWithCycleDetails, SingleChronicleQueue> queueCreator) throws IOException {
         assumeFalse(OS.isWindows());
         expectException("The current cycle seems to have been deleted from under the queue, scanning to find the next remaining cycle");
 

--- a/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.*;
 
 public class ThreadedQueueTest extends QueueTestCommon {
 
-    public static final int REQUIRED_COUNT = 10;
+    private static final int REQUIRED_COUNT = 10;
 
     @Override
     @Before

--- a/src/test/java/net/openhft/chronicle/queue/VisibilityOfMessagesBetweenTailorsAndAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/VisibilityOfMessagesBetweenTailorsAndAppenderTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 @RequiredForClient
 public class VisibilityOfMessagesBetweenTailorsAndAppenderTest extends QueueTestCommon {
 
-    volatile long lastWrittenIndex = Long.MIN_VALUE;
+    private volatile long lastWrittenIndex = Long.MIN_VALUE;
 
     @Override
     @Before

--- a/src/test/java/net/openhft/chronicle/queue/WriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WriteBytesTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 @RequiredForClient
 public class WriteBytesTest extends QueueTestCommon {
-    final Bytes<?> outgoingBytes = Bytes.elasticByteBuffer();
+    private final Bytes<?> outgoingBytes = Bytes.elasticByteBuffer();
     private final byte[] incomingMsgBytes = new byte[100];
     private final byte[] outgoingMsgBytes = new byte[100];
 
@@ -1050,12 +1050,12 @@ public class WriteBytesTest extends QueueTestCommon {
         }
     }
 
-    public boolean postOneMessage(@NotNull ExcerptAppender appender) {
+    private boolean postOneMessage(@NotNull ExcerptAppender appender) {
         appender.writeBytes(outgoingBytes);
         return true;
     }
 
-    public int fetchOneMessage(@NotNull ExcerptTailer tailer, @NotNull byte[] using) {
+    private int fetchOneMessage(@NotNull ExcerptTailer tailer, @NotNull byte[] using) {
         try (DocumentContext dc = tailer.readingDocument()) {
             return !dc.isPresent() ? -1 : dc.wire().bytes().read(using);
         }

--- a/src/test/java/net/openhft/chronicle/queue/bench/BenchmarkUtils.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/BenchmarkUtils.java
@@ -3,7 +3,7 @@
  */
 package net.openhft.chronicle.queue.bench;
 
-class BenchmarkUtils {
+public class BenchmarkUtils {
 
     /**
      * {@link Thread#join()} a thread and deal with interrupted exception

--- a/src/test/java/net/openhft/chronicle/queue/bench/BenchmarkUtils.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/BenchmarkUtils.java
@@ -3,7 +3,7 @@
  */
 package net.openhft.chronicle.queue.bench;
 
-public class BenchmarkUtils {
+class BenchmarkUtils {
 
     /**
      * {@link Thread#join()} a thread and deal with interrupted exception

--- a/src/test/java/net/openhft/chronicle/queue/bench/ByteArrayJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/ByteArrayJLBHBenchmark.java
@@ -12,8 +12,8 @@ public class ByteArrayJLBHBenchmark implements JLBHTask {
     private static final int MSG_THROUGHPUT = Integer.getInteger("throughput", 100_000_000);
     private static final int MSG_LENGTH = Integer.getInteger("length", 1_000_000);
     private static int iterations;
-    static byte[] bytesArr1 = new byte[MSG_LENGTH];
-    static byte[] bytesArr3 = new byte[MSG_LENGTH];
+    private static byte[] bytesArr1 = new byte[MSG_LENGTH];
+    private static byte[] bytesArr3 = new byte[MSG_LENGTH];
     private JLBH jlbh;
 
     static {

--- a/src/test/java/net/openhft/chronicle/queue/bench/InternalAppenderJLBH.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/InternalAppenderJLBH.java
@@ -36,7 +36,7 @@ public class InternalAppenderJLBH implements JLBHTask {
     private Bytes<?> payload;
     private JLBH jlbh;
 
-    public InternalAppenderJLBH(RollCycle rollCycle) {
+    private InternalAppenderJLBH(RollCycle rollCycle) {
         this.rollCycle = rollCycle;
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/bench/MethodReaderBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/MethodReaderBenchmark.java
@@ -258,7 +258,7 @@ public class MethodReaderBenchmark implements JLBHTask {
             sampler = stringAndBigDtoCallSampler;
         }
 
-        public void doSample(long startNs) {
+        void doSample(long startNs) {
             sampler.sampleNanos(nanos - startNs);
         }
     }
@@ -272,7 +272,7 @@ public class MethodReaderBenchmark implements JLBHTask {
         private double price;
         private long createdTime;
 
-        public OrderDTO(Random r) {
+        OrderDTO(Random r) {
             side = (char) r.nextInt();
             ordType = (char) r.nextInt();
             symbol = nextSymbol(r);
@@ -313,7 +313,7 @@ public class MethodReaderBenchmark implements JLBHTask {
         private char handlInst;
         private long createdNS;
 
-        public ExecutionReportDTO(Random r) {
+        ExecutionReportDTO(Random r) {
             orderID = nextSymbol(r);
             clOrdID = Bytes.from(nextSymbol(r));
             execID = nextSymbol(r);

--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueContendedWritesJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueContendedWritesJLBHBenchmark.java
@@ -24,7 +24,7 @@ import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilde
 
 @SuppressWarnings("try")
 public class QueueContendedWritesJLBHBenchmark implements JLBHTask {
-    public static final int ITERATIONS = 100_000;
+    private static final int ITERATIONS = 100_000;
     private static final String PATH = System.getProperty("path", "replica");
     private SingleChronicleQueue queue;
     private ExcerptTailer tailer;
@@ -105,7 +105,7 @@ public class QueueContendedWritesJLBHBenchmark implements JLBHTask {
         writerThread2.start();
     }
 
-    long written = 0;
+    private long written = 0;
 
     @Override
     public void run(long startTimeNS) {
@@ -136,8 +136,8 @@ public class QueueContendedWritesJLBHBenchmark implements JLBHTask {
     }
 
     private static class Datum extends SelfDescribingMarshallable {
-        public long ts = 0;
-        public String username;
+        long ts = 0;
+        String username;
         public byte[] filler0 = new byte[128];
         public byte[] filler1 = new byte[128];
         public byte[] filler2 = new byte[128];

--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueLargeMessageJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueLargeMessageJLBHBenchmark.java
@@ -24,8 +24,8 @@ public class QueueLargeMessageJLBHBenchmark implements JLBHTask {
     private static final int MSG_LENGTH = Integer.getInteger("length", 1_000_000);
     private static final String PATH = System.getProperty("path", "replica");
     private static final boolean MSG_DIRECT = Jvm.getBoolean("direct");
-    static byte[] bytesArr = new byte[MSG_LENGTH];
-    static Bytes<?> bytesArr2 = Bytes.allocateDirect(MSG_LENGTH);
+    private static byte[] bytesArr = new byte[MSG_LENGTH];
+    private static Bytes<?> bytesArr2 = Bytes.allocateDirect(MSG_LENGTH);
     private SingleChronicleQueue sourceQueue;
     private SingleChronicleQueue sinkQueue;
     private ExcerptTailer tailer;

--- a/src/test/java/net/openhft/chronicle/queue/cleanup/OnReleaseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/cleanup/OnReleaseTest.java
@@ -29,7 +29,7 @@ public class OnReleaseTest extends QueueTestCommon {
         FlakyTestRunner.builder(this::onRelease0).build().run();
     }
 
-    public void onRelease0() {
+    private void onRelease0() {
         String path = OS.getTarget() + "/onRelease-" + Time.uniqueId();
         SetTimeProvider stp = new SetTimeProvider();
         AtomicInteger writeRoll = new AtomicInteger();

--- a/src/test/java/net/openhft/chronicle/queue/harness/WeeklyRollCycle.java
+++ b/src/test/java/net/openhft/chronicle/queue/harness/WeeklyRollCycle.java
@@ -27,11 +27,11 @@ public class WeeklyRollCycle implements RollCycle {
 
     public static final WeeklyRollCycle INSTANCE = new WeeklyRollCycle("yyyyDDD", (int) TimeUnit.DAYS.toMillis(7L), 16384, 16);
 
-    final String format;
-    final int length;
-    final RollCycleArithmetic arithmetic;
+    private final String format;
+    private final int length;
+    private final RollCycleArithmetic arithmetic;
 
-    WeeklyRollCycle(String format, int length, int indexCount, int indexSpacing) {
+    private WeeklyRollCycle(String format, int length, int indexCount, int indexSpacing) {
         this.format = format;
         this.length = length;
         arithmetic = RollCycleArithmetic.of(indexCount, indexSpacing);

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
@@ -287,7 +287,7 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
 
     }
 
-    public void doTestToLong(RollCycle rollCycle, long epoch, long cycle, Long expectedLong) {
+    private void doTestToLong(RollCycle rollCycle, long epoch, long cycle, Long expectedLong) {
         RollingResourcesCache cache =
                 new RollingResourcesCache(rollCycle, epoch, File::new, File::getName);
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
@@ -130,7 +130,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
         FlakyTestRunner.builder(this::tailerResourcesCanBeReleasedManually0).build().run();
     }
 
-    public void tailerResourcesCanBeReleasedManually0() throws InterruptedException, TimeoutException, ExecutionException {
+    private void tailerResourcesCanBeReleasedManually0() throws InterruptedException, TimeoutException, ExecutionException {
         requestGcCycle();
         Thread.sleep(100);
         try (ChronicleQueue queue = createQueue(SYSTEM_TIME_PROVIDER)) {
@@ -216,7 +216,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
                 .run();
     }
 
-    public void appenderShouldOnlyKeepCurrentRollCycleOpen() {
+    private void appenderShouldOnlyKeepCurrentRollCycleOpen() {
         AtomicLong timeProvider = new AtomicLong(1661323015000L);
         try (ChronicleQueue queue = createQueue(timeProvider::get);
              final ExcerptAppender appender = queue.createAppender()) {
@@ -237,7 +237,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
                 .run();
     }
 
-    public void tailerShouldOnlyKeepCurrentRollCycleOpen() {
+    private void tailerShouldOnlyKeepCurrentRollCycleOpen() {
         final long startTime = 1661323015000L;
         AtomicLong timeProvider = new AtomicLong(startTime);
         final int messageCount = 10;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
@@ -36,7 +36,7 @@ public final class DocumentOrderingTest extends QueueTestCommon {
         }
     }
 
-    Thread thread;
+    private Thread thread;
 
     @Override
     @Before
@@ -236,7 +236,7 @@ public final class DocumentOrderingTest extends QueueTestCommon {
         executorService.shutdownNow();
     }
 
-    public void expectCounterVaueOne(Future<RecordInfo> otherDocumentWriter) throws InterruptedException, ExecutionException, TimeoutException {
+    private void expectCounterVaueOne(Future<RecordInfo> otherDocumentWriter) throws InterruptedException, ExecutionException, TimeoutException {
         try {
             assertEquals(1, otherDocumentWriter.get(5L, TimeUnit.SECONDS).counterValue);
         } catch (TimeoutException e) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 public class EmptyRollCycleTest extends QueueTestCommon {
 
-    public static final String EMPTY_ROLL_CYCLE_NAME = "19700101-0020X.cq4";
+    private static final String EMPTY_ROLL_CYCLE_NAME = "19700101-0020X.cq4";
     private Path dataDirectory;
 
     @Before

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/HelloWorld.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/HelloWorld.java
@@ -3,6 +3,6 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
-interface HelloWorld {
+public interface HelloWorld {
     void hello(String s);
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/HelloWorld.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/HelloWorld.java
@@ -3,6 +3,6 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
-public interface HelloWorld {
+interface HelloWorld {
     void hello(String s);
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexOffsetTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexOffsetTest.java
@@ -10,8 +10,8 @@ import org.junit.Test;
 
 public class IndexOffsetTest extends QueueTestCommon {
 
-    static final SCQIndexing indexing = new SCQIndexing(WireType.BINARY, 1 << 17, 1 << 6);
-    static final SCQIndexing indexing2 = new SCQIndexing(WireType.BINARY, 1 << 7, 1 << 3);
+    private static final SCQIndexing indexing = new SCQIndexing(WireType.BINARY, 1 << 17, 1 << 6);
+    private static final SCQIndexing indexing2 = new SCQIndexing(WireType.BINARY, 1 << 7, 1 << 3);
 
     @Test
     public void testFindExcerpt2() {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexTest.java
@@ -108,7 +108,7 @@ public class IndexTest extends QueueTestCommon {
         }
     }
 
-    public void accessHexEquals(long index0, long indexA) {
+    private void accessHexEquals(long index0, long indexA) {
         assertEquals(Long.toHexString(index0) + " != " + Long.toHexString(indexA), index0, indexA);
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
@@ -24,12 +24,12 @@ import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
  */
 public class IndexingTestCommon extends QueueTestCommon {
 
-    protected SetTimeProvider timeProvider;
-    protected SingleChronicleQueue queue;
-    protected StoreAppender appender;
-    protected List<Closeable> closeables;
-    protected ExcerptTailer tailer;
-    protected File queuePath;
+    SetTimeProvider timeProvider;
+    SingleChronicleQueue queue;
+    StoreAppender appender;
+    private List<Closeable> closeables;
+    ExcerptTailer tailer;
+    private File queuePath;
 
     @BeforeEach
     public void before() {
@@ -49,7 +49,7 @@ public class IndexingTestCommon extends QueueTestCommon {
         IOTools.deleteDirWithFiles(queuePath);
     }
 
-    protected SingleChronicleQueue createQueueInstance() {
+    private SingleChronicleQueue createQueueInstance() {
         return SingleChronicleQueueBuilder.builder()
                 .path(queuePath)
                 .timeProvider(timeProvider)
@@ -57,14 +57,14 @@ public class IndexingTestCommon extends QueueTestCommon {
                 .build();
     }
 
-    protected RollCycle rollCycle() {
+    RollCycle rollCycle() {
         return TestRollCycles.TEST_SECONDLY;
     }
 
     /**
      * @return indexing object for this queue that exposes common indexing operations.
      */
-    public Indexing indexing(SingleChronicleQueue queue) {
+    Indexing indexing(SingleChronicleQueue queue) {
         SingleChronicleQueueStore store = store(queue);
         return store.indexing;
     }
@@ -72,7 +72,7 @@ public class IndexingTestCommon extends QueueTestCommon {
     /**
      * @return gets the store for the last cycle of the queue.
      */
-    public SingleChronicleQueueStore store(SingleChronicleQueue queue) {
+    private SingleChronicleQueueStore store(SingleChronicleQueue queue) {
         SingleChronicleQueueStore store = queue.storeForCycle(queue.lastCycle(), queue.epoch(), false, null);
         closeables.add(store);
         return store;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingToEndTest.java
@@ -95,7 +95,7 @@ class IndexingToEndTest extends IndexingTestCommon {
         return lastIndexAppended;
     }
 
-    public static Stream<TailerDirection> tailerDirections() {
+    private static Stream<TailerDirection> tailerDirections() {
         return Stream.of(TailerDirection.NONE, TailerDirection.FORWARD, TailerDirection.BACKWARD);
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
@@ -33,7 +33,7 @@ public final class MessageHistoryTest extends QueueTestCommon {
     private File inputQueueDir;
     private File middleQueueDir;
     private File outputQueueDir;
-    protected final boolean named;
+    private final boolean named;
 
     public MessageHistoryTest(boolean named) {
         this.named = named;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MicroToucherTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MicroToucherTest.java
@@ -30,7 +30,7 @@ public class MicroToucherTest extends QueueTestCommon {
         touchPage(b -> b.blockSize(64 << 20), 66561);
     }
 
-    public void touchPage(Consumer<SingleChronicleQueueBuilder> configure, int pagesExpected) {
+    private void touchPage(Consumer<SingleChronicleQueueBuilder> configure, int pagesExpected) {
         long start = System.nanoTime();
         String path = OS.getTarget() + "/touchPage-" + System.nanoTime();
         int pages = 0;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/OnEvents.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/OnEvents.java
@@ -4,6 +4,6 @@
 package net.openhft.chronicle.queue.impl.single;
 
 @FunctionalInterface
-public interface OnEvents {
+interface OnEvents {
     void onEvent(String event);
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/OnEvents.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/OnEvents.java
@@ -4,6 +4,6 @@
 package net.openhft.chronicle.queue.impl.single;
 
 @FunctionalInterface
-interface OnEvents {
+public interface OnEvents {
     void onEvent(String event);
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
@@ -26,9 +26,9 @@ import static org.junit.Assert.assertTrue;
 
 class ReferenceCountedCacheTest extends QueueTestCommon {
 
-    public static final int MAX_THREADS_TO_RUN = 6;
-    public static final int MIN_THREADS_TO_RUN = 3;
-    public static final int NUM_RESOURCES = 50;
+    private static final int MAX_THREADS_TO_RUN = 6;
+    private static final int MIN_THREADS_TO_RUN = 3;
+    private static final int NUM_RESOURCES = 50;
     private AtomicInteger createdCount;
     private AtomicInteger releasedCount;
     private ReferenceCountedCache<Integer, TestReferenceCounted, Reservation, RuntimeException> cache;
@@ -101,7 +101,7 @@ class ReferenceCountedCacheTest extends QueueTestCommon {
         private final Random random;
         private final Reservation[] reservations;
 
-        public ReferenceGetter(int numResources, ReferenceCountedCache<Integer, TestReferenceCounted, Reservation, RuntimeException> referenceId, AtomicBoolean running) {
+        ReferenceGetter(int numResources, ReferenceCountedCache<Integer, TestReferenceCounted, Reservation, RuntimeException> referenceId, AtomicBoolean running) {
             this.numResources = numResources;
             this.cache = referenceId;
             this.running = running;
@@ -137,17 +137,17 @@ class ReferenceCountedCacheTest extends QueueTestCommon {
         private final ReferenceCounted referenceCounted;
         private final ReferenceOwner referenceOwner;
 
-        public Reservation(ReferenceCounted referenceCounted) {
+        Reservation(ReferenceCounted referenceCounted) {
             this.referenceOwner = ReferenceOwner.temporary("reservation");
             this.referenceCounted = referenceCounted;
             referenceCounted.reserve(referenceOwner);
         }
 
-        public void release() {
+        void release() {
             this.referenceCounted.release(referenceOwner);
         }
 
-        public void assertNotReleased() {
+        void assertNotReleased() {
             final int referenceCount = this.referenceCounted.refCount();
             assertTrue("Expected reference count of at least 2, got " + referenceCount, referenceCount > 1);
         }
@@ -155,7 +155,7 @@ class ReferenceCountedCacheTest extends QueueTestCommon {
 
     private class TestReferenceCounted extends AbstractReferenceCounted implements ReferenceOwner, Closeable {
 
-        public TestReferenceCounted() {
+        TestReferenceCounted() {
             createdCount.incrementAndGet();
         }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
@@ -299,7 +299,7 @@ public class RollCycleTest extends QueueTestCommon {
         CountDownLatch progressLatch;
         volatile int documentsRead;
 
-        public ParallelQueueObserver(TimeProvider timeProvider, @NotNull Path path) {
+        ParallelQueueObserver(TimeProvider timeProvider, @NotNull Path path) {
             queue = SingleChronicleQueueBuilder.binary(path.toFile())
                     .testBlockSize()
                     .rollCycle(TEST_DAILY)
@@ -332,7 +332,7 @@ public class RollCycleTest extends QueueTestCommon {
             }
         }
 
-        public void await() throws InterruptedException {
+        void await() throws InterruptedException {
             progressLatch.await();
         }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class RollingCycleTest extends QueueTestCommon {
-    protected final boolean named;
+    private final boolean named;
 
     public RollingCycleTest(boolean named) {
         this.named = named;
@@ -299,7 +299,7 @@ public class RollingCycleTest extends QueueTestCommon {
         long _value2;
         long _value3;
 
-        public TestBytesMarshallable(int i) {
+        TestBytesMarshallable(int i) {
             final Random rand = new Random(i);
             _name = "name_" + rand.nextInt();
             _value1 = rand.nextLong();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
@@ -203,7 +203,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
         return file.listFiles((d, n) -> n.endsWith(SingleChronicleQueue.SUFFIX))[0];
     }
 
-    public void checkFileContents(@NotNull File file, String expected) throws FileNotFoundException {
+    private void checkFileContents(@NotNull File file, String expected) throws FileNotFoundException {
 
         @NotNull MappedBytes bytes = MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, PageUtil.getPageSize(file.getAbsolutePath()), true);
         bytes.readLimit(bytes.realCapacity());
@@ -211,7 +211,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
         bytes.releaseLast();
     }
 
-    void doTestWritingTwentyMessagesTinyIndex(int spacing, String expected) throws FileNotFoundException {
+    private void doTestWritingTwentyMessagesTinyIndex(int spacing, String expected) throws FileNotFoundException {
         @NotNull File dir = getTmpDir();
         dir.mkdir();
 
@@ -545,7 +545,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
         appendMode = 0;
     }
 
-    public void appendMessage(@NotNull ExcerptAppender appender, long expectedIndex, String msg) {
+    private void appendMessage(@NotNull ExcerptAppender appender, long expectedIndex, String msg) {
         switch (appendMode) {
             case 1:
                 appender.writeDocument(w -> w.write("msg").text(msg));

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assume.assumeFalse;
 
 public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     private static final String TEST_QUEUE_FILE = "src/test/resources/tr2/20170320.cq4";
-    static final String BASE_PATH = OS.getTarget() + "/singleChronicleQueueBuilderTest";
+    private static final String BASE_PATH = OS.getTarget() + "/singleChronicleQueueBuilderTest";
 
     @AfterClass
     public static void afterClass() {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -63,7 +63,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     private static final long TIMES = (4L << 20L);
     @NotNull
-    private final WireType wireType;
+    protected final WireType wireType;
     protected final boolean named;
     private final Bytes<?> appenderListenerDump = Bytes.allocateElasticOnHeap(256);
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -63,9 +63,9 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     private static final long TIMES = (4L << 20L);
     @NotNull
-    protected final WireType wireType;
-    protected final boolean named;
-    protected final Bytes<?> appenderListenerDump = Bytes.allocateElasticOnHeap(256);
+    private final WireType wireType;
+    private final boolean named;
+    private final Bytes<?> appenderListenerDump = Bytes.allocateElasticOnHeap(256);
 
     public SingleChronicleQueueTest(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
@@ -167,7 +167,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected String expectedForTestAppend() {
+    private String expectedForTestAppend() {
         return "" +
                 "idx: 4a0400000000\n" +
                 "# position: 784, header: 0\n" +
@@ -235,7 +235,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected String expectedForTestTextReadWrite() {
+    private String expectedForTestTextReadWrite() {
         return "" +
                 "idx: 4a0400000000\n" +
                 "# position: 784, header: 0\n" +
@@ -433,7 +433,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected String expectedForTestCanAppendWriteBytesInternalIfAppendLockIsSet() {
+    private String expectedForTestCanAppendWriteBytesInternalIfAppendLockIsSet() {
         return "" +
                 "idx: 0\n" +
                 "# position: 784, header: 0\n" +
@@ -699,7 +699,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         );
     }
 
-    void doTestCheckIndex(@NotNull BiConsumer<ExcerptAppender, Integer> writeTo) {
+    private void doTestCheckIndex(@NotNull BiConsumer<ExcerptAppender, Integer> writeTo) {
         SetTimeProvider stp = new SetTimeProvider();
         stp.currentTimeMillis(System.currentTimeMillis() - 3 * 86400_000L);
         try (final ChronicleQueue queue = builder(getTmpDir(), wireType)
@@ -1698,7 +1698,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    protected String queueLockForTestReentrant() {
+    private String queueLockForTestReentrant() {
         return "";
     }
 
@@ -1920,7 +1920,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected String expectedMetaDataTest2() {
+    private String expectedMetaDataTest2() {
         if (wireType == WireType.BINARY || wireType == WireType.BINARY_LIGHT)
             return "" +
                     "--- !!meta-data #binary\n" +
@@ -2041,7 +2041,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    void readForward(@NotNull ChronicleQueue chronicle, int entries) {
+    private void readForward(@NotNull ChronicleQueue chronicle, int entries) {
         try (ExcerptTailer forwardTailer = chronicle.createTailer(named ? "named" : null)
                 .direction(TailerDirection.FORWARD)
                 .toStart()) {
@@ -2064,7 +2064,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    void readBackward(@NotNull ChronicleQueue chronicle, int entries) {
+    private void readBackward(@NotNull ChronicleQueue chronicle, int entries) {
         ExcerptTailer backwardTailer = chronicle.createTailer(named ? "named" : null)
                 .direction(TailerDirection.BACKWARD)
                 .toEnd();
@@ -2518,7 +2518,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected String expectedMultipleAppenders() {
+    private String expectedMultipleAppenders() {
         if (wireType == WireType.BINARY || wireType == WireType.BINARY_LIGHT)
             return "--- !!meta-data #binary\n" +
                     "header: !STStore {\n" +
@@ -3234,7 +3234,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected SingleChronicleQueueBuilder builder(@NotNull File file, @NotNull WireType wireType) {
+    private SingleChronicleQueueBuilder builder(@NotNull File file, @NotNull WireType wireType) {
         return SingleChronicleQueueBuilder.builder(file, wireType).rollCycle(TEST4_DAILY).testBlockSize();
     }
 
@@ -3295,7 +3295,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected SingleChronicleQueueBuilder builderWithAppendListener(@NotNull File file, @NotNull WireType wireType) {
+    private SingleChronicleQueueBuilder builderWithAppendListener(@NotNull File file, @NotNull WireType wireType) {
         appenderListenerDump.clear();
         return SingleChronicleQueueBuilder.builder(file, wireType)
                 .rollCycle(TEST4_DAILY)
@@ -3309,7 +3309,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected SingleChronicleQueueBuilder binary(@NotNull File file) {
+    private SingleChronicleQueueBuilder binary(@NotNull File file) {
         return builder(file, WireType.BINARY_LIGHT);
     }
 
@@ -3722,7 +3722,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             readMarshallable(wire);
         }
 
-        public MyMarshable() {
+        MyMarshable() {
         }
     }
 
@@ -3730,7 +3730,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         private BytesStore<?, ?> bytes;
         private long index;
 
-        public BytesWithIndex(Bytes<?> bytes, long index) {
+        BytesWithIndex(Bytes<?> bytes, long index) {
             this.bytes = Bytes.allocateElasticDirect(bytes.readRemaining()).write(bytes);
             this.index = index;
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -2518,7 +2518,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    private String expectedMultipleAppenders() {
+    protected String expectedMultipleAppenders() {
         if (wireType == WireType.BINARY || wireType == WireType.BINARY_LIGHT)
             return "--- !!meta-data #binary\n" +
                     "header: !STStore {\n" +
@@ -3234,7 +3234,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    private SingleChronicleQueueBuilder builder(@NotNull File file, @NotNull WireType wireType) {
+    protected SingleChronicleQueueBuilder builder(@NotNull File file, @NotNull WireType wireType) {
         return SingleChronicleQueueBuilder.builder(file, wireType).rollCycle(TEST4_DAILY).testBlockSize();
     }
 
@@ -3309,7 +3309,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    private SingleChronicleQueueBuilder binary(@NotNull File file) {
+    protected SingleChronicleQueueBuilder binary(@NotNull File file) {
         return builder(file, WireType.BINARY_LIGHT);
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -64,7 +64,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     private static final long TIMES = (4L << 20L);
     @NotNull
     private final WireType wireType;
-    private final boolean named;
+    protected final boolean named;
     private final Bytes<?> appenderListenerDump = Bytes.allocateElasticOnHeap(256);
 
     public SingleChronicleQueueTest(@NotNull WireType wireType, boolean named) {
@@ -1920,7 +1920,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @NotNull
-    private String expectedMetaDataTest2() {
+    protected String expectedMetaDataTest2() {
         if (wireType == WireType.BINARY || wireType == WireType.BINARY_LIGHT)
             return "" +
                     "--- !!meta-data #binary\n" +

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
@@ -63,7 +63,7 @@ public class SparseBinarySearchTest extends QueueTestCommon {
         runWithTimeParameters(DAILY, 1);
     }
 
-    public void runWithTimeParameters(RollCycle rollCycle, long incrementInMillis) throws ParseException {
+    private void runWithTimeParameters(RollCycle rollCycle, long incrementInMillis) throws ParseException {
         final SetTimeProvider stp = new SetTimeProvider();
         stp.currentTimeMillis(0);
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
@@ -57,7 +57,7 @@ public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
         testInternalWriteBytes(5, false);
     }
 
-    public void testInternalWriteBytes(int numCopiers, boolean concurrent) throws InterruptedException {
+    private void testInternalWriteBytes(int numCopiers, boolean concurrent) throws InterruptedException {
         final Path sourceDir = IOTools.createTempDirectory("sourceQueue");
         final Path destinationDir = IOTools.createTempDirectory("destinationQueue");
         /**
@@ -135,7 +135,7 @@ public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
         private final Path destinationDir;
         private final int copyId;
 
-        public QueueCopier(Path sourceDir, Path destinationDir, int copyId) {
+        QueueCopier(Path sourceDir, Path destinationDir, int copyId) {
             this.sourceDir = sourceDir;
             this.destinationDir = destinationDir;
             this.copyId = copyId;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -116,11 +116,11 @@ public class StoreAppenderTest extends QueueTestCommon {
         private Semaphore waitingToAcquire;
         private Semaphore waitingAfterInterrupt;
 
-        public BlockedWriter(SingleChronicleQueue queue) {
+        BlockedWriter(SingleChronicleQueue queue) {
             this.queue = queue;
         }
 
-        public void makeSuccessfulWrite() {
+        void makeSuccessfulWrite() {
             waitingToAcquire = new Semaphore(0);
             waitingAfterInterrupt = new Semaphore(0);
             t = new Thread(this::makeInterruptedWriteAttemptThenTryAgain);
@@ -129,7 +129,7 @@ public class StoreAppenderTest extends QueueTestCommon {
             waitForThreads(waitingToAcquire);
         }
 
-        public void makeInterruptedAttemptToWrite() {
+        void makeInterruptedAttemptToWrite() {
             waitingToAcquire.release(1);
             // Wait till the lock() call has been made
             Jvm.pause(10);
@@ -137,7 +137,7 @@ public class StoreAppenderTest extends QueueTestCommon {
             waitForThreads(waitingAfterInterrupt);
         }
 
-        public void makePostInterruptAttemptToWrite() throws InterruptedException {
+        void makePostInterruptAttemptToWrite() throws InterruptedException {
             waitingAfterInterrupt.release();
             t.join();
         }
@@ -164,18 +164,18 @@ public class StoreAppenderTest extends QueueTestCommon {
         private final SingleChronicleQueue queue;
         private final Semaphore inWritingDocument = new Semaphore(0);
 
-        public BlockingWriter(SingleChronicleQueue queue) {
+        BlockingWriter(SingleChronicleQueue queue) {
             this.queue = queue;
         }
 
-        public void blockWrites() {
+        void blockWrites() {
             t = new Thread(this::acquireWritingDocumentThenBlock);
             t.setName("blocking-writer");
             t.start();
             waitForThreads(inWritingDocument);
         }
 
-        public void unblockWrites() throws InterruptedException {
+        void unblockWrites() throws InterruptedException {
             inWritingDocument.release(1);
             t.join();
             t = null;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
@@ -415,7 +415,7 @@ public class StoreTailerTest extends QueueTestCommon {
 
         abstract void doOnSecondThread(ExcerptTailer tailer);
 
-        public void run() throws InterruptedException {
+        void run() throws InterruptedException {
             try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dataDirectory).build()) {
                 BlockingQueue<ExcerptTailer> tq = new LinkedBlockingQueue<>();
                 Thread t = new Thread(() -> {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
 import static org.junit.Assert.assertFalse;
 
 public class TestEmptyFile {
-    Path tmpDir = DirectoryUtils.tempDir(TestEmptyFile.class.getSimpleName()).toPath();
+    private Path tmpDir = DirectoryUtils.tempDir(TestEmptyFile.class.getSimpleName()).toPath();
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Before

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
@@ -134,7 +134,7 @@ public class TestMethodWriterWithThreads extends QueueTestCommon {
     }
 
     @NotNull
-    protected SingleChronicleQueueBuilder builder(@NotNull File file, @NotNull WireType wireType) {
+    private SingleChronicleQueueBuilder builder(@NotNull File file, @NotNull WireType wireType) {
         return SingleChronicleQueueBuilder.builder(file, wireType).rollCycle(TEST4_DAILY).testBlockSize();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
@@ -32,7 +32,7 @@ public class ToEndTest extends QueueTestCommon {
     private static final long FIVE_SECONDS = SECONDS.toMicros(5);
     private static final String ZERO_AS_HEX_STRING = Long.toHexString(0);
     private static final String LONG_MIN_VALUE_AS_HEX_STRING = Long.toHexString(Long.MIN_VALUE);
-    long lastCycle;
+    private long lastCycle;
 
     @Test
     public void missingCyclesToEndTest() {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
@@ -63,7 +63,7 @@ public class WriteBytesIndexTest extends QueueTestCommon {
         }
     }
 
-    static ChronicleQueue createQueue(File path) {
+    private static ChronicleQueue createQueue(File path) {
         return SingleChronicleQueueBuilder.single(path)
                 .testBlockSize()
                 .rollCycle(TEST4_SECONDLY)

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
@@ -41,30 +41,30 @@ import static org.junit.Assert.assertTrue;
 
 public class RollCycleMultiThreadStressTest extends QueueTestCommon {
 
-    final long SLEEP_PER_WRITE_NANOS;
-    final int TEST_TIME;
-    final int ROLL_EVERY_MS;
-    final int DELAY_READER_RANDOM_MS;
-    final int DELAY_WRITER_RANDOM_MS;
-    final int CORES;
-    final Random random;
+    private final long SLEEP_PER_WRITE_NANOS;
+    private final int TEST_TIME;
+    private final int ROLL_EVERY_MS;
+    private final int DELAY_READER_RANDOM_MS;
+    private final int DELAY_WRITER_RANDOM_MS;
+    private final int CORES;
+    private final Random random;
     final int NUMBER_OF_INTS;
-    final boolean PRETOUCH;
-    final boolean READERS_READ_ONLY;
+    private final boolean PRETOUCH;
+    private final boolean READERS_READ_ONLY;
     final boolean DUMP_QUEUE;
-    final boolean SHARED_WRITE_QUEUE;
-    final boolean DOUBLE_BUFFER;
-    final int WARMUP;
-    final SetTimeProvider timeProvider = new SetTimeProvider();
-    final Histogram combinedHisto = new Histogram();
-    PretoucherThread pretoucherThread = null;
+    private final boolean SHARED_WRITE_QUEUE;
+    private final boolean DOUBLE_BUFFER;
+    private final int WARMUP;
+    private final SetTimeProvider timeProvider = new SetTimeProvider();
+    private final Histogram combinedHisto = new Histogram();
+    private PretoucherThread pretoucherThread = null;
     private ChronicleQueue sharedWriterQueue;
 
     public RollCycleMultiThreadStressTest() {
         this(StressTestType.VANILLA);
     }
 
-    protected RollCycleMultiThreadStressTest(StressTestType type) {
+    RollCycleMultiThreadStressTest(StressTestType type) {
         SLEEP_PER_WRITE_NANOS = Jvm.getLong("writeLatency", 30_000L);
         TEST_TIME = Jvm.getInteger("testTime", 15);
         ROLL_EVERY_MS = Jvm.getInteger("rollEvery", 300);
@@ -90,7 +90,7 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
         }
     }
 
-    static boolean areAllReadersComplete(final int expectedNumberOfMessages, final List<Reader> readers) {
+    private static boolean areAllReadersComplete(final int expectedNumberOfMessages, final List<Reader> readers) {
         boolean allReadersComplete = true;
 
         for (Reader reader : readers) {
@@ -106,7 +106,7 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
         new RollCycleMultiThreadStressTest().run();
     }
 
-    static void shutdownAll(int waitSecs, ExecutorService... ess) throws InterruptedException {
+    private static void shutdownAll(int waitSecs, ExecutorService... ess) throws InterruptedException {
         for (ExecutorService es : ess)
             es.shutdownNow();
 
@@ -136,7 +136,7 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
         finishedNormally = true;
     }
 
-    protected void run() throws InterruptedException {
+    void run() throws InterruptedException {
         stress0();
 
         TeamCityHelper.histo(getClass().getSimpleName() + ".end-to-end", combinedHisto, System.out);
@@ -303,7 +303,7 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
         IOTools.deleteDirWithFiles(file);
     }
 
-    protected ReaderCheckingStrategy getReaderCheckingStrategy() {
+    ReaderCheckingStrategy getReaderCheckingStrategy() {
         return new DefaultReaderCheckingStrategy();
     }
 
@@ -315,7 +315,7 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
     }
 
     @NotNull
-    SingleChronicleQueueBuilder queueBuilder(File path) {
+    private SingleChronicleQueueBuilder queueBuilder(File path) {
         return SingleChronicleQueueBuilder.binary(path)
                 .testBlockSize()
                 .timeProvider(timeProvider)

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 public class RollCycleMultiThreadTest extends QueueTestCommon {
 
-    public static final RollCycle ROLL_CYCLE = TEST_DAILY;
+    private static final RollCycle ROLL_CYCLE = TEST_DAILY;
 
     @Test
     public void testRead1() throws ExecutionException, InterruptedException {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerJmhState.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerJmhState.java
@@ -16,11 +16,11 @@ import java.nio.file.Paths;
 
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 
-public class BackwardsTailerJmhState {
+class BackwardsTailerJmhState {
 
     private static final Logger log = LoggerFactory.getLogger(BackwardsTailerToEndPerfAcceptanceTest.class);
 
-    protected ExcerptTailer tailer;
+    private ExcerptTailer tailer;
     private File queuePath;
     private SingleChronicleQueue queue;
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndBoundaryJmhBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndBoundaryJmhBenchmark.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 
 @Fork(value = 1, warmups = 1)
 @State(Scope.Benchmark)
-public class BackwardsTailerToEndBoundaryJmhBenchmark {
+class BackwardsTailerToEndBoundaryJmhBenchmark {
 
     private BackwardsTailerJmhState state = new BackwardsTailerJmhState();
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndBoundaryJmhBenchmarkEndSpacingMinusOne.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndBoundaryJmhBenchmarkEndSpacingMinusOne.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 
 @Fork(value = 1, warmups = 1)
 @State(Scope.Benchmark)
-public class BackwardsTailerToEndBoundaryJmhBenchmarkEndSpacingMinusOne {
+class BackwardsTailerToEndBoundaryJmhBenchmarkEndSpacingMinusOne {
 
     private BackwardsTailerJmhState state = new BackwardsTailerJmhState();
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
@@ -87,7 +87,7 @@ public class SingleTableStoreIntegrationTests extends QueueTestCommon {
         assertEquals(1, context.newQueueInstance().tableStoreGet(key));
     }
 
-    public class TestContext implements Closeable {
+    class TestContext implements Closeable {
 
         private final File queuePath = getTmpDir();
         private final List<SingleChronicleQueue> queues = new ArrayList<>();
@@ -95,7 +95,7 @@ public class SingleTableStoreIntegrationTests extends QueueTestCommon {
         /**
          * @return A fresh Queue instance pointing at the same path as all other queue instances for this test context.
          */
-        public SingleChronicleQueue newQueueInstance() {
+        SingleChronicleQueue newQueueInstance() {
             SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().path(queuePath).build();
             queues.add(queue);
             return queue;

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/FieldlessMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/FieldlessMethodReaderTest.java
@@ -74,7 +74,7 @@ public class FieldlessMethodReaderTest extends QueueTestCommon {
     static class CustomEntity extends SelfDescribingMarshallable {
         private CustomEnumType enumType;
 
-        public CustomEntity enumType(CustomEnumType enumType) {
+        CustomEntity enumType(CustomEnumType enumType) {
             this.enumType = enumType;
             return this;
         }

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
@@ -48,7 +48,7 @@ public class RollEOFTest extends QueueTestCommon {
     private static final ReferenceOwner test = ReferenceOwner.temporary("test");
 
     @Nullable
-    static SingleChronicleQueueStore loadStore(@NotNull Wire wire) {
+    private static SingleChronicleQueueStore loadStore(@NotNull Wire wire) {
         final StringBuilder eventName = new StringBuilder();
         wire.readEventName(eventName);
         if (eventName.toString().equals(MetaDataKeys.header.name())) {

--- a/src/test/java/net/openhft/chronicle/queue/issue/TailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/TailerTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertEquals;
 
 public class TailerTest extends QueueTestCommon {
 
-    public static final Path QUEUE_PATH = Paths.get(OS.getTarget() + "/host-1/queue/broker_out");
-    public static final int OFFSET = 3;
+    private static final Path QUEUE_PATH = Paths.get(OS.getTarget() + "/host-1/queue/broker_out");
+    private static final int OFFSET = 3;
 
     @Before
     @After

--- a/src/test/java/net/openhft/chronicle/queue/jitter/QueueReadJitterMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/jitter/QueueReadJitterMain.java
@@ -17,12 +17,12 @@ import net.openhft.chronicle.wire.DocumentContext;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class QueueReadJitterMain {
-    public static final String PROFILE_OF_THE_THREAD = "profile of the thread";
+    private static final String PROFILE_OF_THE_THREAD = "profile of the thread";
 
-    static int runTime = Integer.getInteger("runTime", 600); // seconds
-    static int size = Integer.getInteger("size", 128); // bytes
-    static int sampleTime = Integer.getInteger("sampleTime", 30); // micro-seconds
-    static volatile boolean running = true;
+    private static int runTime = Integer.getInteger("runTime", 600); // seconds
+    private static int size = Integer.getInteger("size", 128); // bytes
+    private static int sampleTime = Integer.getInteger("sampleTime", 30); // micro-seconds
+    private static volatile boolean running = true;
 
     static {
         System.setProperty("jvm.safepoint.enabled", "true");
@@ -33,7 +33,7 @@ public class QueueReadJitterMain {
         new QueueReadJitterMain().run();
     }
 
-    protected void run() {
+    private void run() {
         MappedFile.warmup();
 
         String path = "test-q-" + Time.uniqueId();
@@ -98,7 +98,7 @@ public class QueueReadJitterMain {
         IOTools.deleteDirWithFiles(path, 2);
     }
 
-    protected ChronicleQueue createQueue(String path) {
+    private ChronicleQueue createQueue(String path) {
         return SingleChronicleQueueBuilder.single(path).blockSize(1 << 20).build();
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/jitter/QueueReadJitterMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/jitter/QueueReadJitterMain.java
@@ -33,7 +33,7 @@ public class QueueReadJitterMain {
         new QueueReadJitterMain().run();
     }
 
-    private void run() {
+    public void run() {
         MappedFile.warmup();
 
         String path = "test-q-" + Time.uniqueId();

--- a/src/test/java/net/openhft/chronicle/queue/jitter/QueueWriteJitterMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/jitter/QueueWriteJitterMain.java
@@ -32,7 +32,7 @@ public class QueueWriteJitterMain {
         new QueueWriteJitterMain().run();
     }
 
-    private void run() {
+    public void run() {
         MappedFile.warmup();
 
         String path = "test-q-" + Time.uniqueId();

--- a/src/test/java/net/openhft/chronicle/queue/jitter/QueueWriteJitterMain.java
+++ b/src/test/java/net/openhft/chronicle/queue/jitter/QueueWriteJitterMain.java
@@ -15,13 +15,13 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 
 public class QueueWriteJitterMain {
-    public static final String PROFILE_OF_THE_THREAD = "profile of the thread";
+    private static final String PROFILE_OF_THE_THREAD = "profile of the thread";
 
-    static int runTime = Integer.getInteger("runTime", 600); // seconds
-    static int size = Integer.getInteger("size", 128); // bytes
-    static int sampleTime = Integer.getInteger("sampleTime", 30); // micro-seconds
-    static volatile boolean running = true;
-    static volatile long writeStarted = Long.MAX_VALUE;
+    private static int runTime = Integer.getInteger("runTime", 600); // seconds
+    private static int size = Integer.getInteger("size", 128); // bytes
+    private static int sampleTime = Integer.getInteger("sampleTime", 30); // micro-seconds
+    private static volatile boolean running = true;
+    private static volatile long writeStarted = Long.MAX_VALUE;
 
     static {
         System.setProperty("jvm.safepoint.enabled", "true");
@@ -32,7 +32,7 @@ public class QueueWriteJitterMain {
         new QueueWriteJitterMain().run();
     }
 
-    protected void run() {
+    private void run() {
         MappedFile.warmup();
 
         String path = "test-q-" + Time.uniqueId();
@@ -121,7 +121,7 @@ public class QueueWriteJitterMain {
         }
     }
 
-    protected ChronicleQueue createQueue(String path) {
+    private ChronicleQueue createQueue(String path) {
         return SingleChronicleQueueBuilder.single(path).testBlockSize().build();
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/micros/MarketDataListener.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/MarketDataListener.java
@@ -4,6 +4,6 @@
 package net.openhft.chronicle.queue.micros;
 
 @FunctionalInterface
-public interface MarketDataListener {
+interface MarketDataListener {
     void onTopOfBookPrice(TopOfBookPrice price);
 }

--- a/src/test/java/net/openhft/chronicle/queue/micros/Order.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/Order.java
@@ -6,10 +6,10 @@ package net.openhft.chronicle.queue.micros;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 
 public class Order extends SelfDescribingMarshallable {
-    final String symbol;
-    final Side side;
-    final double limitPrice;
-    final double quantity;
+    private final String symbol;
+    private final Side side;
+    private final double limitPrice;
+    private final double quantity;
 
     public Order(String symbol, Side side, double limitPrice, double quantity) {
         this.symbol = symbol;

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderIdea.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderIdea.java
@@ -5,7 +5,7 @@ package net.openhft.chronicle.queue.micros;
 
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 
-public class OrderIdea extends SelfDescribingMarshallable {
+class OrderIdea extends SelfDescribingMarshallable {
     final String symbol;
     final Side side;
     final double limitPrice;

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderIdeaListener.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderIdeaListener.java
@@ -4,6 +4,6 @@
 package net.openhft.chronicle.queue.micros;
 
 @FunctionalInterface
-public interface OrderIdeaListener {
+interface OrderIdeaListener {
     void onOrderIdea(OrderIdea orderIdea);
 }

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderManager.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderManager.java
@@ -9,9 +9,9 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class OrderManager implements MarketDataListener, OrderIdeaListener {
-    final OrderListener orderListener;
-    final Map<String, TopOfBookPrice> priceMap = new TreeMap<>();
-    final Map<String, OrderIdea> ideaMap = new TreeMap<>();
+    private final OrderListener orderListener;
+    private final Map<String, TopOfBookPrice> priceMap = new TreeMap<>();
+    private final Map<String, OrderIdea> ideaMap = new TreeMap<>();
 
     public OrderManager(OrderListener orderListener) {
         this.orderListener = orderListener;

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
@@ -104,7 +104,7 @@ public class OrderManagerTest extends QueueTestCommon {
         FlakyTestRunner.builder(this::testWithQueueHistory0).build().run();
     }
 
-    public void testWithQueueHistory0() {
+    private void testWithQueueHistory0() {
         File queuePath = new File(OS.getTarget(), "testWithQueueHistory-" + Time.uniqueId());
         File queuePath2 = new File(OS.getTarget(), "testWithQueueHistory-down-" + Time.uniqueId());
         try {

--- a/src/test/java/net/openhft/chronicle/queue/micros/SidedMarketDataCombiner.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/SidedMarketDataCombiner.java
@@ -9,8 +9,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class SidedMarketDataCombiner implements SidedMarketDataListener {
-    final MarketDataListener mdListener;
-    final Map<String, TopOfBookPrice> priceMap = new TreeMap<>();
+    private final MarketDataListener mdListener;
+    private final Map<String, TopOfBookPrice> priceMap = new TreeMap<>();
 
     public SidedMarketDataCombiner(MarketDataListener mdListener) {
         this.mdListener = mdListener;

--- a/src/test/java/net/openhft/chronicle/queue/micros/SidedMarketDataListener.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/SidedMarketDataListener.java
@@ -4,6 +4,6 @@
 package net.openhft.chronicle.queue.micros;
 
 @FunctionalInterface
-public interface SidedMarketDataListener {
+interface SidedMarketDataListener {
     void onSidedPrice(SidedPrice sidedPrice);
 }

--- a/src/test/java/net/openhft/chronicle/queue/micros/SidedPrice.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/SidedPrice.java
@@ -18,7 +18,7 @@ public class SidedPrice extends SelfDescribingMarshallable {
     }
 
     @NotNull
-    public SidedPrice init(String symbol, long timestamp, Side side, double price, double quantity) {
+    private SidedPrice init(String symbol, long timestamp, Side side, double price, double quantity) {
         this.symbol = symbol;
         this.timestamp = timestamp;
         this.side = side;

--- a/src/test/java/net/openhft/chronicle/queue/micros/TopOfBookPrice.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/TopOfBookPrice.java
@@ -8,10 +8,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.TimeUnit;
 
-public class TopOfBookPrice extends SelfDescribingMarshallable {
-    public static final long TIMESTAMP_LIMIT = TimeUnit.SECONDS.toMillis(1000);
+class TopOfBookPrice extends SelfDescribingMarshallable {
+    private static final long TIMESTAMP_LIMIT = TimeUnit.SECONDS.toMillis(1000);
     final String symbol;
-    long timestamp;
+    private long timestamp;
     double buyPrice, buyQuantity;
     double sellPrice, sellQuantity;
 

--- a/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerVersioningTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerVersioningTest.java
@@ -149,7 +149,7 @@ public class NamedTailerVersioningTest extends QueueTestCommon {
         }
     }
 
-    public void copyFolder(Path src, Path dest) throws IOException {
+    private void copyFolder(Path src, Path dest) throws IOException {
         try (Stream<Path> stream = Files.walk(src)) {
             stream.forEach(source -> copy(source, dest.resolve(src.relativize(source))));
         }

--- a/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
@@ -170,7 +170,7 @@ public class FileUtilTest extends QueueTestCommon {
     }
 
     @NotNull
-    protected SingleChronicleQueueBuilder builder(@NotNull File file, @NotNull WireType wireType) {
+    private SingleChronicleQueueBuilder builder(@NotNull File file, @NotNull WireType wireType) {
         return SingleChronicleQueueBuilder.builder(file, wireType).rollCycle(TEST4_DAILY).testBlockSize();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/util/HugetlbfsTestUtil.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/HugetlbfsTestUtil.java
@@ -12,9 +12,9 @@ import java.nio.file.Paths;
 
 public final class HugetlbfsTestUtil {
 
-    public static final String HUGETLBFS_PATH_PROPERTY = "chronicle.queue.tests.hugetlbfsPath";
+    private static final String HUGETLBFS_PATH_PROPERTY = "chronicle.queue.tests.hugetlbfsPath";
 
-    public static final String HUGETLBFS_PATH = Jvm.getProperty(HUGETLBFS_PATH_PROPERTY, "/mnt/huge");
+    private static final String HUGETLBFS_PATH = Jvm.getProperty(HUGETLBFS_PATH_PROPERTY, "/mnt/huge");
 
     private HugetlbfsTestUtil() {
     }
@@ -37,7 +37,7 @@ public final class HugetlbfsTestUtil {
      *
      * @return The value of {@link #HUGETLBFS_PATH} if it exists, otherwise null.
      */
-    public static String hugetlbfsPath() {
+    private static String hugetlbfsPath() {
         if (new File(HUGETLBFS_PATH).exists()) {
             return HUGETLBFS_PATH;
         } else {

--- a/src/test/java/net/openhft/chronicle/queue/util/StackSampler.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/StackSampler.java
@@ -37,7 +37,7 @@ public class StackSampler {
      * periodic intervals. This method is internally used by the background
      * thread created in the constructor.
      */
-    void sampling() {
+    private void sampling() {
         while (!Thread.currentThread().isInterrupted()) {
             Thread t = thread;
             if (t != null) {


### PR DESCRIPTION
This PR applies a consistent sweep across the **test** sources to improve encapsulation, reduce accidental API surface, and quiet static-analysis tools without changing behaviour.

### What changed

* **Visibility tightened**

  * Converted many test-only helpers, constants, DTOs, and inner classes from `public`/`protected`/package-leaky to `private` or package-local where appropriate (e.g. helper methods, constants such as `PATH_NAME`, `REQUIRED_COUNT`, etc.).
  * Interfaces that are only used within a single test class are now package-local to avoid exporting them inadvertently.

* **Helper methods encapsulated**

  * Methods like `doTest(...)`, `run(...)`, `createQueue(...)`, `writeThreeKeys(...)`, `writeMany(...)`, `readMany(...)`, and similar are now `private` to signal test-internal use and reduce noise in IDE code completion and static analysis.

* **Minor cleanup for clarity / static analysis**

  * Standardised field modifiers on test scaffolding (e.g. blackhole variables, random seeds) to `private` where not intentionally shared.
  * Adjusted a few test DTOs and builders to reduce mutability exposure where not needed.
  * Kept naming and structure intact to preserve readability and diffs.
