### PR TITLE
Selectively roll back surefire arg line change from commit 41b3bda

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,8 +266,8 @@
                     <forkCount>1</forkCount>
                     <!--                    <reuseForks>false</reuseForks>-->
                     <runOrder>hourly</runOrder>
-                    <!-- propagate JPMS flags from parent into unit test JVMs along with jacoco agent -->
-                    <argLine>${surefireArgLine} ${jvm.requiredArgs}</argLine>
+                    <!-- propagate JPMS flags from parent into unit test JVMs -->
+                    <argLine>${argLine} ${jvm.requiredArgs}</argLine>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
argLine was changed in https://github.com/OpenHFT/Chronicle-Queue/commit/41b3bda4608dd936d5745b2173f1ee3791974a11 and this appears to not be compatible with the current release version of the parent pom