### PR TITLE
QUEUE-106 binary search linear scan supports empty roll cycles

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/BinarySearch.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/BinarySearch.java
@@ -84,7 +84,7 @@ public enum BinarySearch {
         if (!iterator.hasNext())
             return -1;
         final RollCycle rollCycle = tailer.queue().rollCycle();
-        long prevIndex = iterator.next();
+        long prevIndex = -1;
 
         cycleLoop:
         while (iterator.hasNext()) {
@@ -93,14 +93,11 @@ public enum BinarySearch {
 
             final boolean b = tailer.moveToIndex(rollCycle.toIndex((int) (long) current, 0));
             if (!b)
-                return prevIndex;
+                continue;
 
             while (true) {
                 try (final DocumentContext dc = tailer.readingDocument()) {
-                    if (!dc.isPresent()) {
-                        return prevIndex;
-                    }
-                    if (rollCycle.toCycle(dc.index()) > current) {
+                    if (!dc.isPresent() || rollCycle.toCycle(dc.index()) > current) {
                         continue cycleLoop;
                     }
                     try {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
@@ -4,6 +4,7 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
@@ -40,7 +41,7 @@ public class TestBinarySearch extends QueueTestCommon {
         this.emptyCyclesStrategy = emptyCyclesStrategy;
     }
 
-    @Parameterized.Parameters(name = "items: {0} verify: {1} strategy: {2}")
+    @Parameterized.Parameters(name = "items: {0} verify: {1} emptyCycles: {2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(runForEveryEmptyCycleStrategy(new Object[][]{
                 {0, 0},
@@ -91,13 +92,13 @@ public class TestBinarySearch extends QueueTestCommon {
                     myData.key = i;
                     myData.value = "some value where the key=" + i;
                     myData.writeMarshallable(dc.wire());
-                    System.out.println("written key: " + myData.key + " at index: " + dc.index() + " cycle: " + appender.cycle());
+                    Jvm.startup().on(getClass(), "written key: " + myData.key + " at index: " + dc.index() + " cycle: " + appender.cycle());
                     stp.advanceMillis(300);
                     keyToIndex.put(myData.key, dc.index());
                 }
 
                 if (i > 0 && numberOfMessages > 10 && i % (numberOfMessages / 10) == 0) {
-                    System.out.println("Written " + i + " messages");
+                    Jvm.startup().on(getClass(), "Written " + i + " messages");
                 }
 
                 if (!writtenEmptyCycles && emptyCyclesStrategy.inMiddle() && appender.cycle() != queue.firstCycle()) {
@@ -106,7 +107,7 @@ public class TestBinarySearch extends QueueTestCommon {
                 }
 
             }
-            System.out.println("Written " + numberOfMessages + " messages");
+            Jvm.startup().on(getClass(), "Written " + numberOfMessages + " messages");
 
             if (emptyCyclesStrategy.atEnd()) {
                 writeEmptyCycles(appender);
@@ -121,8 +122,7 @@ public class TestBinarySearch extends QueueTestCommon {
                 return Integer.compare(o1Key, o2Key);
             };
 
-            try (final ExcerptTailer tailer = queue.createTailer();
-                 final ExcerptTailer binarySearchTailer = queue.createTailer()) {
+            try (final ExcerptTailer binarySearchTailer = queue.createTailer()) {
                 for (int j = 0; j < numberOfMessagesToVerify; j++) {
                     int indexToVerify = (int) retrievalStrategy.retrieveIndex(j, numberOfMessages);
                     Wire key = toWire(indexToVerify);
@@ -132,13 +132,13 @@ public class TestBinarySearch extends QueueTestCommon {
                     key.bytes().releaseLast();
 
                     if (j > 0 && numberOfMessagesToVerify > 10 && j % (numberOfMessagesToVerify / 10) == 0) {
-                        System.out.println("Verified " + j + " messages");
+                        Jvm.startup().on(getClass(), "Verified " + j + " messages");
                     }
                 }
-                System.out.println("Verified " + numberOfMessagesToVerify + " messages");
+                Jvm.startup().on(getClass(), "Verified " + numberOfMessagesToVerify + " messages");
 
                 Wire key = toWire(numberOfMessages);
-                long result = BinarySearch.search(tailer, key, comparator);
+                long result = BinarySearch.search(binarySearchTailer, key, comparator);
                 Assert.assertTrue("Should not find non-existent", result < 0);
             }
         }
@@ -189,7 +189,7 @@ public class TestBinarySearch extends QueueTestCommon {
             }
         },
         RANDOM {
-            final Random random = new Random();
+            final Random random = new Random(234563434L);
             @Override
             public long retrieveIndex(long currentIndex, long totalNumberOfMessages) {
                 return random.nextInt((int) totalNumberOfMessages);
@@ -224,10 +224,6 @@ public class TestBinarySearch extends QueueTestCommon {
 
         public boolean single() {
             return this == SINGLE_EMPTY_AT_START || this == SINGLE_EMPTY_AT_END || this == SINGLE_EMPTY_IN_MIDDLE;
-        }
-
-        public boolean multiple() {
-            return this == MULTIPLE_EMPTY_AT_START || this == MULTIPLE_EMPTY_AT_END || this == MULTIPLE_CONCURRENTLY_EMPTY_IN_MIDDLE;
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
@@ -9,6 +9,7 @@ import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
@@ -19,92 +20,138 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.text.ParseException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
+import java.util.*;
 
-import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class TestBinarySearch extends QueueTestCommon {
 
+    private final Map<Integer, Long> keyToIndex = new HashMap<>();
     private final int numberOfMessages;
+    private final int numberOfMessagesToVerify;
+    private final RetrievalStrategy retrievalStrategy;
+    private final EmptyCyclesStrategy emptyCyclesStrategy;
 
-    public TestBinarySearch(int numberOfMessages) {
+    public TestBinarySearch(int numberOfMessages, int numberOfMessagesToVerify, EmptyCyclesStrategy emptyCyclesStrategy) {
         this.numberOfMessages = numberOfMessages;
+        this.numberOfMessagesToVerify = numberOfMessagesToVerify;
+        this.retrievalStrategy = numberOfMessages == numberOfMessagesToVerify ? RetrievalStrategy.LINEAR : RetrievalStrategy.RANDOM;
+        this.emptyCyclesStrategy = emptyCyclesStrategy;
     }
 
-    @Parameterized.Parameters(name = "items in queue: {0}")
+    @Parameterized.Parameters(name = "items: {0} verify: {1} strategy: {2}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {0},
-                {1},
-                {2},
-                {100}
-        });
+        return Arrays.asList(runForEveryEmptyCycleStrategy(new Object[][]{
+                {0, 0},
+                {1, 1},
+                {2, 2},
+                {10, 10},
+                {100, 50},
+                {100, 100},
+        }));
+    }
+
+    private static Object[][] runForEveryEmptyCycleStrategy(Object[][] parameters) {
+        EmptyCyclesStrategy[] emptyCyclesStrategies = EmptyCyclesStrategy.values();
+        int noStrategies = emptyCyclesStrategies.length;
+        Object[][] result = new Object[parameters.length * noStrategies][];
+        for (int i = 0; i < parameters.length; i++) {
+            Object[] parameter = parameters[i];
+            for (int j = 0; j < noStrategies; j++) {
+                Object[] newParameter = Arrays.copyOf(parameter, parameter.length + 1);
+                newParameter[parameter.length] = emptyCyclesStrategies[j];
+                result[i*noStrategies + j] = newParameter;
+            }
+        }
+        return result;
     }
 
     @Test
-    public void testBinarySearch() throws ParseException {
+    public void testBinarySearch() {
         final SetTimeProvider stp = new SetTimeProvider();
-        long time = 0;
-        stp.currentTimeMillis(time);
+        stp.currentTimeMillis(0);
+
+        boolean writtenEmptyCycles = false;
 
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(getTmpDir())
-                .rollCycle(TEST_SECONDLY)
+                .rollCycle(TestRollCycles.TEST_SECONDLY)
                 .timeProvider(stp)
                 .build();
              final ExcerptAppender appender = queue.createAppender()) {
+
+            if (emptyCyclesStrategy.atStart()) {
+                writeEmptyCycles(appender);
+                writtenEmptyCycles = true;
+            }
 
             for (int i = 0; i < numberOfMessages; i++) {
                 try (final DocumentContext dc = appender.writingDocument()) {
                     final MyData myData = new MyData();
                     myData.key = i;
                     myData.value = "some value where the key=" + i;
-                    dc.wire().getValueOut().typedMarshallable(myData);
-                    time += 300;
-                    stp.currentTimeMillis(time);
+                    myData.writeMarshallable(dc.wire());
+                    System.out.println("written key: " + myData.key + " at index: " + dc.index() + " cycle: " + appender.cycle());
+                    stp.advanceMillis(300);
+                    keyToIndex.put(myData.key, dc.index());
                 }
+
+                if (i > 0 && numberOfMessages > 10 && i % (numberOfMessages / 10) == 0) {
+                    System.out.println("Written " + i + " messages");
+                }
+
+                if (!writtenEmptyCycles && emptyCyclesStrategy.inMiddle() && appender.cycle() != queue.firstCycle()) {
+                    writeEmptyCycles(appender);
+                    writtenEmptyCycles = true;
+                }
+
+            }
+            System.out.println("Written " + numberOfMessages + " messages");
+
+            if (emptyCyclesStrategy.atEnd()) {
+                writeEmptyCycles(appender);
             }
 
+            MyData reusableComparatorData = new MyData();
             final Comparator<Wire> comparator = (o1, o2) -> {
-                final long readPositionO1 = o1.bytes().readPosition();
-                final long readPositionO2 = o2.bytes().readPosition();
-                try {
-                    final MyData myDataO1;
-                    try (final DocumentContext dc = o1.readingDocument()) {
-                        myDataO1 = dc.wire().getValueIn().typedMarshallable();
-                    }
-
-                    final MyData myDataO2;
-                    try (final DocumentContext dc = o2.readingDocument()) {
-                        myDataO2 = dc.wire().getValueIn().typedMarshallable();
-                    }
-
-                    final int compare = Integer.compare(myDataO1.key, myDataO2.key);
-                    return compare;
-                } finally {
-                    o1.bytes().readPosition(readPositionO1);
-                    o2.bytes().readPosition(readPositionO2);
-                }
+                reusableComparatorData.readMarshallable(o1);
+                int o1Key = reusableComparatorData.key;
+                reusableComparatorData.readMarshallable(o2);
+                int o2Key = reusableComparatorData.key;
+                return Integer.compare(o1Key, o2Key);
             };
 
             try (final ExcerptTailer tailer = queue.createTailer();
                  final ExcerptTailer binarySearchTailer = queue.createTailer()) {
-                for (int j = 0; j < numberOfMessages; j++) {
-                    try (DocumentContext ignored = tailer.readingDocument()) {
-                        assert ignored != null;
-                        Wire key = toWire(j);
-                        long index = BinarySearch.search(binarySearchTailer, key, comparator);
-                        Assert.assertEquals(tailer.index(), index);
-                        key.bytes().releaseLast();
+                for (int j = 0; j < numberOfMessagesToVerify; j++) {
+                    int indexToVerify = (int) retrievalStrategy.retrieveIndex(j, numberOfMessages);
+                    Wire key = toWire(indexToVerify);
+                    long index = BinarySearch.search(binarySearchTailer, key, comparator);
+                    long expectedIndex = keyToIndex.get(indexToVerify);
+                    assertEquals("Failed looking for item at index: " + expectedIndex, expectedIndex, index);
+                    key.bytes().releaseLast();
+
+                    if (j > 0 && numberOfMessagesToVerify > 10 && j % (numberOfMessagesToVerify / 10) == 0) {
+                        System.out.println("Verified " + j + " messages");
                     }
                 }
+                System.out.println("Verified " + numberOfMessagesToVerify + " messages");
 
                 Wire key = toWire(numberOfMessages);
-                Assert.assertTrue("Should not find non-existent", BinarySearch.search(tailer, key, comparator) < 0);
+                long result = BinarySearch.search(tailer, key, comparator);
+                Assert.assertTrue("Should not find non-existent", result < 0);
             }
+        }
+    }
+
+    private void writeEmptyCycles(ExcerptAppender appender) {
+        int numberOfEmptyCycles = emptyCyclesStrategy.single() ? 1 : 2;
+        for (int i = 0; i < numberOfEmptyCycles; i++) {
+            try (final DocumentContext dc = appender.writingDocument()) {
+                // easiest way to write an empty cycle is to start writing a document and then rollback
+                dc.rollbackOnClose();
+            }
+            ((SetTimeProvider)appender.queue().time()).advanceMillis(appender.queue().rollCycle().lengthInMillis() + 1);
         }
     }
 
@@ -115,10 +162,7 @@ public class TestBinarySearch extends QueueTestCommon {
         myData.value = Integer.toString(key);
         Wire wire = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
         wire.usePadding(true);
-
-        try (final DocumentContext dc = wire.writingDocument()) {
-            dc.wire().getValueOut().typedMarshallable(myData);
-        }
+        myData.writeMarshallable(wire);
 
         return wire;
     }
@@ -134,6 +178,56 @@ public class TestBinarySearch extends QueueTestCommon {
                     "key=" + key +
                     ", value='" + value + '\'' +
                     '}';
+        }
+    }
+
+    public enum RetrievalStrategy {
+        LINEAR {
+            @Override
+            public long retrieveIndex(long currentIndex, long totalNumberOfMessages) {
+                return currentIndex;
+            }
+        },
+        RANDOM {
+            final Random random = new Random();
+            @Override
+            public long retrieveIndex(long currentIndex, long totalNumberOfMessages) {
+                return random.nextInt((int) totalNumberOfMessages);
+            }
+        };
+
+        public abstract long retrieveIndex(long currentIndex, long totalNumberOfMessages);
+
+    }
+
+    public enum EmptyCyclesStrategy {
+        NO_EMPTY_CYCLES,
+        SINGLE_EMPTY_AT_START,
+        SINGLE_EMPTY_AT_END,
+        MULTIPLE_EMPTY_AT_START,
+        MULTIPLE_EMPTY_AT_END,
+        SINGLE_EMPTY_IN_MIDDLE,
+        MULTIPLE_CONCURRENTLY_EMPTY_IN_MIDDLE
+        ;
+
+        public boolean atStart() {
+            return this == SINGLE_EMPTY_AT_START || this == MULTIPLE_EMPTY_AT_START;
+        }
+
+        public boolean atEnd() {
+            return this == SINGLE_EMPTY_AT_END || this == MULTIPLE_EMPTY_AT_END;
+        }
+
+        public boolean inMiddle() {
+            return this == SINGLE_EMPTY_IN_MIDDLE || this == MULTIPLE_CONCURRENTLY_EMPTY_IN_MIDDLE;
+        }
+
+        public boolean single() {
+            return this == SINGLE_EMPTY_AT_START || this == SINGLE_EMPTY_AT_END || this == SINGLE_EMPTY_IN_MIDDLE;
+        }
+
+        public boolean multiple() {
+            return this == MULTIPLE_EMPTY_AT_START || this == MULTIPLE_EMPTY_AT_END || this == MULTIPLE_CONCURRENTLY_EMPTY_IN_MIDDLE;
         }
     }
 }


### PR DESCRIPTION
Previously the linear scan to determine which roll cycle to binary search for an entry didn't expect roll cycles to be empty. 

When it encountered a roll cycle which contained no documents, it would short circuit to return the previous roll cycle to perform binary search in.

This change starts the search at the first cycle, and removes the short circuiting in the case that there is nothing in the cycle. This change trades performance by a negligible amount in favour of accuracy