### PR TITLE
Migrate Chronicle Queue tests to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,12 +138,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>

--- a/src/test/java/net/openhft/chronicle/queue/AcquireReleaseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/AcquireReleaseTest.java
@@ -11,8 +11,7 @@ import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.queue.impl.StoreFileListener;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.ExecutionException;
@@ -20,8 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class AcquireReleaseTest extends QueueTestCommon {
@@ -66,8 +64,8 @@ public class AcquireReleaseTest extends QueueTestCommon {
 
             BackgroundResourceReleaser.releasePendingResources();
 
-            Assert.assertEquals(iter, acount.get());
-            Assert.assertEquals(iter, qcount.get());
+            assertEquals(iter, acount.get());
+            assertEquals(iter, qcount.get());
         }
         IOTools.deleteDirWithFiles(dir);
     }

--- a/src/test/java/net/openhft/chronicle/queue/AcquireReleaseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/AcquireReleaseTest.java
@@ -22,9 +22,9 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class AcquireReleaseTest extends QueueTestCommon {
+class AcquireReleaseTest extends QueueTestCommon {
     @Test
-    public void testAcquireAndRelease() {
+    void testAcquireAndRelease() {
         File dir = IOTools.createTempDirectory("testAcquireAndRelease").toFile();
 
         AtomicInteger acount = new AtomicInteger();
@@ -71,7 +71,7 @@ public class AcquireReleaseTest extends QueueTestCommon {
     }
 
     @Test
-    public void testReserveAndRelease() {
+    void testReserveAndRelease() {
         File dir = getTmpDir();
 
         SetTimeProvider stp = new SetTimeProvider();
@@ -96,7 +96,7 @@ public class AcquireReleaseTest extends QueueTestCommon {
     }
 
     @Test
-    public void testWithCleanupStoreFilesWithNoDataAcquireAndRelease() throws InterruptedException, ExecutionException {
+    void testWithCleanupStoreFilesWithNoDataAcquireAndRelease() throws InterruptedException, ExecutionException {
         final File dir = getTmpDir();
         final SetTimeProvider stp = new SetTimeProvider();
         final AtomicInteger acount = new AtomicInteger();

--- a/src/test/java/net/openhft/chronicle/queue/AppenderListenerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/AppenderListenerTest.java
@@ -7,9 +7,9 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AppenderListenerTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/AppenderListenerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/AppenderListenerTest.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class AppenderListenerTest extends QueueTestCommon {
+class AppenderListenerTest extends QueueTestCommon {
 
     @Test
-    public void appenderListenerTest() {
+    void appenderListenerTest() {
         String path = OS.getTarget() + "/appenderListenerTest";
         StringBuilder results = new StringBuilder();
         try (ChronicleQueue q = SingleChronicleQueueBuilder.single(path)

--- a/src/test/java/net/openhft/chronicle/queue/CheckHalfWrittenMsgNotSeenByTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CheckHalfWrittenMsgNotSeenByTailerTest.java
@@ -17,13 +17,13 @@ import java.io.InputStreamReader;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class CheckHalfWrittenMsgNotSeenByTailerTest extends QueueTestCommon {
+class CheckHalfWrittenMsgNotSeenByTailerTest extends QueueTestCommon {
     static {
         // load the lass
         HalfWriteAMessage.class.getName();
     }
 
-    public static class HalfWriteAMessage {
+    static class HalfWriteAMessage {
 
         // writes three messages the third messas is half written
         public static void main(String[] args) throws InterruptedException {
@@ -64,7 +64,7 @@ public class CheckHalfWrittenMsgNotSeenByTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void checkTailerOnlyReadsTwoMessageOneProcess() throws InterruptedException {
+    void checkTailerOnlyReadsTwoMessageOneProcess() throws InterruptedException {
         assumeTrue(!OS.isWindows());
         final File queueDirectory = DirectoryUtils.tempDir("halfWritten");
 
@@ -102,7 +102,7 @@ public class CheckHalfWrittenMsgNotSeenByTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void checkTailerOnlyReadsTwoMessageTwoProcesses() throws IOException, InterruptedException {
+    void checkTailerOnlyReadsTwoMessageTwoProcesses() throws IOException, InterruptedException {
         assumeTrue(OS.isLinux() && OS.is64Bit());
         ignoreException("Forced unlocking `chronicle.write.lock` in lock file:target/halfWritten");
 

--- a/src/test/java/net/openhft/chronicle/queue/CheckHalfWrittenMsgNotSeenByTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CheckHalfWrittenMsgNotSeenByTailerTest.java
@@ -7,16 +7,15 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class CheckHalfWrittenMsgNotSeenByTailerTest extends QueueTestCommon {
     static {
@@ -66,7 +65,7 @@ public class CheckHalfWrittenMsgNotSeenByTailerTest extends QueueTestCommon {
 
     @Test
     public void checkTailerOnlyReadsTwoMessageOneProcess() throws InterruptedException {
-        Assume.assumeTrue(!OS.isWindows());
+        assumeTrue(!OS.isWindows());
         final File queueDirectory = DirectoryUtils.tempDir("halfWritten");
 
         HalfWriteAMessage.writeIncompleteMessage(queueDirectory.toString(), false);
@@ -79,15 +78,15 @@ public class CheckHalfWrittenMsgNotSeenByTailerTest extends QueueTestCommon {
              final ExcerptTailer tailer = single.createTailer()) {
 
             try (final DocumentContext dc = tailer.readingDocument()) {
-                Assert.assertTrue(dc.isPresent());
-                Assert.assertEquals("hello world 1", dc.wire().read("key1").text());
-                Assert.assertEquals("hello world 2", dc.wire().read("key2").text());
+                assertTrue(dc.isPresent());
+                assertEquals("hello world 1", dc.wire().read("key1").text());
+                assertEquals("hello world 2", dc.wire().read("key2").text());
             }
 
             try (final DocumentContext dc = tailer.readingDocument()) {
-                Assert.assertTrue(dc.isPresent());
-                Assert.assertEquals("hello world 3", dc.wire().read("key1").text());
-                Assert.assertEquals("hello world 4", dc.wire().read("key2").text());
+                assertTrue(dc.isPresent());
+                assertEquals("hello world 3", dc.wire().read("key1").text());
+                assertEquals("hello world 4", dc.wire().read("key2").text());
             }
 
             try (final DocumentContext dc = tailer.readingDocument()) {
@@ -104,7 +103,7 @@ public class CheckHalfWrittenMsgNotSeenByTailerTest extends QueueTestCommon {
 
     @Test
     public void checkTailerOnlyReadsTwoMessageTwoProcesses() throws IOException, InterruptedException {
-        Assume.assumeTrue(OS.isLinux() && OS.is64Bit());
+        assumeTrue(OS.isLinux() && OS.is64Bit());
         ignoreException("Forced unlocking `chronicle.write.lock` in lock file:target/halfWritten");
 
         final File queueDirectory = DirectoryUtils.tempDir("halfWritten");
@@ -117,15 +116,15 @@ public class CheckHalfWrittenMsgNotSeenByTailerTest extends QueueTestCommon {
              final ExcerptTailer tailer = single.createTailer()) {
 
             try (final DocumentContext dc = tailer.readingDocument()) {
-                Assert.assertTrue(dc.isPresent());
-                Assert.assertEquals("hello world 1", dc.wire().read("key1").text());
-                Assert.assertEquals("hello world 2", dc.wire().read("key2").text());
+                assertTrue(dc.isPresent());
+                assertEquals("hello world 1", dc.wire().read("key1").text());
+                assertEquals("hello world 2", dc.wire().read("key2").text());
             }
 
             try (final DocumentContext dc = tailer.readingDocument()) {
-                Assert.assertTrue(dc.isPresent());
-                Assert.assertEquals("hello world 3", dc.wire().read("key1").text());
-                Assert.assertEquals("hello world 4", dc.wire().read("key2").text());
+                assertTrue(dc.isPresent());
+                assertEquals("hello world 3", dc.wire().read("key1").text());
+                assertEquals("hello world 4", dc.wire().read("key2").text());
             }
 
             try (final DocumentContext dc = tailer.readingDocument()) {

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleAppenderCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleAppenderCycleTest.java
@@ -8,8 +8,8 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This test case replicates the assertion error in Chronicle StoreAppender's checkWritePositionHeaderNumber() method. see
@@ -29,7 +29,7 @@ public class ChronicleAppenderCycleTest extends QueueTestCommon {
     private static final long LATCH_TIMEOUT_MS = 5000;
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleAppenderCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleAppenderCycleTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This test case replicates the assertion error in Chronicle StoreAppender's checkWritePositionHeaderNumber() method. see
  * https://github.com/OpenHFT/Chronicle-Queue/issues/611
  */
-public class ChronicleAppenderCycleTest extends QueueTestCommon {
+class ChronicleAppenderCycleTest extends QueueTestCommon {
 
     private static final long LATCH_TIMEOUT_MS = 5000;
 
@@ -35,7 +35,7 @@ public class ChronicleAppenderCycleTest extends QueueTestCommon {
     }
 
     @Test
-    public void testAppenderCycle() throws IOException {
+    void testAppenderCycle() throws IOException {
         String id = "testAppenderCycle";
         Bytes<?> msg = Bytes.allocateDirect(64);
         try {

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainCliTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainCliTest.java
@@ -6,7 +6,7 @@ package net.openhft.chronicle.queue;
 import net.openhft.chronicle.queue.reader.ChronicleHistoryReader;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -14,7 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ChronicleHistoryReaderMainCliTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainCliTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainCliTest.java
@@ -16,10 +16,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ChronicleHistoryReaderMainCliTest extends QueueTestCommon {
+class ChronicleHistoryReaderMainCliTest extends QueueTestCommon {
 
     @Test
-    public void runConfiguresReaderFromArguments() throws Exception {
+    void runConfiguresReaderFromArguments() throws Exception {
         final Path queueDir = Files.createTempDirectory("history-reader");
         final TestChronicleHistoryReaderMain main = new TestChronicleHistoryReaderMain();
 
@@ -39,7 +39,7 @@ public class ChronicleHistoryReaderMainCliTest extends QueueTestCommon {
     }
 
     @Test
-    public void parseCommandLineWithHelpOption() {
+    void parseCommandLineWithHelpOption() {
         final TestChronicleHistoryReaderMain main = new TestChronicleHistoryReaderMain();
 
         try {
@@ -52,7 +52,7 @@ public class ChronicleHistoryReaderMainCliTest extends QueueTestCommon {
     }
 
     @Test
-    public void parseCommandLineMissingDirectoryPrintsError() {
+    void parseCommandLineMissingDirectoryPrintsError() {
         final TestChronicleHistoryReaderMain main = new TestChronicleHistoryReaderMain();
 
         try {

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainTest.java
@@ -7,17 +7,15 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.queue.reader.ChronicleHistoryReader;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 import java.nio.file.Path;
 import java.security.Permission;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 @SuppressWarnings({"deprecation", "removal"})
 public class ChronicleHistoryReaderMainTest {
@@ -34,14 +32,14 @@ public class ChronicleHistoryReaderMainTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         // SecurityManager is effectively disabled from JDK 17 onwards
         assumeTrue(Jvm.majorVersion() < 17);
         System.setSecurityManager(new NoExitSecurityManager());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         System.setSecurityManager(null);
     }

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 @SuppressWarnings({"deprecation", "removal"})
-public class ChronicleHistoryReaderMainTest {
+class ChronicleHistoryReaderMainTest {
 
     private static class NoExitSecurityManager extends SecurityManager {
         @Override
@@ -33,19 +33,19 @@ public class ChronicleHistoryReaderMainTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         // SecurityManager is effectively disabled from JDK 17 onwards
         assumeTrue(Jvm.majorVersion() < 17);
         System.setSecurityManager(new NoExitSecurityManager());
     }
 
     @AfterEach
-    public void tearDown() {
+    protected void tearDown() {
         System.setSecurityManager(null);
     }
 
     @Test
-    public void testRunExecutesChronicleHistoryReader() {
+    void testRunExecutesChronicleHistoryReader() {
         // Setup
         ChronicleHistoryReaderMain main = new ChronicleHistoryReaderMain() {
             @Override
@@ -65,7 +65,7 @@ public class ChronicleHistoryReaderMainTest {
     }
 
     @Test
-    public void testSetupChronicleHistoryReader() {
+    void testSetupChronicleHistoryReader() {
         // Simulate command line arguments
         String[] args = {"-d", "test-directory", "-p", "-m", "-t", "NANOSECONDS"};
         ChronicleHistoryReaderMain main = new ChronicleHistoryReaderMain();
@@ -116,7 +116,7 @@ public class ChronicleHistoryReaderMainTest {
     }
 
     @Test
-    public void testParseCommandLine() {
+    void testParseCommandLine() {
         // Test that parseCommandLine correctly parses arguments
         ChronicleHistoryReaderMain main = new ChronicleHistoryReaderMain();
         Options options = main.options();
@@ -128,7 +128,7 @@ public class ChronicleHistoryReaderMainTest {
     }
 
     @Test
-    public void testParseCommandLineHelpOption() {
+    void testParseCommandLineHelpOption() {
         ChronicleHistoryReaderMain main = new ChronicleHistoryReaderMain() {
             @Override
             protected void printHelpAndExit(Options options, int status, String message) {
@@ -152,7 +152,7 @@ public class ChronicleHistoryReaderMainTest {
     }
 
     @Test
-    public void testOptionsConfiguration() {
+    void testOptionsConfiguration() {
         ChronicleHistoryReaderMain main = new ChronicleHistoryReaderMain();
         Options options = main.options();
 
@@ -168,7 +168,7 @@ public class ChronicleHistoryReaderMainTest {
     }
 
     @Test
-    public void testPrintHelpAndExit() {
+    void testPrintHelpAndExit() {
         ChronicleHistoryReaderMain main = new ChronicleHistoryReaderMain();
         Options options = main.options();
         try {

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
@@ -26,10 +26,10 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_SECOND
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ChronicleQueueIndexTest extends QueueTestCommon {
+class ChronicleQueueIndexTest extends QueueTestCommon {
 
     @Test
-    public void checkTheEOFisWrittenToPreQueueFileWritingDocumentMetadata() {
+    void checkTheEOFisWrittenToPreQueueFileWritingDocumentMetadata() {
 
         final Consumer<InternalAppender> writer = appender -> {
             try (DocumentContext wd = appender.writingDocument(true)) {
@@ -40,7 +40,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void checkTheEOFisWrittenToPreQueueFileWritingDocument() {
+    void checkTheEOFisWrittenToPreQueueFileWritingDocument() {
         final Consumer<InternalAppender> writer = appender -> {
             try (DocumentContext wd = appender.writingDocument()) {
                 wd.wire().write("key").writeDouble(1);
@@ -101,7 +101,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void testIndexQueue() {
+    void testIndexQueue() {
 
         File file1 = getTmpDir();
         file1.deleteOnExit();
@@ -155,7 +155,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void read5thMessageTest() {
+    void read5thMessageTest() {
         SetTimeProvider stp = new SetTimeProvider();
         stp.currentTimeMillis(CLOCK.currentTimeMillis());
         try (final ChronicleQueue queue = ChronicleQueue
@@ -212,7 +212,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
 
     // https://github.com/OpenHFT/Chronicle-Queue/issues/822
     @Test
-    public void writeReadMetadata() {
+    void writeReadMetadata() {
         try (final ChronicleQueue queue = ChronicleQueue
                 .singleBuilder(getTmpDir())
                 .rollCycle(TEST4_SECONDLY)
@@ -294,7 +294,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void D() {
+    void D() {
         driver(
                 new String[]{"data-1"},
                 new boolean[]{false}
@@ -302,7 +302,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void M() {
+    void M() {
         driver(
                 new String[]{"data-1"},
                 new boolean[]{true}
@@ -310,7 +310,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void DDD() {
+    void DDD() {
         driver(
                 new String[]{"data-1", "data-2", "data-3"},
                 new boolean[]{false, false, false}
@@ -318,7 +318,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void DDM() {
+    void DDM() {
         driver(
                 new String[]{"data-1", "data-2", "meta-1"},
                 new boolean[]{false, false, true}
@@ -326,7 +326,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void DMD() {
+    void DMD() {
         driver(
                 new String[]{"data-1", "meta-1", "data-2"},
                 new boolean[]{false, true, false}
@@ -334,7 +334,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void DMM() {
+    void DMM() {
         driver(
                 new String[]{"data-1", "meta-1", "meta-2"},
                 new boolean[]{false, true, true}
@@ -342,7 +342,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void MMM() {
+    void MMM() {
         driver(
                 new String[]{"meta-1", "meta-2", "meta-3"},
                 new boolean[]{true, true, true}
@@ -350,7 +350,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void MMD() {
+    void MMD() {
         driver(
                 new String[]{"meta-1", "meta-2", "data-1"},
                 new boolean[]{true, true, false}
@@ -358,7 +358,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void MDM() {
+    void MDM() {
         driver(
                 new String[]{"meta-1", "data-1", "meta-2"},
                 new boolean[]{true, false, true}
@@ -366,7 +366,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void MDD() {
+    void MDD() {
         driver(
                 new String[]{"meta-1", "data-1", "data-2"},
                 new boolean[]{true, false, false}

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
@@ -10,8 +10,7 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.Wire;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -25,7 +24,7 @@ import java.util.stream.IntStream;
 import static net.openhft.chronicle.core.time.SystemTimeProvider.CLOCK;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_SECONDLY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ChronicleQueueIndexTest extends QueueTestCommon {
 
@@ -67,7 +66,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
 
             writer1.accept(appender);
 
-            Assert.assertFalse(hasEOFAtEndOfFile(file1));
+            assertFalse(hasEOFAtEndOfFile(file1));
         }
 
         tpConsumer.accept(tp, rollCycle);
@@ -142,7 +141,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
                     results.add(forRead.to8bitString());
                     forRead.clear();
                 }
-                assertTrue(results.toString(), results.contains("Hello World 1"));
+                assertTrue(results.contains("Hello World 1"), results.toString());
                 assertTrue(results.contains("Hello World 2"));
                 // The reader fails to read the third message. The reason for this is
                 // that there was no EOF marker placed at end of the 18264 indexed file
@@ -228,7 +227,7 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
                 dc.wire().write("a").text("hello");
             }
             try (DocumentContext dc = tailer.readingDocument(metadata)) {
-                Assert.assertTrue(dc.isPresent());
+                assertTrue(dc.isPresent());
             }
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMethodsWithoutParametersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMethodsWithoutParametersTest.java
@@ -12,10 +12,10 @@ import java.io.File;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ChronicleQueueMethodsWithoutParametersTest extends QueueTestCommon {
+class ChronicleQueueMethodsWithoutParametersTest extends QueueTestCommon {
 
     @Test
-    public void test() {
+    void test() {
         File file = getTmpDir();
 
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(file)
@@ -50,7 +50,7 @@ public class ChronicleQueueMethodsWithoutParametersTest extends QueueTestCommon 
         void methodWithOneParam(int i);
     }
 
-    public static class SomeManager implements SomeListener {
+    static class SomeManager implements SomeListener {
 
         boolean methodWithoutParamsInvoked = false;
         boolean methodWithOneParamInvoked = false;

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMethodsWithoutParametersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMethodsWithoutParametersTest.java
@@ -5,13 +5,12 @@ package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.core.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ChronicleQueueMethodsWithoutParametersTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMicrobench.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMicrobench.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Idea borrowed from Netty - https://github.com/netty/netty - microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
  */
-public class ChronicleQueueMicrobench {
+class ChronicleQueueMicrobench {
 
     protected static final int DEFAULT_WARMUP_ITERATIONS = 10;
     protected static final int DEFAULT_MEASURE_ITERATIONS = 10;

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMicrobench.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueMicrobench.java
@@ -12,7 +12,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.io.File;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Idea borrowed from Netty - https://github.com/netty/netty - microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTest.java
@@ -9,23 +9,22 @@ import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.OutputStream;
 import java.io.Writer;
 
-import static org.junit.Assert.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("deprecation")
 public class ChronicleQueueTest extends QueueTestCommon {
 
     private static final String PATH_NAME = OS.getTarget() + "/test-path";
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         // Clean up the test directory
         IOTools.deleteDirWithFiles(PATH_NAME);

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTest.java
@@ -20,25 +20,25 @@ import java.io.Writer;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("deprecation")
-public class ChronicleQueueTest extends QueueTestCommon {
+class ChronicleQueueTest extends QueueTestCommon {
 
     private static final String PATH_NAME = OS.getTarget() + "/test-path";
 
     @AfterAll
-    public static void cleanup() {
+    static void cleanup() {
         // Clean up the test directory
         IOTools.deleteDirWithFiles(PATH_NAME);
     }
 
     @Test
-    public void testSingleBuilderCreatesNewInstance() {
+    void testSingleBuilderCreatesNewInstance() {
         // Test that the singleBuilder() method returns a valid SingleChronicleQueueBuilder instance
         SingleChronicleQueueBuilder builder = ChronicleQueue.singleBuilder();
         assertNotNull(builder);
     }
 
     @Test
-    public void testIndexForIdThrowsUnsupportedOperationException() {
+    void testIndexForIdThrowsUnsupportedOperationException() {
         // Test that indexForId(String id) throws an UnsupportedOperationException as expected
         try (ChronicleQueue queue = new StubChronicleQueue()) {
             assertThrows(UnsupportedOperationException.class, () -> queue.indexForId("someId"));
@@ -46,7 +46,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testCreateTailerThrowsUnsupportedOperationExceptionForNamedTailer() {
+    void testCreateTailerThrowsUnsupportedOperationExceptionForNamedTailer() {
         // Test that createTailer(String id) throws an UnsupportedOperationException for the default implementation
         try (ChronicleQueue queue = new StubChronicleQueue()) {
             assertThrows(UnsupportedOperationException.class, () -> queue.createTailer("namedTailer"));
@@ -54,7 +54,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testCreateTailerCreatesNewExcerptTailer() {
+    void testCreateTailerCreatesNewExcerptTailer() {
         // Assuming createTailer() creates a valid ExcerptTailer when not overridden
         try (ChronicleQueue queue = ChronicleQueue.single(PATH_NAME);  // Adjust with a proper path
              ExcerptTailer tailer = queue.createTailer()) {
@@ -63,7 +63,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testFileAbsolutePath() {
+    void testFileAbsolutePath() {
         // Assuming fileAbsolutePath() returns the correct absolute path of the Chronicle Queue
         try (ChronicleQueue queue = ChronicleQueue.single(PATH_NAME)) {  // Use a test path
             String path = queue.fileAbsolutePath();
@@ -73,7 +73,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testDumpCallsOutputStreamWriter() {
+    void testDumpCallsOutputStreamWriter() {
         // Test that dump(OutputStream stream, long fromIndex, long toIndex) calls the writer version correctly
         try (ChronicleQueue queue = new StubChronicleQueue() {
 
@@ -91,7 +91,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testLastIndexReplicatedReturnsMinusOne() {
+    void testLastIndexReplicatedReturnsMinusOne() {
         // Test that lastIndexReplicated() returns -1
         try (ChronicleQueue queue = new StubChronicleQueue()) {
             assertEquals(-1, queue.lastIndexReplicated());
@@ -99,7 +99,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testLastAcknowledgedIndexReplicatedReturnsMinusOne() {
+    void testLastAcknowledgedIndexReplicatedReturnsMinusOne() {
         // Test that lastAcknowledgedIndexReplicated() returns -1
         try (ChronicleQueue queue = new StubChronicleQueue()) {
             assertEquals(-1, queue.lastAcknowledgedIndexReplicated());
@@ -107,7 +107,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testLastIndexMSyncedReturnsMinusOne() {
+    void testLastIndexMSyncedReturnsMinusOne() {
         // Test that lastIndexMSynced() returns -1
         try (ChronicleQueue queue = new StubChronicleQueue()) {
             assertEquals(-1, queue.lastIndexMSynced());
@@ -115,7 +115,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testLastIndexMSyncedThrowsUnsupportedOperationException() {
+    void testLastIndexMSyncedThrowsUnsupportedOperationException() {
         // Test that lastIndexMSynced(long lastIndexMSynced) throws UnsupportedOperationException
         try (ChronicleQueue queue = new StubChronicleQueue()) {
             assertThrows(UnsupportedOperationException.class, () -> queue.lastIndexMSynced(100L));
@@ -123,7 +123,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testAwaitAsyncReturnsTrue() {
+    void testAwaitAsyncReturnsTrue() {
         // Test that awaitAsync() always returns true
         try (ChronicleQueue queue = new StubChronicleQueue()) {
             assertTrue(queue.awaitAsync());
@@ -131,7 +131,7 @@ public class ChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testNonAsyncTailerCallsCreateTailer() {
+    void testNonAsyncTailerCallsCreateTailer() {
         // Test that nonAsyncTailer() calls createTailer()
         try (ChronicleQueue queue = ChronicleQueue.single(PATH_NAME)) {  // Adjust with a proper path
             assertNotNull(queue.nonAsyncTailer());

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
@@ -12,11 +12,9 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.rollcycles.SparseRollCycles.SMALL_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,9 +32,9 @@ class ChronicleQueueTwoThreadsTest extends QueueTestCommon {
         super.threadDump();
     }
 
-    @Disabled("long running test")
     @Test
-    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+    @Disabled("long running test")
+    @Timeout(60)
     void testUnbuffered() throws InterruptedException {
         doTest(false, 50_000);
     }

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
@@ -11,16 +11,14 @@ import net.openhft.chronicle.core.annotation.RequiredForClient;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.File;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static net.openhft.chronicle.queue.rollcycles.SparseRollCycles.SMALL_DAILY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 @RequiredForClient
 public class ChronicleQueueTwoThreadsTest extends QueueTestCommon {
@@ -29,13 +27,14 @@ public class ChronicleQueueTwoThreadsTest extends QueueTestCommon {
     private static final long INTERVAL_US = 10;
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
 
-    @Ignore("long running test")
-    @Test(timeout = 60000)
+    @Disabled("long running test")
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testUnbuffered() throws InterruptedException {
         doTest(false, 50_000);
     }
@@ -161,7 +160,6 @@ public class ChronicleQueueTwoThreadsTest extends QueueTestCommon {
     }
 
     private static void assumeBufferingAvailable() {
-        assumeTrue("BufferMode.Asynchronous requires Chronicle Queue Enterprise",
-                SingleChronicleQueueBuilder.areEnterpriseFeaturesAvailable());
+        assumeTrue(SingleChronicleQueueBuilder.areEnterpriseFeaturesAvailable(), "BufferMode.Asynchronous requires Chronicle Queue Enterprise");
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 @RequiredForClient
-public class ChronicleQueueTwoThreadsTest extends QueueTestCommon {
+class ChronicleQueueTwoThreadsTest extends QueueTestCommon {
 
     private static final int BYTES_LENGTH = 256;
     private static final long INTERVAL_US = 10;
@@ -35,23 +35,23 @@ public class ChronicleQueueTwoThreadsTest extends QueueTestCommon {
     @Disabled("long running test")
     @Test
     @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testUnbuffered() throws InterruptedException {
+    void testUnbuffered() throws InterruptedException {
         doTest(false, 50_000);
     }
 
     @Test
-    public void testConcurrentShortRun() throws InterruptedException {
+    void testConcurrentShortRun() throws InterruptedException {
         doTest(false, 1_000);
     }
 
     @Test
-    public void testBufferedShortRun() throws InterruptedException {
+    void testBufferedShortRun() throws InterruptedException {
         assumeBufferingAvailable();
         doTest(BufferMode.Asynchronous, false, false, 1_000);
     }
 
     @Test
-    public void testBufferedHeapBytes() throws InterruptedException {
+    void testBufferedHeapBytes() throws InterruptedException {
         assumeBufferingAvailable();
         doTest(BufferMode.Asynchronous, true, true, 512);
     }

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueTwoThreadsTest.java
@@ -12,9 +12,11 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.rollcycles.SparseRollCycles.SMALL_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,7 +36,7 @@ class ChronicleQueueTwoThreadsTest extends QueueTestCommon {
 
     @Disabled("long running test")
     @Test
-    @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
     void testUnbuffered() throws InterruptedException {
         doTest(false, 50_000);
     }

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainCliTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainCliTest.java
@@ -40,20 +40,20 @@ class ChronicleReaderMainCliTest extends QueueTestCommon {
 
     @Test
     void invalidContentBasedLimiterClassThrows() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            final java.io.File dir = getTmpDir();
-            ChronicleReaderMain main = new ChronicleReaderMain();
-            main.run(new String[]{"-d", dir.getAbsolutePath(), "-cbl", "not.a.RealClass"});
-        });
+        final java.io.File dir = getTmpDir();
+        ChronicleReaderMain main = new ChronicleReaderMain();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> main.run(new String[]{"-d", dir.getAbsolutePath(), "-cbl", "not.a.RealClass"}));
     }
 
     @Test
     void invalidBinarySearchComparatorClassThrows() {
-        assertThrows(ClassNotFoundException.class, () -> {
-            final java.io.File dir = getTmpDir();
-            ChronicleReaderMain main = new ChronicleReaderMain();
-            main.run(new String[]{"-d", dir.getAbsolutePath(), "-b", "not.a.RealClass"});
-        });
+        final java.io.File dir = getTmpDir();
+        ChronicleReaderMain main = new ChronicleReaderMain();
+
+        assertThrows(ClassNotFoundException.class,
+                () -> main.run(new String[]{"-d", dir.getAbsolutePath(), "-b", "not.a.RealClass"}));
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainCliTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainCliTest.java
@@ -8,12 +8,12 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.queue.reader.ChronicleReader;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ChronicleReaderMainCliTest extends QueueTestCommon {
 
@@ -35,21 +35,25 @@ public class ChronicleReaderMainCliTest extends QueueTestCommon {
         }
 
         final String out = capture.toString();
-        assertTrue("Expected output to contain written text", out.contains("hello"));
+        assertTrue(out.contains("hello"), "Expected output to contain written text");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void invalidContentBasedLimiterClassThrows() {
-        final java.io.File dir = getTmpDir();
-        ChronicleReaderMain main = new ChronicleReaderMain();
-        main.run(new String[]{"-d", dir.getAbsolutePath(), "-cbl", "not.a.RealClass"});
+        assertThrows(IllegalArgumentException.class, () -> {
+            final java.io.File dir = getTmpDir();
+            ChronicleReaderMain main = new ChronicleReaderMain();
+            main.run(new String[]{"-d", dir.getAbsolutePath(), "-cbl", "not.a.RealClass"});
+        });
     }
 
-    @Test(expected = ClassNotFoundException.class)
+    @Test
     public void invalidBinarySearchComparatorClassThrows() {
-        final java.io.File dir = getTmpDir();
-        ChronicleReaderMain main = new ChronicleReaderMain();
-        main.run(new String[]{"-d", dir.getAbsolutePath(), "-b", "not.a.RealClass"});
+        assertThrows(ClassNotFoundException.class, () -> {
+            final java.io.File dir = getTmpDir();
+            ChronicleReaderMain main = new ChronicleReaderMain();
+            main.run(new String[]{"-d", dir.getAbsolutePath(), "-b", "not.a.RealClass"});
+        });
     }
 
     @Test
@@ -79,7 +83,7 @@ public class ChronicleReaderMainCliTest extends QueueTestCommon {
         final String out = capture.toString();
         assertTrue(out.contains("second"));
         assertTrue(out.contains("third"));
-        assertTrue("Start index should skip earlier entries", !out.contains("first"));
+        assertTrue(!out.contains("first"), "Start index should skip earlier entries");
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainCliTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainCliTest.java
@@ -15,10 +15,10 @@ import java.io.PrintStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ChronicleReaderMainCliTest extends QueueTestCommon {
+class ChronicleReaderMainCliTest extends QueueTestCommon {
 
     @Test
-    public void mainReadsAndPrintsQueueRecords() {
+    void mainReadsAndPrintsQueueRecords() {
         final java.io.File dir = getTmpDir();
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(dir).build();
              ExcerptAppender appender = queue.createAppender()) {
@@ -39,7 +39,7 @@ public class ChronicleReaderMainCliTest extends QueueTestCommon {
     }
 
     @Test
-    public void invalidContentBasedLimiterClassThrows() {
+    void invalidContentBasedLimiterClassThrows() {
         assertThrows(IllegalArgumentException.class, () -> {
             final java.io.File dir = getTmpDir();
             ChronicleReaderMain main = new ChronicleReaderMain();
@@ -48,7 +48,7 @@ public class ChronicleReaderMainCliTest extends QueueTestCommon {
     }
 
     @Test
-    public void invalidBinarySearchComparatorClassThrows() {
+    void invalidBinarySearchComparatorClassThrows() {
         assertThrows(ClassNotFoundException.class, () -> {
             final java.io.File dir = getTmpDir();
             ChronicleReaderMain main = new ChronicleReaderMain();
@@ -57,7 +57,7 @@ public class ChronicleReaderMainCliTest extends QueueTestCommon {
     }
 
     @Test
-    public void mainHonoursStartIndex() {
+    void mainHonoursStartIndex() {
         final java.io.File dir = getTmpDir();
         long secondIndex;
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(dir).build();
@@ -87,7 +87,7 @@ public class ChronicleReaderMainCliTest extends QueueTestCommon {
     }
 
     @Test
-    public void methodReaderOptionsEnableMessageHistory() {
+    void methodReaderOptionsEnableMessageHistory() {
         final java.io.File dir = getTmpDir();
         TestChronicleReaderMain main = new TestChronicleReaderMain();
 

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.apache.commons.cli.Options;
 import org.junit.jupiter.api.Test;
 
@@ -16,10 +17,10 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Unit tests for ChronicleReaderMain class.
  */
-public class ChronicleReaderMainTest extends QueueTestCommon {
+class ChronicleReaderMainTest extends QueueTestCommon {
 
     @Test
-    public void testMainWithValidArguments() {
+    void testMainWithValidArguments() {
         ignoreException("Metadata file not found in readOnly mode");
         try {
             // Create a temporary directory for the test
@@ -58,7 +59,7 @@ public class ChronicleReaderMainTest extends QueueTestCommon {
     }
 
     @Test
-    public void testOptionsConfiguration() {
+    void testOptionsConfiguration() {
         ChronicleReaderMain main = new ChronicleReaderMain();
         Options options = main.options();
 

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleReaderMainTest.java
@@ -3,15 +3,15 @@
  */
 package net.openhft.chronicle.queue;
 
-import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.commons.cli.Options;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for ChronicleReaderMain class.
@@ -39,7 +39,7 @@ public class ChronicleReaderMainTest extends QueueTestCommon {
 
                 ChronicleReaderMain.main(args);  // Run the main method with valid args
 
-                assertTrue("Expected valid arguments to run without issues.", true);
+                assertTrue(true, "Expected valid arguments to run without issues.");
             } finally {
                 // Reset System.out and System.err
                 System.setOut(originalOut);

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleRollingIssueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleRollingIssueTest.java
@@ -10,9 +10,9 @@ import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.StoreFileListener;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,13 +28,13 @@ public class ChronicleRollingIssueTest extends QueueTestCommon {
     private String path;
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
         path = OS.getTarget() + "/" + getClass().getSimpleName() + "-" + Time.uniqueId();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         IOTools.deleteDirWithFiles(path);
     }

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleRollingIssueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleRollingIssueTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 
 @RequiredForClient
-public class ChronicleRollingIssueTest extends QueueTestCommon {
+class ChronicleRollingIssueTest extends QueueTestCommon {
 
     private String path;
 
@@ -35,12 +35,12 @@ public class ChronicleRollingIssueTest extends QueueTestCommon {
     }
 
     @AfterEach
-    public void tearDown() {
+    protected void tearDown() {
         IOTools.deleteDirWithFiles(path);
     }
 
     @Test
-    public void test() throws InterruptedException {
+    void test() throws InterruptedException {
         int threads = Math.min(64, Runtime.getRuntime().availableProcessors() * 4) - 1;
         int messages = 100;
 

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleWriterMainCliTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleWriterMainCliTest.java
@@ -4,18 +4,16 @@
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.OS;
-import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import net.openhft.chronicle.wire.WireType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ChronicleWriterMainCliTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleWriterMainCliTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleWriterMainCliTest.java
@@ -15,15 +15,15 @@ import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ChronicleWriterMainCliTest extends QueueTestCommon {
+class ChronicleWriterMainCliTest extends QueueTestCommon {
 
     @Test
-    public void mainWritesYamlFilesToQueue() throws Exception {
+    void mainWritesYamlFilesToQueue() throws Exception {
         final Path queueDir = getTmpDir().toPath();
         final Path payload = Files.createTempFile(Paths.get(OS.getTarget()), "writer-cli", ".yaml");
         Files.write(payload, "!int 42\n".getBytes(StandardCharsets.UTF_8));
 
-        ChronicleWriterMain.main(new String[] {
+        ChronicleWriterMain.main(new String[]{
                 "-d", queueDir.toString(),
                 "-m", "value",
                 payload.toString()
@@ -42,7 +42,7 @@ public class ChronicleWriterMainCliTest extends QueueTestCommon {
     }
 
     @Test
-    public void mainAcceptsMultipleFiles() throws Exception {
+    void mainAcceptsMultipleFiles() throws Exception {
         final Path queueDir = getTmpDir().toPath();
         final Path payloadOne = Files.createTempFile(Paths.get(OS.getTarget()), "writer-cli", ".yaml");
         final Path payloadTwo = Files.createTempFile(Paths.get(OS.getTarget()), "writer-cli", ".yaml");

--- a/src/test/java/net/openhft/chronicle/queue/ChunkCountTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChunkCountTest.java
@@ -8,19 +8,19 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.DAILY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class ChunkCountTest extends QueueTestCommon {
     @Test
     public void chunks() {
         File tempFile = IOTools.createTempFile("chunks");
-        Assume.assumeFalse("Ignored on hugetlbfs as chunk count will vary under huge pages", PageUtil.isHugePage(tempFile.getAbsolutePath()));
+        assumeFalse(PageUtil.isHugePage(tempFile.getAbsolutePath()), "Ignored on hugetlbfs as chunk count will vary under huge pages");
         final SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder
                 .binary(tempFile)
                 .testBlockSize()
@@ -39,7 +39,7 @@ public class ChunkCountTest extends QueueTestCommon {
                 }
                 final long expected = 1 + (pos >> 18);
 
-                assertEquals("i: " + i, expected, queue.chunkCount());
+                assertEquals(expected, queue.chunkCount(), "i: " + i);
             }
         } finally {
             IOTools.deleteDirWithFiles(tempFile);

--- a/src/test/java/net/openhft/chronicle/queue/ChunkCountTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChunkCountTest.java
@@ -16,9 +16,9 @@ import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class ChunkCountTest extends QueueTestCommon {
+class ChunkCountTest extends QueueTestCommon {
     @Test
-    public void chunks() {
+    void chunks() {
         File tempFile = IOTools.createTempFile("chunks");
         assumeFalse(PageUtil.isHugePage(tempFile.getAbsolutePath()), "Ignored on hugetlbfs as chunk count will vary under huge pages");
         final SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder

--- a/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Disabled("long running")
 @TestMethodOrder(MethodOrderer.MethodName.class)
 @RequiredForClient
-public class ContendedWriterTest extends QueueTestCommon {
+class ContendedWriterTest extends QueueTestCommon {
     private static final long NUMBER_OF_LONGS = 3;
     private final AtomicBoolean running = new AtomicBoolean(true);
 
@@ -37,64 +37,64 @@ public class ContendedWriterTest extends QueueTestCommon {
     }
 
     @Test
-    public void oneThread() {
+    void oneThread() {
         test("oneThread", new Config(false, 1, 0));
     }
 
     @Test
-    public void oneThreadDeferred() {
+    void oneThreadDeferred() {
         test("oneThreadDeferred", new Config(true, 1, 0));
     }
 
     @Test
-    public void sixThreads() {
+    void sixThreads() {
         Config config15 = new Config(false, 1, 5);
         test("sixThreads", config15, config15, config15, config15, config15, config15);
     }
 
     @Test
-    public void sixThreadsDeferred() {
+    void sixThreadsDeferred() {
         Config config15 = new Config(true, 1, 5);
         test("sixThreadsDeferred", config15, config15, config15, config15, config15, config15);
     }
 
     @Test
-    public void twoThreadsWritingLargeMessagesAtSameSlowRate() {
+    void twoThreadsWritingLargeMessagesAtSameSlowRate() {
         test("twoThreadsWritingLargeMessagesAtSameSlowRate",
                 new Config(false, 1, 5),
                 new Config(false, 1, 5));
     }
 
     @Test
-    public void twoThreadsWritingLargeMessagesAtSameSlowRateBothDeferred() {
+    void twoThreadsWritingLargeMessagesAtSameSlowRateBothDeferred() {
         test("twoThreadsWritingLargeMessagesAtSameSlowRateBothDeferred",
                 new Config(true, 1, 5),
                 new Config(true, 1, 5));
     }
 
     @Test
-    public void twoThreadsWritingLargeMessagesOneFastOneSlow() {
+    void twoThreadsWritingLargeMessagesOneFastOneSlow() {
         test("twoThreadsWritingLargeMessagesOneFastOneSlow",
                 new Config(false, 1, 0),
                 new Config(false, 1, 5));
     }
 
     @Test
-    public void twoThreadsWritingLargeMessagesOneFastOneSlowAndDeferred() {
+    void twoThreadsWritingLargeMessagesOneFastOneSlowAndDeferred() {
         test("twoThreadsWritingLargeMessagesOneFastOneSlowAndDeferred",
                 new Config(false, 1, 0),
                 new Config(true, 1, 5));
     }
 
     @Test
-    public void twoThreadsWritingLargeMessagesFastAndSmallMessagesSlow() {
+    void twoThreadsWritingLargeMessagesFastAndSmallMessagesSlow() {
         test("twoThreadsWritingLargeMessagesFastAndSmallMessagesSlow",
                 new Config(false, 1, 0),
                 new Config(false, 0, 5));
     }
 
     @Test
-    public void twoThreadsWritingLargeMessagesFastAndSmallMessagesSlowAndDeferred() {
+    void twoThreadsWritingLargeMessagesFastAndSmallMessagesSlowAndDeferred() {
         test("twoThreadsWritingLargeMessagesFastAndSmallMessagesSlowAndDeferred",
                 new Config(false, 1, 0),
                 new Config(true, 0, 5));

--- a/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ContendedWriterTest.java
@@ -12,26 +12,26 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.*;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.File;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-@Ignore("long running")
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@Disabled("long running")
+@TestMethodOrder(MethodOrderer.MethodName.class)
 @RequiredForClient
 public class ContendedWriterTest extends QueueTestCommon {
     private static final long NUMBER_OF_LONGS = 3;
     private final AtomicBoolean running = new AtomicBoolean(true);
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }

--- a/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
@@ -19,7 +19,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class CreateAtIndexTest extends QueueTestCommon {
+class CreateAtIndexTest extends QueueTestCommon {
 
     @Test
     public void
@@ -91,7 +91,7 @@ public class CreateAtIndexTest extends QueueTestCommon {
     }
 
     @Test
-    public void testWrittenAndReadIndexesAreTheSameOfTheFirstExcerpt() {
+    void testWrittenAndReadIndexesAreTheSameOfTheFirstExcerpt() {
         File tmp = getTmpDir();
 
         long expected;

--- a/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
@@ -10,15 +10,13 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.impl.single.IllegalIndexException;
 import net.openhft.chronicle.queue.impl.single.InternalAppender;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.single;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class CreateAtIndexTest extends QueueTestCommon {
@@ -108,7 +106,7 @@ public class CreateAtIndexTest extends QueueTestCommon {
                 dc.wire().write().text("some-data");
 
                 expected = dc.index();
-                Assert.assertTrue(expected > 0);
+                assertTrue(expected > 0);
 
             }
 
@@ -121,16 +119,16 @@ public class CreateAtIndexTest extends QueueTestCommon {
 
                 {
                     long actualIndex = dc.index();
-                    Assert.assertTrue(actualIndex > 0);
+                    assertTrue(actualIndex > 0);
 
-                    Assert.assertEquals(expected, actualIndex);
+                    assertEquals(expected, actualIndex);
                 }
 
                 {
                     long actualIndex = tailer.index();
-                    Assert.assertTrue(actualIndex > 0);
+                    assertTrue(actualIndex > 0);
 
-                    Assert.assertEquals(expected, actualIndex);
+                    assertEquals(expected, actualIndex);
                 }
             }
         }

--- a/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
@@ -20,7 +20,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class CycleNotFoundTest extends QueueTestCommon {
+class CycleNotFoundTest extends QueueTestCommon {
 
     private static final int NUMBER_OF_TAILERS = 20;
     private static final long INTERVAL_US = 50;
@@ -36,7 +36,7 @@ public class CycleNotFoundTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 50_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void tailerCycleNotFoundTest() throws InterruptedException, ExecutionException {
+    void tailerCycleNotFoundTest() throws InterruptedException, ExecutionException {
         File path = getTmpDir();  // added nano time just to make
 
         ExecutorService executorService = Executors.newFixedThreadPool((int) NUMBER_OF_MSG,

--- a/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -37,7 +36,7 @@ class CycleNotFoundTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 50_000L, unit = TimeUnit.MILLISECONDS)
+    @Timeout(50)
     void tailerCycleNotFoundTest() throws InterruptedException, ExecutionException {
         File path = getTmpDir();  // added nano time just to make
 

--- a/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
@@ -7,9 +7,8 @@ import net.openhft.chronicle.core.annotation.RequiredForClient;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -18,7 +17,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class CycleNotFoundTest extends QueueTestCommon {
@@ -29,12 +28,14 @@ public class CycleNotFoundTest extends QueueTestCommon {
     // reduced so that it runs quicker for the continuous integration (CI)
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
 
-    @Test(timeout = 50_000L)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 50_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void tailerCycleNotFoundTest() throws InterruptedException, ExecutionException {
         File path = getTmpDir();  // added nano time just to make
 
@@ -60,19 +61,19 @@ public class CycleNotFoundTest extends QueueTestCommon {
                         if (!dc.isPresent())
                             continue;
 
-                        Assert.assertTrue(dc.isData());
-                        Assert.assertEquals(last + 1, last = dc.wire().read().int64());
+                        assertTrue(dc.isData());
+                        assertEquals(last + 1, last = dc.wire().read().int64());
                         count++;
                         counter.incrementAndGet();
                     }
 
                     if (executorService.isShutdown())
-                        Assert.fail();
+                        fail();
                 }
 
                 // check nothing after the NUMBER_OF_MSG
                 try (DocumentContext dc = tailer.readingDocument()) {
-                    Assert.assertFalse(dc.isPresent());
+                    assertFalse(dc.isPresent());
                 }
             } finally {
                 // System.out.printf("Read %,d messages, thread=" + Thread.currentThread().getName() + "\n", count);

--- a/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CycleNotFoundTest.java
@@ -8,10 +8,12 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -35,7 +37,7 @@ class CycleNotFoundTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 50_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 50_000L, unit = TimeUnit.MILLISECONDS)
     void tailerCycleNotFoundTest() throws InterruptedException, ExecutionException {
         File path = getTmpDir();  // added nano time just to make
 

--- a/src/test/java/net/openhft/chronicle/queue/DiskSpaceMonitoringIntegrationTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DiskSpaceMonitoringIntegrationTest.java
@@ -16,7 +16,7 @@ import java.lang.reflect.Field;
 import java.nio.file.FileStore;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Whilst {@link DiskSpaceMonitor} is defined in the Threads module Queue is heavily dependent on it. Of particular

--- a/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
@@ -9,10 +9,10 @@ import net.openhft.chronicle.core.annotation.RequiredForClient;
 import net.openhft.chronicle.wire.BytesInBinaryMarshallable;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class DtoBytesMarshallableTest extends QueueTestCommon {
@@ -37,7 +37,7 @@ public class DtoBytesMarshallableTest extends QueueTestCommon {
             try (DocumentContext dc = q.createTailer().readingDocument()) {
 
                 DtoBytesMarshallable who = (DtoBytesMarshallable) dc.wire().read("who").object();
-                Assert.assertEquals("!net.openhft.chronicle.queue.DtoBytesMarshallableTest$DtoBytesMarshallable {\n" +
+                assertEquals("!net.openhft.chronicle.queue.DtoBytesMarshallableTest$DtoBytesMarshallable {\n" +
                         "  name: rob,\n" +
                         "  age: 45\n" +
                         "}\n", who.toString());
@@ -69,7 +69,7 @@ public class DtoBytesMarshallableTest extends QueueTestCommon {
                 DtoAbstractMarshallable who = (DtoAbstractMarshallable) dc.wire().read("who").object();
                 // System.out.println(who);
 
-                Assert.assertTrue(yaml.contains(who.toString()));
+                assertTrue(yaml.contains(who.toString()));
             }
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DtoBytesMarshallableTest.java
@@ -12,13 +12,14 @@ import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class DtoBytesMarshallableTest extends QueueTestCommon {
+class DtoBytesMarshallableTest extends QueueTestCommon {
 
     @Test
-    public void testDtoBytesMarshallable() {
+    void testDtoBytesMarshallable() {
 
         File tmp = getTmpDir();
 
@@ -46,7 +47,7 @@ public class DtoBytesMarshallableTest extends QueueTestCommon {
     }
 
     @Test
-    public void testDtoAbstractMarshallable() {
+    void testDtoAbstractMarshallable() {
 
         File tmp = getTmpDir();
 

--- a/src/test/java/net/openhft/chronicle/queue/DumpQueueMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DumpQueueMainTest.java
@@ -7,15 +7,14 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.queue.main.DumpMain;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DumpQueueMainTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/DumpQueueMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/DumpQueueMainTest.java
@@ -16,10 +16,10 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class DumpQueueMainTest extends QueueTestCommon {
+class DumpQueueMainTest extends QueueTestCommon {
 
     @Test
-    public void shouldBeAbleToDumpReadOnlyQueueFile() throws IOException {
+    void shouldBeAbleToDumpReadOnlyQueueFile() throws IOException {
         if (OS.isWindows())
             return;
 
@@ -47,7 +47,7 @@ public class DumpQueueMainTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldDumpDirectoryListing() {
+    void shouldDumpDirectoryListing() {
         final File dataDir = getTmpDir();
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.
                 binary(dataDir).

--- a/src/test/java/net/openhft/chronicle/queue/ExcerptAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ExcerptAppenderTest.java
@@ -10,12 +10,12 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.UnrecoverableTimeoutException;
 import net.openhft.chronicle.wire.Wire;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for ExcerptAppender interface implementations.
@@ -92,7 +92,7 @@ public class ExcerptAppenderTest extends QueueTestCommon {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         IOTools.deleteDirWithFiles(TEST_QUEUE);
     }

--- a/src/test/java/net/openhft/chronicle/queue/ExcerptAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ExcerptAppenderTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Unit tests for ExcerptAppender interface implementations.
  */
-public class ExcerptAppenderTest extends QueueTestCommon {
+class ExcerptAppenderTest extends QueueTestCommon {
 
     private static final String TEST_QUEUE = OS.getTarget() + "/ExcerptAppenderTest";
 
@@ -93,12 +93,12 @@ public class ExcerptAppenderTest extends QueueTestCommon {
     }
 
     @AfterAll
-    public static void cleanup() {
+    static void cleanup() {
         IOTools.deleteDirWithFiles(TEST_QUEUE);
     }
 
     @Test
-    public void testWriteBytes() {
+    void testWriteBytes() {
         ExcerptAppenderImpl appender = new ExcerptAppenderImpl();
         Bytes<byte[]> bytes = Bytes.wrapForRead("Test data".getBytes(StandardCharsets.UTF_8));
 
@@ -108,7 +108,7 @@ public class ExcerptAppenderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testLastIndexAppended() {
+    void testLastIndexAppended() {
         ExcerptAppenderImpl appender = new ExcerptAppenderImpl();
 
         assertEquals(0, appender.lastIndexAppended());
@@ -120,21 +120,21 @@ public class ExcerptAppenderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testCycle() {
+    void testCycle() {
         ExcerptAppenderImpl appender = new ExcerptAppenderImpl();
 
         assertEquals(1, appender.cycle());
     }
 
     @Test
-    public void testWire() {
+    void testWire() {
         ExcerptAppenderImpl appender = new ExcerptAppenderImpl();
 
         assertNull(appender.wire());  // As wire is not set in this example
     }
 
     @Test
-    public void testPretouch() {
+    void testPretouch() {
         ExcerptAppenderImpl appender = new ExcerptAppenderImpl();
         long before = appender.lastIndexAppended();
         appender.pretouch();
@@ -143,7 +143,7 @@ public class ExcerptAppenderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testNormaliseEOFs() {
+    void testNormaliseEOFs() {
         ExcerptAppenderImpl appender = new ExcerptAppenderImpl();
         long before = appender.lastIndexAppended();
         appender.normaliseEOFs();

--- a/src/test/java/net/openhft/chronicle/queue/ExcerptCommonTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ExcerptCommonTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Unit tests for ExcerptCommon interface implementations.
  */
-public class ExcerptCommonTest extends QueueTestCommon {
+class ExcerptCommonTest extends QueueTestCommon {
 
     private static final String TEST_QUEUE = OS.getTarget() + "/ExcerptCommonTest";
 
@@ -70,7 +70,7 @@ public class ExcerptCommonTest extends QueueTestCommon {
     }
 
     @Test
-    public void testSourceId() {
+    void testSourceId() {
         try (ChronicleQueue queue = ChronicleQueue.single(TEST_QUEUE)) {
             ExcerptCommonImpl excerpt = new ExcerptCommonImpl(123, queue, null);
             assertEquals(123, excerpt.sourceId());
@@ -78,7 +78,7 @@ public class ExcerptCommonTest extends QueueTestCommon {
     }
 
     @Test
-    public void testQueue() {
+    void testQueue() {
         try (ChronicleQueue queue = ChronicleQueue.single(TEST_QUEUE)) {
             ExcerptCommonImpl excerpt = new ExcerptCommonImpl(123, queue, null);
             assertEquals(queue, excerpt.queue());
@@ -86,7 +86,7 @@ public class ExcerptCommonTest extends QueueTestCommon {
     }
 
     @Test
-    public void testCurrentFile() {
+    void testCurrentFile() {
         File file = new File("testfile.txt");
         try (ChronicleQueue queue = ChronicleQueue.single(TEST_QUEUE)) {
             ExcerptCommonImpl excerpt = new ExcerptCommonImpl(123, queue, file);
@@ -98,7 +98,7 @@ public class ExcerptCommonTest extends QueueTestCommon {
     }
 
     @Test
-    public void testSync() {
+    void testSync() {
         try (ChronicleQueue queue = ChronicleQueue.single(TEST_QUEUE)) {
             ExcerptCommonImpl excerpt = new ExcerptCommonImpl(123, queue, null);
             excerpt.sync(); // Would test actual sync if implemented

--- a/src/test/java/net/openhft/chronicle/queue/ExcerptCommonTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ExcerptCommonTest.java
@@ -4,12 +4,11 @@
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.OS;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for ExcerptCommon interface implementations.

--- a/src/test/java/net/openhft/chronicle/queue/ExcerptTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ExcerptTailerTest.java
@@ -12,53 +12,53 @@ import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ExcerptTailerTest extends QueueTestCommon {
+class ExcerptTailerTest extends QueueTestCommon {
 
     private ExcerptTailer excerptTailer;
     private ChronicleQueue queue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         File dir = new File(System.getProperty("java.io.tmpdir"), "queue-test");
         queue = ChronicleQueue.single(dir.getPath());
         excerptTailer = queue.createTailer();
     }
 
     @AfterEach
-    public void tearDown() {
+    protected void tearDown() {
         excerptTailer.close();
         queue.close();
     }
 
     @Test
-    public void testReadingDocumentWithMetaData() {
+    void testReadingDocumentWithMetaData() {
         try (DocumentContext dc = excerptTailer.readingDocument(true)) {
             assertNotNull(dc);
         }
     }
 
     @Test
-    public void testReadingDocumentWithoutMetaData() {
+    void testReadingDocumentWithoutMetaData() {
         try (DocumentContext dc = excerptTailer.readingDocument(false)) {
             assertNotNull(dc);
         }
     }
 
     @Test
-    public void testIndex() {
+    void testIndex() {
         long index = excerptTailer.index();
         assertTrue(index >= 0);
     }
 
     @Test
-    public void testLastReadIndex() {
+    void testLastReadIndex() {
         // The last read index may return -1 or 0 depending on the state
         long lastReadIndex = excerptTailer.lastReadIndex();
         assertTrue(lastReadIndex == -1 || lastReadIndex == 0);
     }
 
     @Test
-    public void testCycle() {
+    void testCycle() {
         // Since no data has been read, cycle should be Integer.MIN_VALUE as no cycle has been loaded
         int cycle = excerptTailer.cycle();
         assertEquals(Integer.MIN_VALUE, cycle);

--- a/src/test/java/net/openhft/chronicle/queue/ExcerptTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ExcerptTailerTest.java
@@ -4,27 +4,27 @@
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExcerptTailerTest extends QueueTestCommon {
 
     private ExcerptTailer excerptTailer;
     private ChronicleQueue queue;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         File dir = new File(System.getProperty("java.io.tmpdir"), "queue-test");
         queue = ChronicleQueue.single(dir.getPath());
         excerptTailer = queue.createTailer();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         excerptTailer.close();
         queue.close();

--- a/src/test/java/net/openhft/chronicle/queue/HugetlbfsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/HugetlbfsTest.java
@@ -6,7 +6,6 @@ package net.openhft.chronicle.queue;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import net.openhft.chronicle.queue.util.HugetlbfsTestUtil;
 import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.queue.util.HugetlbfsTestUtil.getHugetlbfsQueueDirectory;

--- a/src/test/java/net/openhft/chronicle/queue/HugetlbfsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/HugetlbfsTest.java
@@ -14,10 +14,10 @@ import static net.openhft.chronicle.queue.util.HugetlbfsTestUtil.isHugetlbfsAvai
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class HugetlbfsTest extends QueueTestCommon {
+class HugetlbfsTest extends QueueTestCommon {
 
     @Test
-    public void queueHugetlbfsEndToEndSimpleAcceptanceTest() {
+    void queueHugetlbfsEndToEndSimpleAcceptanceTest() {
         assumeTrue(isHugetlbfsAvailable());
         String path = getHugetlbfsQueueDirectory(testMethodName);
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single()

--- a/src/test/java/net/openhft/chronicle/queue/HugetlbfsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/HugetlbfsTest.java
@@ -6,24 +6,20 @@ package net.openhft.chronicle.queue;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import net.openhft.chronicle.queue.util.HugetlbfsTestUtil;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.queue.util.HugetlbfsTestUtil.getHugetlbfsQueueDirectory;
 import static net.openhft.chronicle.queue.util.HugetlbfsTestUtil.isHugetlbfsAvailable;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class HugetlbfsTest extends QueueTestCommon {
-
-    @Rule
-    public TestName testName = new TestName();
 
     @Test
     public void queueHugetlbfsEndToEndSimpleAcceptanceTest() {
         assumeTrue(isHugetlbfsAvailable());
-        String path = getHugetlbfsQueueDirectory(testName);
+        String path = getHugetlbfsQueueDirectory(testMethodName);
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single()
                 .path(path)
                 .build();

--- a/src/test/java/net/openhft/chronicle/queue/IgnoreMethodBasedOnFirstArgTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/IgnoreMethodBasedOnFirstArgTest.java
@@ -7,9 +7,9 @@ import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.MethodFilterOnFirstArg;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IgnoreMethodBasedOnFirstArgTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/IgnoreMethodBasedOnFirstArgTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/IgnoreMethodBasedOnFirstArgTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class IgnoreMethodBasedOnFirstArgTest extends QueueTestCommon {
+class IgnoreMethodBasedOnFirstArgTest extends QueueTestCommon {
 
     private static final String EXPECTED_ENVELOPE = "for:rob";
     private static final String MSG = "hello world";
@@ -21,7 +21,7 @@ public class IgnoreMethodBasedOnFirstArgTest extends QueueTestCommon {
     }
 
     @Test
-    public void testIgnoreMethodBasedOnFirstArg() {
+    void testIgnoreMethodBasedOnFirstArg() {
         try (SingleChronicleQueue build = SingleChronicleQueueBuilder.binary(DirectoryUtils.tempDir("q")).build()) {
             Printer printer = build.methodWriter(Printer.class);
             printer.print(EXPECTED_ENVELOPE, MSG);

--- a/src/test/java/net/openhft/chronicle/queue/IncompleteMessageTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/IncompleteMessageTest.java
@@ -7,18 +7,17 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.ValueOut;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IncompleteMessageTest extends QueueTestCommon {
-    @Rule
-    public TemporaryFolder tmpDir = new TemporaryFolder();
+    @TempDir
+    Path tmpDir;
 
     @Test
     public void incompleteMessageShouldBeSkipped() {
@@ -52,6 +51,6 @@ public class IncompleteMessageTest extends QueueTestCommon {
     }
 
     private SingleChronicleQueue createQueue() {
-        return SingleChronicleQueueBuilder.binary(tmpDir.getRoot()).timeoutMS(250).build();
+        return SingleChronicleQueueBuilder.binary(tmpDir.toFile()).timeoutMS(250).build();
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/IncompleteMessageTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/IncompleteMessageTest.java
@@ -15,12 +15,12 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class IncompleteMessageTest extends QueueTestCommon {
+class IncompleteMessageTest extends QueueTestCommon {
     @TempDir
     Path tmpDir;
 
     @Test
-    public void incompleteMessageShouldBeSkipped() {
+    void incompleteMessageShouldBeSkipped() {
         System.setProperty("queue.force.unlock.mode", "ALWAYS");
         expectException("Couldn't acquire write lock after ");
         expectException("Forced unlock for the lock ");

--- a/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
@@ -11,9 +11,8 @@ import net.openhft.chronicle.queue.impl.single.*;
 import net.openhft.chronicle.wire.WireType;
 import net.openhft.chronicle.wire.WriteAfterEOFException;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -22,12 +21,11 @@ import static net.openhft.chronicle.queue.DirectoryUtils.tempDir;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_HOURLY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class InternalAppenderWriteBytesTest extends QueueTestCommon {
 
-    @Before
+    @BeforeEach
     public void before() {
         if (OS.isMacOSX())
             ignoreException(exceptionKey -> exceptionKey.clazz == DirectoryUtils.class, "Ignore DirectoryUtils");
@@ -210,31 +208,35 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
         return SingleChronicleQueueBuilder.binary(tmpDir).timeProvider(() -> 0).testBlockSize().rollCycle(TEST4_DAILY).build();
     }
 
-    @Test(expected = IllegalIndexException.class)
+    @Test
     public void cannotAppendToExistingCycleIfNotNextIndex() {
-        @NotNull Bytes<byte[]> test = Bytes.from("hello world");
-        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir()).timeProvider(() -> 0).build();
-             ExcerptAppender appender = q.createAppender()) {
-            // append to cycle 0, sequence 0
-            appender.writeBytes(test);
+        assertThrows(IllegalIndexException.class, () -> {
+            @NotNull Bytes<byte[]> test = Bytes.from("hello world");
+            try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir()).timeProvider(() -> 0).build();
+                 ExcerptAppender appender = q.createAppender()) {
+                // append to cycle 0, sequence 0
+                appender.writeBytes(test);
 
-            // this will throw because it is not in sequence (cycle 0, sequence 2)
-            ((InternalAppender) appender).writeBytes(2, test);
-        }
+                // this will throw because it is not in sequence (cycle 0, sequence 2)
+                ((InternalAppender) appender).writeBytes(2, test);
+            }
+        });
     }
 
-    @Test(expected = IllegalIndexException.class)
+    @Test
     public void cannotWriteToNonZeroIndexOfNewRollCycle() {
-        final RollCycle rollCycle = RollCycles.DEFAULT;
-        try (SingleChronicleQueue q = binary(tempDir("q"))
-                .rollCycle(rollCycle)
-                .timeProvider(() -> 0).build();
-             ExcerptAppender appender = q.createAppender()) {
-            appender.writeText("hello");    // cycle 0, sequence 0
+        assertThrows(IllegalIndexException.class, () -> {
+            final RollCycle rollCycle = RollCycles.DEFAULT;
+            try (SingleChronicleQueue q = binary(tempDir("q"))
+                    .rollCycle(rollCycle)
+                    .timeProvider(() -> 0).build();
+                 ExcerptAppender appender = q.createAppender()) {
+                appender.writeText("hello");    // cycle 0, sequence 0
 
-            // attempt to write to cycle 1, sequence 1
-            ((InternalAppender) appender).writeBytes(rollCycle.toIndex(1, 1), Bytes.from("text"));
-        }
+                // attempt to write to cycle 1, sequence 1
+                ((InternalAppender) appender).writeBytes(rollCycle.toIndex(1, 1), Bytes.from("text"));
+            }
+        });
     }
 
     @Test
@@ -252,7 +254,7 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
             timeProvider.advanceMillis(TimeUnit.SECONDS.toMillis(65 * 60));
             appender.writeBytes(test2);
 
-            Assert.assertTrue(hasEOF(q, firstCycle));
+            assertTrue(hasEOF(q, firstCycle));
             // here we try and write to previous cycle file
             assertThrows(WriteAfterEOFException.class, () -> ((InternalAppender) appender).writeBytes(nextIndexInFirstCycle, test1));
         }

--- a/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
@@ -23,17 +23,17 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_HOURLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class InternalAppenderWriteBytesTest extends QueueTestCommon {
+class InternalAppenderWriteBytesTest extends QueueTestCommon {
 
     @BeforeEach
-    public void before() {
+    void before() {
         if (OS.isMacOSX())
             ignoreException(exceptionKey -> exceptionKey.clazz == DirectoryUtils.class, "Ignore DirectoryUtils");
         ignoreException(e -> e.level == LogLevel.PERF, "ignore all PERF");
     }
 
     @Test
-    public void canWriteAtEndOfLastExistingRollCycle() {
+    void canWriteAtEndOfLastExistingRollCycle() {
         @NotNull Bytes<byte[]> test = Bytes.from("hello world");
         @NotNull Bytes<byte[]> test2 = Bytes.from("hello world again");
         Bytes<?> result = Bytes.elasticHeapByteBuffer();
@@ -61,7 +61,7 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void canWriteAtBeginningOfNextRollCycle() {
+    void canWriteAtBeginningOfNextRollCycle() {
         @NotNull Bytes<byte[]> test = Bytes.from("hello world");
         @NotNull Bytes<byte[]> test2 = Bytes.from("hello world again");
         Bytes<?> result = Bytes.elasticHeapByteBuffer();
@@ -89,7 +89,7 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void cannotOverwriteExistingEntries() {
+    void cannotOverwriteExistingEntries() {
         @NotNull Bytes<byte[]> originalBytes = Bytes.from("hello world");
         final Bytes<byte[]> overwriteBytes = Bytes.from("HELLO WORLD");
         Bytes<?> result = Bytes.elasticHeapByteBuffer();
@@ -108,7 +108,7 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void cannotOverwriteExistingEntries_DifferentQueueInstance() {
+    void cannotOverwriteExistingEntries_DifferentQueueInstance() {
         @NotNull Bytes<byte[]> test = Bytes.from("hello world");
         @NotNull Bytes<byte[]> test2 = Bytes.from("hello world2");
         Bytes<?> result = Bytes.elasticHeapByteBuffer();
@@ -209,7 +209,7 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void cannotAppendToExistingCycleIfNotNextIndex() {
+    void cannotAppendToExistingCycleIfNotNextIndex() {
         assertThrows(IllegalIndexException.class, () -> {
             @NotNull Bytes<byte[]> test = Bytes.from("hello world");
             try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir()).timeProvider(() -> 0).build();
@@ -224,7 +224,7 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void cannotWriteToNonZeroIndexOfNewRollCycle() {
+    void cannotWriteToNonZeroIndexOfNewRollCycle() {
         assertThrows(IllegalIndexException.class, () -> {
             final RollCycle rollCycle = RollCycles.DEFAULT;
             try (SingleChronicleQueue q = binary(tempDir("q"))
@@ -240,7 +240,7 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void cannotAppendToPreviousCycle() {
+    void cannotAppendToPreviousCycle() {
         @NotNull Bytes<byte[]> test = Bytes.from("hello world");
         @NotNull Bytes<byte[]> test1 = Bytes.from("hello world again cycle1");
         @NotNull Bytes<byte[]> test2 = Bytes.from("hello world cycle2");

--- a/src/test/java/net/openhft/chronicle/queue/LastAcknowledgedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LastAcknowledgedTest.java
@@ -12,15 +12,14 @@ import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class LastAcknowledgedTest extends QueueTestCommon {
@@ -78,19 +77,19 @@ public class LastAcknowledgedTest extends QueueTestCommon {
             ExcerptAppender appender = queue.createAppender();
 
             ExcerptTailer tailer = queue.createTailer();
-            Assert.assertFalse(tailer.readAfterReplicaAcknowledged());
+            assertFalse(tailer.readAfterReplicaAcknowledged());
 
             // Set up the tailer to use a custom acknowledged index replicated check
             tailer.acknowledgedIndexReplicatedCheck((index, lastSequenceAck) -> index <= lastSequenceAck);
-            Assert.assertTrue(tailer.readAfterReplicaAcknowledged());
+            assertTrue(tailer.readAfterReplicaAcknowledged());
 
             // tolerateNumberOfUnAckedMessages
             {
                 appender.writeText("hello1");
-                Assert.assertEquals(null, tailer.readText());
+                assertEquals(null, tailer.readText());
                 lastAcknowledgedIndexReplicatedLongValue.setVolatileValue(appender.lastIndexAppended());
-                Assert.assertEquals("hello1", tailer.readText());
-                Assert.assertEquals(null, tailer.readText());
+                assertEquals("hello1", tailer.readText());
+                assertEquals(null, tailer.readText());
             }
 
             // tolerateNumberOfUnAckedMessages = 1
@@ -100,9 +99,9 @@ public class LastAcknowledgedTest extends QueueTestCommon {
                 appender.writeText("hello2");
                 lastAcknowledgedIndexReplicatedLongValue.setVolatileValue(appender.lastIndexAppended());
                 appender.writeText("hello3");
-                Assert.assertEquals("hello2", tailer.readText());
-                Assert.assertEquals("hello3", tailer.readText());
-                Assert.assertEquals(null, tailer.readText());
+                assertEquals("hello2", tailer.readText());
+                assertEquals("hello3", tailer.readText());
+                assertEquals(null, tailer.readText());
             }
 
             // tolerateNumberOfUnAckedMessages = 2
@@ -113,10 +112,10 @@ public class LastAcknowledgedTest extends QueueTestCommon {
                 lastAcknowledgedIndexReplicatedLongValue.setVolatileValue(appender.lastIndexAppended());
                 appender.writeText("hello5");
                 appender.writeText("hello6");
-                Assert.assertEquals("hello4", tailer.readText());
-                Assert.assertEquals("hello5", tailer.readText());
-                Assert.assertEquals("hello6", tailer.readText());
-                Assert.assertEquals(null, tailer.readText());
+                assertEquals("hello4", tailer.readText());
+                assertEquals("hello5", tailer.readText());
+                assertEquals("hello6", tailer.readText());
+                assertEquals(null, tailer.readText());
             }
         }
     }
@@ -145,22 +144,22 @@ public class LastAcknowledgedTest extends QueueTestCommon {
             ExcerptAppender appender = queue.createAppender();
             timeProvider.set(1);
             ExcerptTailer tailer = queue.createTailer();
-            Assert.assertFalse(tailer.readAfterReplicaAcknowledged());
+            assertFalse(tailer.readAfterReplicaAcknowledged());
 
             // Set up the tailer to use a custom acknowledged index replicated check
             tailer.acknowledgedIndexReplicatedCheck((index, lastSequenceAck) -> index <= lastSequenceAck);
-            Assert.assertTrue(tailer.readAfterReplicaAcknowledged());
+            assertTrue(tailer.readAfterReplicaAcknowledged());
 
             timeProvider.set(1);
             // tolerateNumberOfUnAckedMessages
             {
                 appender.writeText("hello1");
                 appender.writeText("hello2");
-                Assert.assertEquals(null, tailer.readText());
+                assertEquals(null, tailer.readText());
                 lastAcknowledgedIndexReplicatedLongValue.setVolatileValue(appender.lastIndexAppended());
-                Assert.assertEquals("hello1", tailer.readText());
-                Assert.assertEquals("hello2", tailer.readText());
-                Assert.assertEquals(null, tailer.readText());
+                assertEquals("hello1", tailer.readText());
+                assertEquals("hello2", tailer.readText());
+                assertEquals(null, tailer.readText());
             }
 
             timeProvider.set(2);
@@ -171,8 +170,8 @@ public class LastAcknowledgedTest extends QueueTestCommon {
             // causing the roll
             timeProvider.set(1002);
 
-            Assert.assertEquals("hello3", tailer.readText());
-            Assert.assertEquals(null, tailer.readText());
+            assertEquals("hello3", tailer.readText());
+            assertEquals(null, tailer.readText());
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/LastAcknowledgedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LastAcknowledgedTest.java
@@ -22,9 +22,9 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class LastAcknowledgedTest extends QueueTestCommon {
+class LastAcknowledgedTest extends QueueTestCommon {
     @Test
-    public void testLastAcknowledge() {
+    void testLastAcknowledge() {
         String name = OS.getTarget() + "/testLastAcknowledge-" + Time.uniqueId();
         long lastIndexAppended;
         try (ChronicleQueue q = SingleChronicleQueueBuilder.single(name).testBlockSize().build();
@@ -66,7 +66,7 @@ public class LastAcknowledgedTest extends QueueTestCommon {
     }
 
     @Test
-    public void testReadBeforeAcknowledgment() throws IOException {
+    void testReadBeforeAcknowledgment() throws IOException {
 
         // Set up a Chronicle Queue and a StoreTailer for testing
         String pathName = "target" + System.nanoTime();
@@ -130,7 +130,7 @@ public class LastAcknowledgedTest extends QueueTestCommon {
      * @throws IOException if the Chronicle Queue cannot be created
      */
     @Test
-    public void testReadBeforeAcknowledgmentOnRoll() throws IOException {
+    void testReadBeforeAcknowledgmentOnRoll() throws IOException {
 
         // Set up a Chronicle Queue and a StoreTailer for testing
         String pathName = "target" + System.nanoTime();

--- a/src/test/java/net/openhft/chronicle/queue/LastIndexAppendedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LastIndexAppendedTest.java
@@ -9,13 +9,13 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.single;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class LastIndexAppendedTest extends QueueTestCommon {

--- a/src/test/java/net/openhft/chronicle/queue/LastIndexAppendedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LastIndexAppendedTest.java
@@ -18,10 +18,10 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class LastIndexAppendedTest extends QueueTestCommon {
+class LastIndexAppendedTest extends QueueTestCommon {
 
     @Test
-    public void testLastIndexAppendedAcrossRestarts() {
+    void testLastIndexAppendedAcrossRestarts() {
         String path = OS.getTarget() + "/" + getClass().getSimpleName() + "-" + Time.uniqueId();
 
         try {
@@ -48,7 +48,7 @@ public class LastIndexAppendedTest extends QueueTestCommon {
     }
 
     @Test
-    public void testTwoAppenders() {
+    void testTwoAppenders() {
         File path = getTmpDir();
         long a_index;
 

--- a/src/test/java/net/openhft/chronicle/queue/LatinCharTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LatinCharTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class LatinCharTest extends QueueTestCommon {
+class LatinCharTest extends QueueTestCommon {
 
     private static class Message extends SelfDescribingMarshallable {
         String s;
@@ -27,7 +27,7 @@ public class LatinCharTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldCorrectlyEncodeDecode() {
+    void shouldCorrectlyEncodeDecode() {
 
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder
                 .binary(DirectoryUtils.tempDir("temp"))

--- a/src/test/java/net/openhft/chronicle/queue/LatinCharTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/LatinCharTest.java
@@ -6,10 +6,10 @@ package net.openhft.chronicle.queue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LatinCharTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/MappedFileSafeLimitTooSmallTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MappedFileSafeLimitTooSmallTest.java
@@ -6,10 +6,11 @@ package net.openhft.chronicle.queue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Arrays;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * see https://github.com/OpenHFT/Chronicle-Queue/issues/535
@@ -17,7 +18,7 @@ import java.util.Arrays;
  */
 public class MappedFileSafeLimitTooSmallTest extends QueueTestCommon {
 
-    @org.junit.Test
+    @Test
     public void testMappedFileSafeLimitTooSmall() {
 
         final int arraySize = 40_000;
@@ -43,7 +44,7 @@ public class MappedFileSafeLimitTooSmallTest extends QueueTestCommon {
 
             for (int i = 0; i < 5; i++) {
                 try (DocumentContext dc = queue.createTailer().readingDocument()) {
-                    Assert.assertArrayEquals(data, dc.wire().read("data").bytes());
+                    assertArrayEquals(data, dc.wire().read("data").bytes());
                 }
             }
         }

--- a/src/test/java/net/openhft/chronicle/queue/MappedFileSafeLimitTooSmallTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MappedFileSafeLimitTooSmallTest.java
@@ -10,16 +10,17 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * see https://github.com/OpenHFT/Chronicle-Queue/issues/535
  * Created by Rob Austin
  */
-public class MappedFileSafeLimitTooSmallTest extends QueueTestCommon {
+class MappedFileSafeLimitTooSmallTest extends QueueTestCommon {
 
     @Test
-    public void testMappedFileSafeLimitTooSmall() {
+    void testMappedFileSafeLimitTooSmall() {
 
         final int arraySize = 40_000;
         final int blockSize = arraySize * 6;

--- a/src/test/java/net/openhft/chronicle/queue/MarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MarshallableTest.java
@@ -5,13 +5,12 @@ package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.IOTools;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MarshallableTest extends QueueTestCommon {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/MarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MarshallableTest.java
@@ -12,9 +12,9 @@ import java.io.File;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MarshallableTest extends QueueTestCommon {
+class MarshallableTest extends QueueTestCommon {
     @Test
-    public void testWriteText() {
+    void testWriteText() {
         File dir = getTmpDir();
         try (ChronicleQueue queue = binary(dir)
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/MessageReaderWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MessageReaderWriterTest.java
@@ -18,10 +18,10 @@ import java.util.Arrays;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class MessageReaderWriterTest extends QueueTestCommon {
+class MessageReaderWriterTest extends QueueTestCommon {
 
     @Test
-    public void testWriteWhileReading() {
+    void testWriteWhileReading() {
         ClassAliasPool.CLASS_ALIASES.addAlias(Message1.class);
         ClassAliasPool.CLASS_ALIASES.addAlias(Message2.class);
 

--- a/src/test/java/net/openhft/chronicle/queue/MessageReaderWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MessageReaderWriterTest.java
@@ -10,13 +10,12 @@ import net.openhft.chronicle.core.util.ObjectUtils;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class MessageReaderWriterTest extends QueueTestCommon {

--- a/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
@@ -23,15 +23,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 @TestMethodOrder(MethodOrderer.MethodName.class)
-public class MethodReaderObjectReuseTest extends QueueTestCommon {
+class MethodReaderObjectReuseTest extends QueueTestCommon {
     @BeforeEach
-    public void resetCounters() {
+    void resetCounters() {
         PingDTO.constructionCounter = 0;
         PingDTO.constructionExpected = 0;
     }
 
     @Test
-    public void testOneOne() {
+    void testOneOne() {
         ClassAliasPool.CLASS_ALIASES.addAlias(PingDTO.class);
         String path = OS.getTarget() + "/MethodReaderObjectReuseTest-" + Time.uniqueId();
         try (ChronicleQueue cq = SingleChronicleQueueBuilder.single(path).build()) {
@@ -74,7 +74,7 @@ public class MethodReaderObjectReuseTest extends QueueTestCommon {
     }
 
     @Test
-    public void testPayloadSnapshotWhenSourceMutates() {
+    void testPayloadSnapshotWhenSourceMutates() {
         ClassAliasPool.CLASS_ALIASES.addAlias(PingDTO.class);
         String path = OS.getTarget() + "/MethodReaderObjectReuseTest-snapshot-" + Time.uniqueId();
         try (ChronicleQueue cq = SingleChronicleQueueBuilder.single(path).build()) {
@@ -99,7 +99,7 @@ public class MethodReaderObjectReuseTest extends QueueTestCommon {
     }
 
     @Test
-    public void testZZDirectBytesSnapshotWhenSourceMutates() {
+    void testZZDirectBytesSnapshotWhenSourceMutates() {
         ClassAliasPool.CLASS_ALIASES.addAlias(DirectPingDTO.class);
         String path = OS.getTarget() + "/MethodReaderObjectReuseTest-direct-" + Time.uniqueId();
         try (ChronicleQueue cq = SingleChronicleQueueBuilder.single(path).build()) {

--- a/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
@@ -12,20 +12,19 @@ import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class MethodReaderObjectReuseTest extends QueueTestCommon {
-    @Before
+    @BeforeEach
     public void resetCounters() {
         PingDTO.constructionCounter = 0;
         PingDTO.constructionExpected = 0;
@@ -38,7 +37,6 @@ public class MethodReaderObjectReuseTest extends QueueTestCommon {
         try (ChronicleQueue cq = SingleChronicleQueueBuilder.single(path).build()) {
             PingDTO.constructionExpected++;
             PingDTO pdtio = new PingDTO();
-            PingDTO.constructionExpected++;
             Pinger pinger = cq.methodWriter(Pinger.class);
             for (int i = 0; i < 5; i++) {
                 pinger.ping(pdtio);

--- a/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MethodReaderObjectReuseTest.java
@@ -37,6 +37,7 @@ class MethodReaderObjectReuseTest extends QueueTestCommon {
         try (ChronicleQueue cq = SingleChronicleQueueBuilder.single(path).build()) {
             PingDTO.constructionExpected++;
             PingDTO pdtio = new PingDTO();
+            PingDTO.constructionExpected++;
             Pinger pinger = cq.methodWriter(Pinger.class);
             for (int i = 0; i < 5; i++) {
                 pinger.ping(pdtio);

--- a/src/test/java/net/openhft/chronicle/queue/MoveIndexAfterFailedTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveIndexAfterFailedTailerTest.java
@@ -11,13 +11,13 @@ import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.ReadMarshallable;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
 import static java.lang.System.currentTimeMillis;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class MoveIndexAfterFailedTailerTest extends QueueTestCommon {
@@ -60,7 +60,7 @@ public class MoveIndexAfterFailedTailerTest extends QueueTestCommon {
             }
             myIndex = HOURLY.toIndex(++myCycle, 0);
         }
-        Assert.assertEquals(expected, count);
+        assertEquals(expected, count);
     }
 
     private ReadMarshallable read() {

--- a/src/test/java/net/openhft/chronicle/queue/MoveIndexAfterFailedTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveIndexAfterFailedTailerTest.java
@@ -20,10 +20,10 @@ import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class MoveIndexAfterFailedTailerTest extends QueueTestCommon {
+class MoveIndexAfterFailedTailerTest extends QueueTestCommon {
 
     @Test
-    public void test() {
+    void test() {
         String basePath = OS.getTarget() + "/" + getClass().getSimpleName() + "-" + Time.uniqueId();
         final SingleChronicleQueueBuilder myBuilder = SingleChronicleQueueBuilder.single(basePath)
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
@@ -9,16 +9,16 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.Threads;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
 
@@ -32,13 +32,17 @@ public class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
     private AtomicBoolean shutDown = new AtomicBoolean();
     private boolean resourceTracing;
 
+    @BeforeEach
+    public void beforeEachMoveToCycleMultiThreadedStressTest() {
+        threadDump();
+        disableResourceTracing();
+    }
+
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
 
-    @Before
     public void disableResourceTracing() {
         // with this enabled, and a 32 GB heap this fails with flight recorder
         // with this disabled, and a 32 *MB* heap this passes with flight recorder on
@@ -46,12 +50,14 @@ public class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
         Jvm.setResourceTracing(false);
     }
 
-    @After
+    @AfterEach
     public void resetResourceTracing() {
         Jvm.setResourceTracing(resourceTracing);
     }
 
-    @Test(timeout = 60000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void test() throws ExecutionException, InterruptedException {
         final String path = OS.getTarget() + "/stressMoveToCycle-" + Time.uniqueId();
         final ExecutorService es = Executors.newCachedThreadPool();
@@ -80,12 +86,7 @@ public class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
             Thread.sleep(100);
 
             f.forEach(c -> {
-                try {
-                    c.get(1, TimeUnit.SECONDS);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    Assert.fail();
-                }
+                assertDoesNotThrow(() -> c.get(1, TimeUnit.SECONDS));
             });
         }
 

--- a/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
@@ -10,10 +10,12 @@ import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.Threads;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,7 +37,7 @@ class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
 
     @BeforeEach
     void beforeEachMoveToCycleMultiThreadedStressTest() {
-        public threadDump();
+        threadDump();
         disableResourceTracing();
     }
 
@@ -58,7 +60,7 @@ class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
     void test() throws ExecutionException, InterruptedException {
         final String path = OS.getTarget() + "/stressMoveToCycle-" + Time.uniqueId();
         final ExecutorService es = Executors.newCachedThreadPool();

--- a/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -60,7 +59,7 @@ class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(60)
     void test() throws ExecutionException, InterruptedException {
         final String path = OS.getTarget() + "/stressMoveToCycle-" + Time.uniqueId();
         final ExecutorService es = Executors.newCachedThreadPool();

--- a/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MoveToCycleMultiThreadedStressTest.java
@@ -18,9 +18,10 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
+class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
 
     private ThreadLocal<ExcerptTailer> tailer;
     private final AtomicLong last = new AtomicLong();
@@ -33,8 +34,8 @@ public class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
     private boolean resourceTracing;
 
     @BeforeEach
-    public void beforeEachMoveToCycleMultiThreadedStressTest() {
-        threadDump();
+    void beforeEachMoveToCycleMultiThreadedStressTest() {
+        public threadDump();
         disableResourceTracing();
     }
 
@@ -51,14 +52,14 @@ public class MoveToCycleMultiThreadedStressTest extends QueueTestCommon {
     }
 
     @AfterEach
-    public void resetResourceTracing() {
+    void resetResourceTracing() {
         Jvm.setResourceTracing(resourceTracing);
     }
 
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void test() throws ExecutionException, InterruptedException {
+    void test() throws ExecutionException, InterruptedException {
         final String path = OS.getTarget() + "/stressMoveToCycle-" + Time.uniqueId();
         final ExecutorService es = Executors.newCachedThreadPool();
 

--- a/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
@@ -14,9 +14,9 @@ import java.io.File;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MultipleNamedTailersTest extends QueueTestCommon {
+class MultipleNamedTailersTest extends QueueTestCommon {
     @Test
-    public void multipleTailers() {
+    void multipleTailers() {
         File tmpDir = new File(OS.getTarget(), "multipleTailers" + System.nanoTime());
 
         try (ChronicleQueue q1 = SingleChronicleQueueBuilder.single(tmpDir).testBlockSize().rollCycle(TEST_SECONDLY).build();

--- a/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/MultipleNamedTailersTest.java
@@ -7,13 +7,12 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MultipleNamedTailersTest extends QueueTestCommon {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/NoDataIsSkippedWithInterruptTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/NoDataIsSkippedWithInterruptTest.java
@@ -6,17 +6,17 @@ package net.openhft.chronicle.queue;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NoDataIsSkippedWithInterruptTest extends QueueTestCommon {
 
     private static final String EXPECTED = "Hello World";
 
-    @After
+    @AfterEach
     public void clearInterrupt() {
         Thread.interrupted();
     }
@@ -34,14 +34,14 @@ public class NoDataIsSkippedWithInterruptTest extends QueueTestCommon {
 
             Thread.currentThread().interrupt();
             excerptAppender.writeText(EXPECTED);
-            Assert.assertTrue(Thread.currentThread().isInterrupted());
+            assertTrue(Thread.currentThread().isInterrupted());
 
             timeProvider.advanceMillis(60_000);
 
             excerptAppender.writeText(EXPECTED);
 
-            Assert.assertEquals(EXPECTED, tailer.readText());
-            Assert.assertEquals(EXPECTED, tailer.readText());
+            assertEquals(EXPECTED, tailer.readText());
+            assertEquals(EXPECTED, tailer.readText());
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/NoDataIsSkippedWithInterruptTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/NoDataIsSkippedWithInterruptTest.java
@@ -12,17 +12,17 @@ import org.junit.jupiter.api.Test;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class NoDataIsSkippedWithInterruptTest extends QueueTestCommon {
+class NoDataIsSkippedWithInterruptTest extends QueueTestCommon {
 
     private static final String EXPECTED = "Hello World";
 
     @AfterEach
-    public void clearInterrupt() {
+    void clearInterrupt() {
         Thread.interrupted();
     }
 
     @Test
-    public void test() {
+    void test() {
         final SetTimeProvider timeProvider = new SetTimeProvider();
         try (SingleChronicleQueue q = SingleChronicleQueueBuilder.single(DirectoryUtils.tempDir("."))
                 .rollCycle(MINUTELY)

--- a/src/test/java/net/openhft/chronicle/queue/NoMessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/NoMessageHistoryTest.java
@@ -3,9 +3,9 @@
  */
 package net.openhft.chronicle.queue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NoMessageHistoryTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/NoMessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/NoMessageHistoryTest.java
@@ -7,81 +7,81 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class NoMessageHistoryTest extends QueueTestCommon {
+class NoMessageHistoryTest extends QueueTestCommon {
 
     @Test
-    public void testSingletonInstance() {
+    void testSingletonInstance() {
         // Test that the singleton instance is available and not null
         assertNotNull(NoMessageHistory.INSTANCE);
     }
 
     @Test
-    public void testTimings() {
+    void testTimings() {
         // Test that timings() always returns 0
         assertEquals(0, NoMessageHistory.INSTANCE.timings());
     }
 
     @Test
-    public void testTimingForIndex() {
+    void testTimingForIndex() {
         // Test that timing(int n) always returns -1
         assertEquals(-1, NoMessageHistory.INSTANCE.timing(0));
         assertEquals(-1, NoMessageHistory.INSTANCE.timing(1));
     }
 
     @Test
-    public void testSources() {
+    void testSources() {
         // Test that sources() always returns 0
         assertEquals(0, NoMessageHistory.INSTANCE.sources());
     }
 
     @Test
-    public void testSourceIdForIndex() {
+    void testSourceIdForIndex() {
         // Test that sourceId(int n) always returns -1
         assertEquals(-1, NoMessageHistory.INSTANCE.sourceId(0));
         assertEquals(-1, NoMessageHistory.INSTANCE.sourceId(1));
     }
 
     @Test
-    public void testSourceIdsEndsWith() {
+    void testSourceIdsEndsWith() {
         // Test that sourceIdsEndsWith(int[] sourceIds) always returns false
-        assertFalse(NoMessageHistory.INSTANCE.sourceIdsEndsWith(new int[] {1, 2, 3}));
+        assertFalse(NoMessageHistory.INSTANCE.sourceIdsEndsWith(new int[]{1, 2, 3}));
     }
 
     @Test
-    public void testSourceIndexForIndex() {
+    void testSourceIndexForIndex() {
         // Test that sourceIndex(int n) always returns -1
         assertEquals(-1, NoMessageHistory.INSTANCE.sourceIndex(0));
         assertEquals(-1, NoMessageHistory.INSTANCE.sourceIndex(1));
     }
 
     @Test
-    public void testResetWithParameters() {
+    void testResetWithParameters() {
         // Test that reset(int sourceId, long sourceIndex) performs no action (no exceptions thrown)
         NoMessageHistory.INSTANCE.reset(1, 100L);
         assertTrue(true); // if we got here without an exception, the test passes
     }
 
     @Test
-    public void testResetWithoutParameters() {
+    void testResetWithoutParameters() {
         // Test that reset() performs no action (no exceptions thrown)
         NoMessageHistory.INSTANCE.reset();
         assertTrue(true); // if we got here without an exception, the test passes
     }
 
     @Test
-    public void testLastSourceId() {
+    void testLastSourceId() {
         // Test that lastSourceId() always returns -1
         assertEquals(-1, NoMessageHistory.INSTANCE.lastSourceId());
     }
 
     @Test
-    public void testLastSourceIndex() {
+    void testLastSourceIndex() {
         // Test that lastSourceIndex() always returns -1
         assertEquals(-1, NoMessageHistory.INSTANCE.lastSourceIndex());
     }
 
     @Test
-    public void testIsDirty() {
+    void testIsDirty() {
         // Test that isDirty() always returns false
         assertFalse(NoMessageHistory.INSTANCE.isDirty());
     }

--- a/src/test/java/net/openhft/chronicle/queue/OvertakeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/OvertakeTest.java
@@ -11,13 +11,12 @@ import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Index runs away on double close - AM
@@ -54,7 +53,12 @@ public class OvertakeTest extends QueueTestCommon {
         return t_index;
     }
 
-    @Before
+    @BeforeEach
+    public void beforeEachOvertakeTest() {
+        before();
+        threadDump();
+    }
+
     public void before() {
         path = OS.getTarget() + "/" + getClass().getSimpleName() + "-" + Time.uniqueId();
         try (ChronicleQueue appender_queue = ChronicleQueue.singleBuilder(path)
@@ -75,7 +79,6 @@ public class OvertakeTest extends QueueTestCommon {
     }
 
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }

--- a/src/test/java/net/openhft/chronicle/queue/OvertakeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/OvertakeTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Index runs away on double close - AM
  */
 @RequiredForClient
-public class OvertakeTest extends QueueTestCommon {
+class OvertakeTest extends QueueTestCommon {
 
     private String path;
 
@@ -54,9 +54,9 @@ public class OvertakeTest extends QueueTestCommon {
     }
 
     @BeforeEach
-    public void beforeEachOvertakeTest() {
+    void beforeEachOvertakeTest() {
         before();
-        threadDump();
+        public threadDump();
     }
 
     public void before() {
@@ -84,7 +84,7 @@ public class OvertakeTest extends QueueTestCommon {
     }
 
     @Test
-    public void appendAndTail() {
+    void appendAndTail() {
         try (ChronicleQueue tailer_queue = ChronicleQueue.singleBuilder(path)
                 .testBlockSize()
                 .writeBufferMode(BufferMode.None)
@@ -102,7 +102,7 @@ public class OvertakeTest extends QueueTestCommon {
     }
 
     @Override
-    public void tearDown() {
+    protected public void tearDown() {
         try {
             IOTools.deleteDirWithFiles(path, 2);
         } catch (Exception ignored) {
@@ -110,7 +110,7 @@ public class OvertakeTest extends QueueTestCommon {
     }
 
     @Test
-    public void threadingTest() throws InterruptedException, ExecutionException, TimeoutException {
+    void threadingTest() throws InterruptedException, ExecutionException, TimeoutException {
         // System.out.println("Continue appending");
         ExecutorService execService = Executors.newFixedThreadPool(2,
                 new NamedThreadFactory("test"));

--- a/src/test/java/net/openhft/chronicle/queue/OvertakeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/OvertakeTest.java
@@ -56,7 +56,7 @@ class OvertakeTest extends QueueTestCommon {
     @BeforeEach
     void beforeEachOvertakeTest() {
         before();
-        public threadDump();
+        threadDump();
     }
 
     public void before() {
@@ -102,7 +102,7 @@ class OvertakeTest extends QueueTestCommon {
     }
 
     @Override
-    protected public void tearDown() {
+    protected void tearDown() {
         try {
             IOTools.deleteDirWithFiles(path, 2);
         } catch (Exception ignored) {

--- a/src/test/java/net/openhft/chronicle/queue/ProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ProxyTest.java
@@ -7,10 +7,10 @@ import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * To avoid the arg[] array created via the methodWriter java.lang.reflect.Proxy, this test shows how you can create a custom proxy
@@ -51,7 +51,7 @@ public class ProxyTest extends QueueTestCommon {
                 methodReader.readOne();
             }
         }
-        Assert.assertEquals("!net.openhft.chronicle.queue.ProxyTest$Message {\n" +
+        assertEquals("!net.openhft.chronicle.queue.ProxyTest$Message {\n" +
                 "  message: test 0\n" +
                 "}\n" +
                 "!net.openhft.chronicle.queue.ProxyTest$Message {\n" +

--- a/src/test/java/net/openhft/chronicle/queue/ProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ProxyTest.java
@@ -10,6 +10,7 @@ import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -17,10 +18,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * <p>
  * Created by Rob Austin
  */
-public class ProxyTest extends QueueTestCommon {
+class ProxyTest extends QueueTestCommon {
 
     @Test
-    public void testReadWrite() {
+    void testReadWrite() {
 
         File tempDir = getTmpDir();
         StringBuilder result = new StringBuilder();

--- a/src/test/java/net/openhft/chronicle/queue/QueueAppendAfterRollReplayedIssueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueAppendAfterRollReplayedIssueTest.java
@@ -23,10 +23,10 @@ import static org.junit.jupiter.api.Assertions.*;
     Queue is reloaded with roll files present and
     writingDocument retrieved with acquireDocument
  */
-public class QueueAppendAfterRollReplayedIssueTest extends QueueTestCommon {
+class QueueAppendAfterRollReplayedIssueTest extends QueueTestCommon {
 
     @Test
-    public void test() {
+    void test() {
         int messages = 10;
 
         String path = OS.getTarget() + "/" + getClass().getSimpleName() + "-" + Time.uniqueId();

--- a/src/test/java/net/openhft/chronicle/queue/QueueAppendAfterRollReplayedIssueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueAppendAfterRollReplayedIssueTest.java
@@ -10,13 +10,13 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
     Scenario:

--- a/src/test/java/net/openhft/chronicle/queue/QueueReadBackwardsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueReadBackwardsTest.java
@@ -4,28 +4,29 @@
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.time.SetTimeProvider;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class QueueReadBackwardsTest extends QueueTestCommon {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    Path temporaryFolder;
 
     private File dataDir;
     private SetTimeProvider timeProvider;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
-        this.dataDir = temporaryFolder.newFolder();
+        this.dataDir = Files.createTempDirectory(temporaryFolder, "queue").toFile();
         this.timeProvider = new SetTimeProvider(new Date().getTime());
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/QueueReadBackwardsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueReadBackwardsTest.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class QueueReadBackwardsTest extends QueueTestCommon {
+class QueueReadBackwardsTest extends QueueTestCommon {
     @TempDir
     Path temporaryFolder;
 
@@ -25,13 +25,13 @@ public class QueueReadBackwardsTest extends QueueTestCommon {
     private SetTimeProvider timeProvider;
 
     @BeforeEach
-    public void setup() throws IOException {
+    void setup() throws IOException {
         this.dataDir = Files.createTempDirectory(temporaryFolder, "queue").toFile();
         this.timeProvider = new SetTimeProvider(new Date().getTime());
     }
 
     @Test
-    public void testReadBackwardsAfterWriteJustOneMessage() {
+    void testReadBackwardsAfterWriteJustOneMessage() {
         RollCycles rollingCycle = RollCycles.DEFAULT;
         // Write a message to the queue
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(dataDir)

--- a/src/test/java/net/openhft/chronicle/queue/QueueReadForwardSkippingACycleBiggerThanADayTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueReadForwardSkippingACycleBiggerThanADayTest.java
@@ -5,28 +5,28 @@ package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.harness.WeeklyRollCycle;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class QueueReadForwardSkippingACycleBiggerThanADayTest extends QueueTestCommon {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    Path temporaryFolder;
 
     private File dataDir;
     private SetTimeProvider timeProvider;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
-        this.dataDir = temporaryFolder.newFolder();
+        this.dataDir = Files.createTempDirectory(temporaryFolder, "queue").toFile();
         this.timeProvider = new SetTimeProvider();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/QueueReadForwardSkippingACycleBiggerThanADayTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueReadForwardSkippingACycleBiggerThanADayTest.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class QueueReadForwardSkippingACycleBiggerThanADayTest extends QueueTestCommon {
+class QueueReadForwardSkippingACycleBiggerThanADayTest extends QueueTestCommon {
     @TempDir
     Path temporaryFolder;
 
@@ -25,13 +25,13 @@ public class QueueReadForwardSkippingACycleBiggerThanADayTest extends QueueTestC
     private SetTimeProvider timeProvider;
 
     @BeforeEach
-    public void setup() throws IOException {
+    void setup() throws IOException {
         this.dataDir = Files.createTempDirectory(temporaryFolder, "queue").toFile();
         this.timeProvider = new SetTimeProvider();
     }
 
     @Test
-    public void testReadForwards() {
+    void testReadForwards() {
         RollCycle rollingCycle = WeeklyRollCycle.INSTANCE;
         // Write a message to the queue
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(dataDir)

--- a/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
@@ -17,11 +17,10 @@ import net.openhft.chronicle.queue.util.HugetlbfsTestUtil;
 import net.openhft.chronicle.testframework.exception.ExceptionTracker;
 import net.openhft.chronicle.wire.MessageHistory;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.*;
-import org.junit.runner.Description;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -33,8 +32,9 @@ import java.util.stream.Stream;
 
 import static net.openhft.chronicle.core.onoes.LogLevel.DEBUG;
 import static net.openhft.chronicle.core.onoes.LogLevel.PERF;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
+@Timeout(60)
 public class QueueTestCommon {
     private static final Set<LogLevel> IGNORED_LOG_LEVELS = EnumSet.of(DEBUG, PERF);
     private static final boolean TRACE_TEST_EXECUTION = Jvm.getBoolean("queue.traceTestExecution");
@@ -48,30 +48,28 @@ public class QueueTestCommon {
         System.setProperty("queue.check.index", "true");
     }
 
-    // JUNIT Rules
-    // catch-all timeout for when it has not been specified
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(60);
+    protected String testMethodName;
 
-    @Rule
-    public final TestName testName = new TestName();
+    @BeforeEach
+    public void beforeEachQueueTestCommon(TestInfo testInfo) {
+        initTestInfo(testInfo);
+        recordTargetDirContents();
+        recordDiskSpace();
+        assumeFinishedNormally();
+        clearMessageHistory();
+        enableReferenceTracing();
+        recordExceptions();
+    }
 
-    @Rule
-    public final ErrorCollector errorCollector = new ErrorCollector();
-
-    @NotNull
-    @Rule
-    public TestRule watcher = new TestWatcher() {
-        @Override
-        protected void starting(@NotNull Description description) {
-            if (TRACE_TEST_EXECUTION) {
-                Jvm.debug().on(getClass(), "Starting test: "
-                        + description.getClassName() + "."
-                        + description.getMethodName()
-                );
-            }
+    public void initTestInfo(TestInfo testInfo) {
+        testMethodName = testInfo.getTestMethod().map(java.lang.reflect.Method::getName).orElse("unknown");
+        if (TRACE_TEST_EXECUTION) {
+            Jvm.debug().on(getClass(), "Starting test: "
+                    + testInfo.getTestClass().map(Class::getName).orElse("unknown") + "."
+                    + testMethodName
+            );
         }
-    };
+    }
 
     private static AtomicLong counter = new AtomicLong();
     private Set<String> targetAllowList;
@@ -79,8 +77,7 @@ public class QueueTestCommon {
 
     @NotNull
     protected File getTmpDir() {
-        final String methodName = testName.getMethodName();
-        String name = methodName == null ? "unknown" : methodName;
+        String name = testMethodName == null ? "unknown" : testMethodName;
         final File tmpDir = DirectoryUtils.tempDir(name + "-" + counter.incrementAndGet());
         tmpDirs.add(tmpDir);
         return tmpDir;
@@ -89,7 +86,6 @@ public class QueueTestCommon {
     /**
      * @see #deleteTargetDirTestArtifacts()
      */
-    @Before
     public void recordTargetDirContents() {
         String target = OS.getTarget();
         File[] files = new File(target).listFiles();
@@ -102,12 +98,17 @@ public class QueueTestCommon {
         }
     }
 
-    @Before
     public void recordDiskSpace() {
         freeSpace = new File(OS.getTarget()).getFreeSpace();
     }
 
-    @After
+    @AfterEach
+    public void afterEachQueueTestCommon() {
+        checkSpaceUsed();
+        deleteTargetDirTestArtifacts();
+        afterChecks();
+    }
+
     public void checkSpaceUsed() {
         long spaceLeft = new File(OS.getTarget()).getFreeSpace();
         if (freeSpace - spaceLeft > 2L << 30) {
@@ -115,17 +116,14 @@ public class QueueTestCommon {
         }
     }
 
-    @Before
     public void assumeFinishedNormally() {
         finishedNormally = true;
     }
 
-    @Before
     public void clearMessageHistory() {
         MessageHistory.get().reset();
     }
 
-    @Before
     public void enableReferenceTracing() {
         AbstractReferenceCounted.enableReferenceTracing();
     }
@@ -134,7 +132,7 @@ public class QueueTestCommon {
         AbstractReferenceCounted.assertReferencesReleased();
     }
 
-    // add @Before to sub class where a thread might be added
+    // add @BeforeEach to sub class where a thread might be added
     public void threadDump() {
         threadDump = new ThreadDump();
     }
@@ -144,7 +142,6 @@ public class QueueTestCommon {
             threadDump.assertNoNewThreads();
     }
 
-    @Before
     public void recordExceptions() {
         Map<ExceptionKey, Integer> recordedExceptions = Jvm.recordExceptions(false);
         exceptionTracker = ExceptionTracker.create(
@@ -201,7 +198,6 @@ public class QueueTestCommon {
      *
      * @see #recordTargetDirContents() which tracks the original contents of target and avoids deleting unrelated files
      */
-    @After
     public void deleteTargetDirTestArtifacts() {
         if (HugetlbfsTestUtil.isHugetlbfsAvailable()) {
             String target = OS.getTarget();
@@ -225,7 +221,6 @@ public class QueueTestCommon {
         }
     }
 
-    @After
     public void afterChecks() {
         preAfter();
         SystemTimeProvider.CLOCK = SystemTimeProvider.INSTANCE;

--- a/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
@@ -51,7 +51,7 @@ public class QueueTestCommon {
     protected String testMethodName;
 
     @BeforeEach
-    public void beforeEachQueueTestCommon(TestInfo testInfo) {
+    void beforeEachQueueTestCommon(TestInfo testInfo) {
         initTestInfo(testInfo);
         recordTargetDirContents();
         recordDiskSpace();
@@ -103,7 +103,7 @@ public class QueueTestCommon {
     }
 
     @AfterEach
-    public void afterEachQueueTestCommon() {
+    void afterEachQueueTestCommon() {
         checkSpaceUsed();
         deleteTargetDirTestArtifacts();
         afterChecks();

--- a/src/test/java/net/openhft/chronicle/queue/QueueWriteDocumentContextTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueWriteDocumentContextTest.java
@@ -12,13 +12,12 @@ import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.MarshallableOut;
 import net.openhft.chronicle.wire.WriteDocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.queue.DirectoryUtils.tempDir;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class QueueWriteDocumentContextTest extends QueueTestCommon {
 
@@ -47,7 +46,7 @@ public class QueueWriteDocumentContextTest extends QueueTestCommon {
         String s = "/nestedPlainText";
         try (ChronicleQueue cq = createQueue(s);
              final ExcerptAppender appender = cq.createAppender()) {
-            Assume.assumeFalse("Ignored on hugetlbfs as byte offsets will be different due to page size", PageUtil.isHugePage(cq.file().getAbsolutePath()));
+            assumeFalse(PageUtil.isHugePage(cq.file().getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
             writeThreeKeys(appender);
             assertEquals("" +
                     "--- !!meta-data #binary\n" +
@@ -127,7 +126,7 @@ public class QueueWriteDocumentContextTest extends QueueTestCommon {
         String s = "/chainedPlainText";
         try (ChronicleQueue cq = createQueue(s);
              final ExcerptAppender appender = cq.createAppender()) {
-            Assume.assumeFalse("Ignored on hugetlbfs as byte offsets will be different due to page size", PageUtil.isHugePage(cq.file().getAbsolutePath()));
+            assumeFalse(PageUtil.isHugePage(cq.file().getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
             writeThreeChainedKeys(appender);
             assertEquals("" +
                             "--- !!meta-data #binary\n" +
@@ -198,8 +197,7 @@ public class QueueWriteDocumentContextTest extends QueueTestCommon {
                             "key: 1\n" +
                             "key: 2\n" +
                             "...\n" +
-                            "# 130644 bytes remaining\n",
-                    cq.dump());
+                            "# 130644 bytes remaining\n", cq.dump());
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/QueueWriteDocumentContextTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueWriteDocumentContextTest.java
@@ -19,7 +19,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class QueueWriteDocumentContextTest extends QueueTestCommon {
+class QueueWriteDocumentContextTest extends QueueTestCommon {
 
     private static void writeThreeKeys(MarshallableOut wire) {
         try (DocumentContext dc0 = wire.acquireWritingDocument(false)) {
@@ -42,7 +42,7 @@ public class QueueWriteDocumentContextTest extends QueueTestCommon {
     }
 
     @Test
-    public void nestedPlainText() {
+    void nestedPlainText() {
         String s = "/nestedPlainText";
         try (ChronicleQueue cq = createQueue(s);
              final ExcerptAppender appender = cq.createAppender()) {
@@ -122,82 +122,82 @@ public class QueueWriteDocumentContextTest extends QueueTestCommon {
     }
 
     @Test
-    public void chainedPlainText() {
+    void chainedPlainText() {
         String s = "/chainedPlainText";
         try (ChronicleQueue cq = createQueue(s);
              final ExcerptAppender appender = cq.createAppender()) {
             assumeFalse(PageUtil.isHugePage(cq.file().getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
             writeThreeChainedKeys(appender);
             assertEquals("" +
-                            "--- !!meta-data #binary\n" +
-                            "header: !STStore {\n" +
-                            "  wireType: !WireType BINARY_LIGHT,\n" +
-                            "  metadata: !SCQMeta {\n" +
-                            "    roll: !SCQSRoll { length: 86400000, format: yyyyMMdd'T1', epoch: 0 },\n" +
-                            "    sourceId: 0\n" +
-                            "  }\n" +
-                            "}\n" +
-                            "# position: 152, header: 0\n" +
-                            "--- !!data #binary\n" +
-                            "listing.highestCycle: 18554\n" +
-                            "# position: 192, header: 1\n" +
-                            "--- !!data #binary\n" +
-                            "listing.lowestCycle: 18554\n" +
-                            "# position: 232, header: 2\n" +
-                            "--- !!data #binary\n" +
-                            "listing.modCount: 3\n" +
-                            "# position: 264, header: 3\n" +
-                            "--- !!data #binary\n" +
-                            "chronicle.write.lock: -9223372036854775808\n" +
-                            "# position: 304, header: 4\n" +
-                            "--- !!data #binary\n" +
-                            "chronicle.append.lock: -9223372036854775808\n" +
-                            "# position: 344, header: 5\n" +
-                            "--- !!data #binary\n" +
-                            "chronicle.lastIndexReplicated: -1\n" +
-                            "# position: 392, header: 6\n" +
-                            "--- !!data #binary\n" +
-                            "chronicle.lastAcknowledgedIndexReplicated: -1\n" +
-                            "# position: 448, header: 7\n" +
-                            "--- !!data #binary\n" +
-                            "chronicle.lastIndexMSynced: -1\n" +
-                            "...\n" +
-                            "# 130572 bytes remaining\n" +
-                            "--- !!meta-data #binary\n" +
-                            "header: !SCQStore {\n" +
-                            "  writePosition: [\n" +
-                            "    400,\n" +
-                            "    1717986918400\n" +
-                            "  ],\n" +
-                            "  indexing: !SCQSIndexing {\n" +
-                            "    indexCount: 8,\n" +
-                            "    indexSpacing: 1,\n" +
-                            "    index2Index: 200,\n" +
-                            "    lastIndex: 1\n" +
-                            "  },\n" +
-                            "  dataFormat: 1\n" +
-                            "}\n" +
-                            "# position: 200, header: -1\n" +
-                            "--- !!meta-data #binary\n" +
-                            "index2index: [\n" +
-                            "  # length: 8, used: 1\n" +
-                            "  304,\n" +
-                            "  0, 0, 0, 0, 0, 0, 0\n" +
-                            "]\n" +
-                            "# position: 304, header: -1\n" +
-                            "--- !!meta-data #binary\n" +
-                            "index: [\n" +
-                            "  # length: 8, used: 1\n" +
-                            "  400,\n" +
-                            "  0, 0, 0, 0, 0, 0, 0\n" +
-                            "]\n" +
-                            "# position: 400, header: 0\n" +
-                            "--- !!data #binary\n" +
-                            "key: 0\n" +
-                            "key: 1\n" +
-                            "key: 2\n" +
-                            "...\n" +
-                            "# 130644 bytes remaining\n", cq.dump());
+                    "--- !!meta-data #binary\n" +
+                    "header: !STStore {\n" +
+                    "  wireType: !WireType BINARY_LIGHT,\n" +
+                    "  metadata: !SCQMeta {\n" +
+                    "    roll: !SCQSRoll { length: 86400000, format: yyyyMMdd'T1', epoch: 0 },\n" +
+                    "    sourceId: 0\n" +
+                    "  }\n" +
+                    "}\n" +
+                    "# position: 152, header: 0\n" +
+                    "--- !!data #binary\n" +
+                    "listing.highestCycle: 18554\n" +
+                    "# position: 192, header: 1\n" +
+                    "--- !!data #binary\n" +
+                    "listing.lowestCycle: 18554\n" +
+                    "# position: 232, header: 2\n" +
+                    "--- !!data #binary\n" +
+                    "listing.modCount: 3\n" +
+                    "# position: 264, header: 3\n" +
+                    "--- !!data #binary\n" +
+                    "chronicle.write.lock: -9223372036854775808\n" +
+                    "# position: 304, header: 4\n" +
+                    "--- !!data #binary\n" +
+                    "chronicle.append.lock: -9223372036854775808\n" +
+                    "# position: 344, header: 5\n" +
+                    "--- !!data #binary\n" +
+                    "chronicle.lastIndexReplicated: -1\n" +
+                    "# position: 392, header: 6\n" +
+                    "--- !!data #binary\n" +
+                    "chronicle.lastAcknowledgedIndexReplicated: -1\n" +
+                    "# position: 448, header: 7\n" +
+                    "--- !!data #binary\n" +
+                    "chronicle.lastIndexMSynced: -1\n" +
+                    "...\n" +
+                    "# 130572 bytes remaining\n" +
+                    "--- !!meta-data #binary\n" +
+                    "header: !SCQStore {\n" +
+                    "  writePosition: [\n" +
+                    "    400,\n" +
+                    "    1717986918400\n" +
+                    "  ],\n" +
+                    "  indexing: !SCQSIndexing {\n" +
+                    "    indexCount: 8,\n" +
+                    "    indexSpacing: 1,\n" +
+                    "    index2Index: 200,\n" +
+                    "    lastIndex: 1\n" +
+                    "  },\n" +
+                    "  dataFormat: 1\n" +
+                    "}\n" +
+                    "# position: 200, header: -1\n" +
+                    "--- !!meta-data #binary\n" +
+                    "index2index: [\n" +
+                    "  # length: 8, used: 1\n" +
+                    "  304,\n" +
+                    "  0, 0, 0, 0, 0, 0, 0\n" +
+                    "]\n" +
+                    "# position: 304, header: -1\n" +
+                    "--- !!meta-data #binary\n" +
+                    "index: [\n" +
+                    "  # length: 8, used: 1\n" +
+                    "  400,\n" +
+                    "  0, 0, 0, 0, 0, 0, 0\n" +
+                    "]\n" +
+                    "# position: 400, header: 0\n" +
+                    "--- !!data #binary\n" +
+                    "key: 0\n" +
+                    "key: 1\n" +
+                    "key: 2\n" +
+                    "...\n" +
+                    "# 130644 bytes remaining\n", cq.dump());
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
@@ -32,15 +32,15 @@ import static org.junit.jupiter.api.Assertions.*;
  * The rare appender will have very bad latency proportional to the number of messages written since
  * it last appended.
  */
-public class RareAppenderLatencyTest extends QueueTestCommon {
+class RareAppenderLatencyTest extends QueueTestCommon {
     private final static int HEAVY_MSGS = 1_000_000;
     private final static int RARE_MSGS = 50;
 
     private ExecutorService appenderES;
 
     @BeforeEach
-    public void beforeEachRareAppenderLatencyTest() {
-        threadDump();
+    void beforeEachRareAppenderLatencyTest() {
+        public threadDump();
         before();
     }
 
@@ -60,7 +60,7 @@ public class RareAppenderLatencyTest extends QueueTestCommon {
     }
 
     @Test
-    public void testRareAppenderLatency() throws InterruptedException, ExecutionException {
+    void testRareAppenderLatency() throws InterruptedException, ExecutionException {
         System.setProperty("ignoreHeaderCountIfNumberOfExcerptsBehindExceeds", "" + (1 << 12));
 
         if (Jvm.isDebug())

--- a/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
@@ -10,8 +10,8 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.UUID;
@@ -20,8 +20,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static junit.framework.TestCase.assertFalse;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * Created by skidder on 8/2/16.
@@ -38,13 +38,17 @@ public class RareAppenderLatencyTest extends QueueTestCommon {
 
     private ExecutorService appenderES;
 
+    @BeforeEach
+    public void beforeEachRareAppenderLatencyTest() {
+        threadDump();
+        before();
+    }
+
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
 
-    @Before
     public void before() {
         appenderES = Executors.newSingleThreadExecutor(
                 new NamedThreadFactory("Appender", false));
@@ -127,7 +131,7 @@ public class RareAppenderLatencyTest extends QueueTestCommon {
             // System.out.println("Wrote first rare one in " + l + " ms");
             // System.out.println("Wrote another rare one in " + (System.currentTimeMillis() - now) + " ms");
 
-            assertFalse("Appending from rare thread latency too high!", l > 150);
+            assertFalse(l > 150, "Appending from rare thread latency too high!");
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RareAppenderLatencyTest.java
@@ -40,7 +40,7 @@ class RareAppenderLatencyTest extends QueueTestCommon {
 
     @BeforeEach
     void beforeEachRareAppenderLatencyTest() {
-        public threadDump();
+        threadDump();
         before();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
@@ -15,7 +15,7 @@ import java.io.File;
 import static org.junit.jupiter.api.Assertions.*;
 
 // For use with C++ RawAccessJava. Called from C++
-public class RawAccessJavaTest extends QueueTestCommon {
+class RawAccessJavaTest extends QueueTestCommon {
 
     private final long QUEUE_HEADER_SIZE = 4;
     private final long RAW_SIZE_PREFIX = 4;
@@ -28,7 +28,7 @@ public class RawAccessJavaTest extends QueueTestCommon {
     }
 
     @Test
-    public void Tailer() {
+    void Tailer() {
         if (!assert_from_cpp())
             return;
 
@@ -70,7 +70,7 @@ public class RawAccessJavaTest extends QueueTestCommon {
     }
 
     @Test
-    public void Appender() {
+    void Appender() {
         if (!assert_from_cpp())
             return;
 
@@ -109,7 +109,7 @@ public class RawAccessJavaTest extends QueueTestCommon {
     }
 
     @Test
-    public void testLengthPrefixValidationWithoutCppInterop() {
+    void testLengthPrefixValidationWithoutCppInterop() {
         File dir = getTmpDir();
         try (ChronicleQueue cq = SingleChronicleQueueBuilder.binary(dir.getAbsolutePath()).build();
              ExcerptAppender appender = cq.createAppender();
@@ -150,7 +150,7 @@ public class RawAccessJavaTest extends QueueTestCommon {
     }
 
     @Test
-    public void testZeroLengthInteropPayloadIsReadable() {
+    void testZeroLengthInteropPayloadIsReadable() {
         File dir = getTmpDir();
         try (ChronicleQueue cq = SingleChronicleQueueBuilder.binary(dir.getAbsolutePath()).build();
              ExcerptAppender appender = cq.createAppender();

--- a/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RawAccessJavaTest.java
@@ -5,16 +5,14 @@ package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.core.io.IOTools;
-import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.Wires;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 // For use with C++ RawAccessJava. Called from C++
 public class RawAccessJavaTest extends QueueTestCommon {
@@ -126,8 +124,7 @@ public class RawAccessJavaTest extends QueueTestCommon {
                 int header = bytes.readInt();
                 int totalLength = Wires.lengthOf(header);
                 int payloadLength = bytes.readInt();
-                assertEquals("Length prefix should match payload content",
-                        totalLength - RAW_SIZE_PREFIX, payloadLength);
+                assertEquals(totalLength - RAW_SIZE_PREFIX, payloadLength, "Length prefix should match payload content");
             }
         } finally {
             IOTools.deleteDirWithFiles(dir, 2);

--- a/src/test/java/net/openhft/chronicle/queue/ReadOneBackwardsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadOneBackwardsTest.java
@@ -9,12 +9,12 @@ import net.openhft.chronicle.wire.MessageHistory;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.VanillaMessageHistory;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * test reading the queue backwards using readOne

--- a/src/test/java/net/openhft/chronicle/queue/ReadOneBackwardsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadOneBackwardsTest.java
@@ -19,15 +19,15 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * test reading the queue backwards using readOne
  */
-public class ReadOneBackwardsTest extends QueueTestCommon {
+class ReadOneBackwardsTest extends QueueTestCommon {
 
     @Test
-    public void test() {
+    void test() {
         doTest(false);
     }
 
     @Test
-    public void testScanning() {
+    void testScanning() {
         doTest(true);
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
@@ -29,7 +29,7 @@ class ReadWriteTest extends QueueTestCommon {
     @BeforeEach
     void beforeEachReadWriteTest() {
         setup();
-        public threadDump();
+        threadDump();
     }
 
     public void setup() {

--- a/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
@@ -21,15 +21,15 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 @RequiredForClient
-public class ReadWriteTest extends QueueTestCommon {
+class ReadWriteTest extends QueueTestCommon {
 
     private static final String STR1 = "hello", STR2 = "hey";
     private File chroniclePath;
 
     @BeforeEach
-    public void beforeEachReadWriteTest() {
+    void beforeEachReadWriteTest() {
         setup();
-        threadDump();
+        public threadDump();
     }
 
     public void setup() {
@@ -51,7 +51,7 @@ public class ReadWriteTest extends QueueTestCommon {
      * to deliver proper fix.
      */
     @AfterEach
-    public void forceCleanupToDeFlakeTests() {
+    void forceCleanupToDeFlakeTests() {
         BackgroundResourceReleaser.releasePendingResources();
     }
 
@@ -61,7 +61,7 @@ public class ReadWriteTest extends QueueTestCommon {
     }
 
     @Test
-    public void testReadFromReadOnlyChronicle() {
+    void testReadFromReadOnlyChronicle() {
         assumeFalse(OS.isWindows());
 
         try (ChronicleQueue out = SingleChronicleQueueBuilder
@@ -83,7 +83,7 @@ public class ReadWriteTest extends QueueTestCommon {
     }
 
     @Test
-    public void testNotInitializedMetadataFile() throws IOException {
+    void testNotInitializedMetadataFile() throws IOException {
         assumeFalse(OS.isWindows());
 
         final String expectedException = "Failback to readonly tablestore";
@@ -111,7 +111,7 @@ public class ReadWriteTest extends QueueTestCommon {
     }
 
     @Test
-    public void testProceedWhenMetadataFileInitialized() throws IOException {
+    void testProceedWhenMetadataFileInitialized() throws IOException {
         assumeFalse(OS.isWindows());
 
         File meta = new File(chroniclePath, "metadata.cq4t");
@@ -154,7 +154,7 @@ public class ReadWriteTest extends QueueTestCommon {
 
     // Can't append to a read-only chronicle
     @Test
-    public void testWriteToReadOnlyChronicle() {
+    void testWriteToReadOnlyChronicle() {
         assertThrows(IllegalStateException.class, () -> {
             if (OS.isWindows()) {
                 System.err.println("#460 Cannot test read only mode on windows");
@@ -174,7 +174,7 @@ public class ReadWriteTest extends QueueTestCommon {
     }
 
     @Test
-    public void testToEndOnReadOnly() {
+    void testToEndOnReadOnly() {
         assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
         try (ChronicleQueue out = SingleChronicleQueueBuilder
@@ -190,7 +190,7 @@ public class ReadWriteTest extends QueueTestCommon {
     }
 
     @Test
-    public void testNonWriteableFilesSetToReadOnly() {
+    void testNonWriteableFilesSetToReadOnly() {
         assumeFalse(OS.isWindows());
         expectException("Failback to readonly tablestore");
         expectException("Forcing queue to be readOnly");

--- a/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
@@ -155,22 +155,15 @@ class ReadWriteTest extends QueueTestCommon {
     // Can't append to a read-only chronicle
     @Test
     void testWriteToReadOnlyChronicle() {
-        assertThrows(IllegalStateException.class, () -> {
-            if (OS.isWindows()) {
-                System.err.println("#460 Cannot test read only mode on windows");
-                throw new IllegalStateException("not run");
-            }
+        assumeFalse(OS.isWindows(), "#460 Cannot test read only mode on windows");
 
-            try (ChronicleQueue out = SingleChronicleQueueBuilder
-                    .binary(chroniclePath)
-                    .testBlockSize()
-                    .readOnly(true)
-                    .build();
-                 final ExcerptAppender appender = out.createAppender()) {
-                assumeTrue(appender != null);
-                // Do nothing
-            }
-        });
+        try (ChronicleQueue out = SingleChronicleQueueBuilder
+                .binary(chroniclePath)
+                .testBlockSize()
+                .readOnly(true)
+                .build()) {
+            assertThrows(IllegalStateException.class, () -> createAppender(out));
+        }
     }
 
     @Test
@@ -207,6 +200,12 @@ class ReadWriteTest extends QueueTestCommon {
             tailer.toEnd();
             long index = tailer.index();
             assertNotEquals(0, index);
+        }
+    }
+
+    private static void createAppender(ChronicleQueue out) {
+        try (ExcerptAppender appender = out.createAppender()) {
+            assertNotNull(appender);
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
@@ -9,9 +9,7 @@ import net.openhft.chronicle.core.annotation.RequiredForClient;
 import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,9 +17,8 @@ import java.io.RandomAccessFile;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 @RequiredForClient
 public class ReadWriteTest extends QueueTestCommon {
@@ -29,7 +26,12 @@ public class ReadWriteTest extends QueueTestCommon {
     private static final String STR1 = "hello", STR2 = "hey";
     private File chroniclePath;
 
-    @Before
+    @BeforeEach
+    public void beforeEachReadWriteTest() {
+        setup();
+        threadDump();
+    }
+
     public void setup() {
         chroniclePath = getTmpDir();
         try (ChronicleQueue readWrite = ChronicleQueue.singleBuilder(chroniclePath)
@@ -48,13 +50,12 @@ public class ReadWriteTest extends QueueTestCommon {
      * Some flakiness with this test in build server due to background resources not released, we will revisit shortly
      * to deliver proper fix.
      */
-    @After
+    @AfterEach
     public void forceCleanupToDeFlakeTests() {
         BackgroundResourceReleaser.releasePendingResources();
     }
 
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
@@ -128,7 +129,7 @@ public class ReadWriteTest extends QueueTestCommon {
                     .binary(chroniclePath)
                     .testBlockSize()
                     .build()) {
-                assumeNotNull(out);
+                assumeTrue(out != null);
                 // Do nothing, just create
             }
         }).start();
@@ -142,8 +143,7 @@ public class ReadWriteTest extends QueueTestCommon {
                 .readOnly(true)
                 .build()) {
 
-            assertTrue("Should have waited for more than 200ms. Actual wait: " + (System.currentTimeMillis() - startTimeMillis.get()) + " ms",
-                    System.currentTimeMillis() - startTimeMillis.get() >= 200);
+            assertTrue(System.currentTimeMillis() - startTimeMillis.get() >= 200, "Should have waited for more than 200ms. Actual wait: " + (System.currentTimeMillis() - startTimeMillis.get()) + " ms");
 
             ExcerptTailer tailer = out.createTailer();
             tailer.toEnd();
@@ -153,27 +153,29 @@ public class ReadWriteTest extends QueueTestCommon {
     }
 
     // Can't append to a read-only chronicle
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testWriteToReadOnlyChronicle() {
-        if (OS.isWindows()) {
-            System.err.println("#460 Cannot test read only mode on windows");
-            throw new IllegalStateException("not run");
-        }
+        assertThrows(IllegalStateException.class, () -> {
+            if (OS.isWindows()) {
+                System.err.println("#460 Cannot test read only mode on windows");
+                throw new IllegalStateException("not run");
+            }
 
-        try (ChronicleQueue out = SingleChronicleQueueBuilder
-                .binary(chroniclePath)
-                .testBlockSize()
-                .readOnly(true)
-                .build();
-             final ExcerptAppender appender = out.createAppender()) {
-            assumeNotNull(appender);
-            // Do nothing
-        }
+            try (ChronicleQueue out = SingleChronicleQueueBuilder
+                    .binary(chroniclePath)
+                    .testBlockSize()
+                    .readOnly(true)
+                    .build();
+                 final ExcerptAppender appender = out.createAppender()) {
+                assumeTrue(appender != null);
+                // Do nothing
+            }
+        });
     }
 
     @Test
     public void testToEndOnReadOnly() {
-        assumeFalse("Read-only mode is not supported on Windows", OS.isWindows());
+        assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
         try (ChronicleQueue out = SingleChronicleQueueBuilder
                 .binary(chroniclePath)

--- a/src/test/java/net/openhft/chronicle/queue/ReadmeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadmeTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ReadmeTest extends QueueTestCommon {
+class ReadmeTest extends QueueTestCommon {
 
     @Test
-    public void createAQueue() {
+    void createAQueue() {
         final String basePath = OS.getTarget() + "/" + getClass().getSimpleName() + "-" + Time.uniqueId();
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(basePath)
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/ReadmeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadmeTest.java
@@ -7,10 +7,10 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ReadmeTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
@@ -18,27 +18,27 @@ import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RollCycleDefaultingTest extends QueueTestCommon {
+class RollCycleDefaultingTest extends QueueTestCommon {
 
     private static final String BASE_PATH = OS.getTarget() + "/rollCycleDefaultingTest";
 
     @Test
-    public void alias() {
+    void alias() {
         assertSame(RollCycles.class, ObjectUtils.implementationToUse(RollCycle.class));
     }
 
     @AfterEach
-    public void clearDefaultRollCycleProperty() {
+    void clearDefaultRollCycleProperty() {
         System.clearProperty(QueueSystemProperties.DEFAULT_ROLL_CYCLE_PROPERTY);
     }
 
     @AfterAll
-    public static void afterClass() {
+    static void afterClass() {
         IOTools.deleteDirWithFiles(BASE_PATH, 2);
     }
 
     @Test
-    public void correctConfigGetsLoaded() {
+    void correctConfigGetsLoaded() {
         String aClass = HOURLY.getClass().getName();
         String configuredCycle = aClass + ":HOURLY";
         System.setProperty(QueueSystemProperties.DEFAULT_ROLL_CYCLE_PROPERTY, configuredCycle);
@@ -47,7 +47,7 @@ public class RollCycleDefaultingTest extends QueueTestCommon {
     }
 
     @Test
-    public void customDefinitionGetsLoaded() {
+    void customDefinitionGetsLoaded() {
         String configuredCycle = MyRollcycle.class.getName();
         System.setProperty(QueueSystemProperties.DEFAULT_ROLL_CYCLE_PROPERTY, configuredCycle);
         SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.binary(BASE_PATH);
@@ -56,7 +56,7 @@ public class RollCycleDefaultingTest extends QueueTestCommon {
     }
 
     @Test
-    public void unknownClassDefaultsToDaily() {
+    void unknownClassDefaultsToDaily() {
         expectException("Default roll cycle class: foobarblah was not found");
         String configuredCycle = "foobarblah";
         System.setProperty(QueueSystemProperties.DEFAULT_ROLL_CYCLE_PROPERTY, configuredCycle);
@@ -66,7 +66,7 @@ public class RollCycleDefaultingTest extends QueueTestCommon {
     }
 
     @Test
-    public void nonRollCycleDefaultsToDaily() {
+    void nonRollCycleDefaultsToDaily() {
         expectException("Configured default rollcycle is not a subclass of RollCycle");
         String configuredCycle = String.class.getName();
         System.setProperty(QueueSystemProperties.DEFAULT_ROLL_CYCLE_PROPERTY, configuredCycle);
@@ -74,7 +74,7 @@ public class RollCycleDefaultingTest extends QueueTestCommon {
         assertEquals(RollCycles.DEFAULT, builder.rollCycle());
     }
 
-    public static class MyRollcycle implements RollCycle {
+    static class MyRollcycle implements RollCycle {
         private final RollCycle delegate = TEST_SECONDLY;
 
         @Override

--- a/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
@@ -8,15 +8,15 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.core.util.ObjectUtils;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.queue.rollcycles.LegacyRollCycles;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RollCycleDefaultingTest extends QueueTestCommon {
 
@@ -24,15 +24,15 @@ public class RollCycleDefaultingTest extends QueueTestCommon {
 
     @Test
     public void alias() {
-        assertEquals(RollCycles.class, ObjectUtils.implementationToUse(RollCycle.class));
+        assertSame(RollCycles.class, ObjectUtils.implementationToUse(RollCycle.class));
     }
 
-    @After
+    @AfterEach
     public void clearDefaultRollCycleProperty() {
         System.clearProperty(QueueSystemProperties.DEFAULT_ROLL_CYCLE_PROPERTY);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         IOTools.deleteDirWithFiles(BASE_PATH, 2);
     }

--- a/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
@@ -18,7 +18,7 @@ import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-class RollCycleDefaultingTest extends QueueTestCommon {
+public class RollCycleDefaultingTest extends QueueTestCommon {
 
     private static final String BASE_PATH = OS.getTarget() + "/rollCycleDefaultingTest";
 
@@ -74,7 +74,7 @@ class RollCycleDefaultingTest extends QueueTestCommon {
         assertEquals(RollCycles.DEFAULT, builder.rollCycle());
     }
 
-    static class MyRollcycle implements RollCycle {
+    public static class MyRollcycle implements RollCycle {
         private final RollCycle delegate = TEST_SECONDLY;
 
         @Override

--- a/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCycleDefaultingTest.java
@@ -8,7 +8,6 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.core.util.ObjectUtils;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import net.openhft.chronicle.queue.rollcycles.LegacyRollCycles;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;

--- a/src/test/java/net/openhft/chronicle/queue/RollCyclesDistinctnessTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCyclesDistinctnessTest.java
@@ -10,10 +10,10 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RollCyclesDistinctnessTest extends QueueTestCommon {
+class RollCyclesDistinctnessTest extends QueueTestCommon {
 
     @Test
-    public void definedRollCycleFormatsAreDistinct() {
+    void definedRollCycleFormatsAreDistinct() {
         Set<String> allPatterns = new HashSet<>();
         int count = 0;
         for (RollCycle cycle : RollCycles.all()) {

--- a/src/test/java/net/openhft/chronicle/queue/RollCyclesDistinctnessTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCyclesDistinctnessTest.java
@@ -3,12 +3,12 @@
  */
 package net.openhft.chronicle.queue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RollCyclesDistinctnessTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/RollCyclesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCyclesTest.java
@@ -5,10 +5,9 @@ package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.annotation.RequiredForClient;
 import net.openhft.chronicle.core.time.TimeProvider;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -21,30 +20,22 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 @RequiredForClient
 public class RollCyclesTest extends QueueTestCommon {
     private static final long NO_EPOCH_OFFSET = 0L;
     private static final long SOME_EPOCH_OFFSET = 17L * 37L;
     private static List<Instant> incrementalTimes;
 
-    private final RollCycle cycle;
     private final AtomicLong clock = new AtomicLong();
     private final TimeProvider timeProvider = clock::get;
 
-    public RollCyclesTest(final String cycleName, final RollCycle cycle) {
-        this.cycle = cycle;
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void generateTimes() {
         incrementalTimes = generateIncrementalTimes();
     }
 
-    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         final List<Object[]> data = new ArrayList<>();
         for (RollCycle testDatum : RollCycles.all()) {
@@ -65,26 +56,30 @@ public class RollCyclesTest extends QueueTestCommon {
         return () -> delegate.currentTimeMillis() - 1;
     }
 
-    @Test
-    public void shouldBe32bitShifted() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldBe32bitShifted(String cycleName, RollCycle cycle) {
         long factor = (long) cycle.defaultIndexCount() * cycle.defaultIndexCount() * cycle.defaultIndexSpacing();
         if (factor < 1L << 32)
             factor = 1L << 32;
         assertEquals(factor, cycle.toIndex(1, 0));
     }
 
-    @Test
-    public void shouldDetermineCurrentCycle() {
-        assertCycleRollTimes(NO_EPOCH_OFFSET, withDelta(timeProvider, NO_EPOCH_OFFSET));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldDetermineCurrentCycle(String cycleName, RollCycle cycle) {
+        assertCycleRollTimes(cycle, NO_EPOCH_OFFSET, withDelta(timeProvider, NO_EPOCH_OFFSET));
     }
 
-    @Test
-    public void shouldTakeEpochIntoAccoutWhenCalculatingCurrentCycle() {
-        assertCycleRollTimes(SOME_EPOCH_OFFSET, withDelta(timeProvider, SOME_EPOCH_OFFSET));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldTakeEpochIntoAccoutWhenCalculatingCurrentCycle(String cycleName, RollCycle cycle) {
+        assertCycleRollTimes(cycle, SOME_EPOCH_OFFSET, withDelta(timeProvider, SOME_EPOCH_OFFSET));
     }
 
-    @Test
-    public void shouldHandleReasonableDateRange() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldHandleReasonableDateRange(String cycleName, RollCycle cycle) {
         final int currentCycle = DefaultCycleCalculator.INSTANCE.currentCycle(cycle, timeProvider, 0);
         // ~ 14 Jul 2017 to 18 May 2033
         for (long nowMillis = 1_500_000_000_000L; nowMillis < 2_000_000_000_000L; nowMillis += (long) 3e10) {
@@ -94,7 +89,7 @@ public class RollCyclesTest extends QueueTestCommon {
         }
     }
 
-    private void assertCycleRollTimes(final long epochOffset, final TimeProvider timeProvider) {
+    private void assertCycleRollTimes(final RollCycle cycle, final long epochOffset, final TimeProvider timeProvider) {
         final long currentTime = System.currentTimeMillis();
         final long currentTimeAtStartOfCycle = currentTime - (currentTime % cycle.lengthInMillis());
         clock.set(currentTimeAtStartOfCycle);
@@ -114,8 +109,9 @@ public class RollCyclesTest extends QueueTestCommon {
         assertEquals(startCycle + 1, cycle.current(minusOneMillisecond(timeProvider), epochOffset));
     }
 
-    @Test
-    public void lexicographicOrderShouldCorrelateToChronologicalOrder() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void lexicographicOrderShouldCorrelateToChronologicalOrder(String cycleName, RollCycle cycle) {
         String lastName = null;
         Instant lastDate = null;
         final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(cycle.format()).withZone(ZoneId.of("UTC"));

--- a/src/test/java/net/openhft/chronicle/queue/RollCyclesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/RollCyclesTest.java
@@ -32,7 +32,7 @@ public class RollCyclesTest extends QueueTestCommon {
     private final TimeProvider timeProvider = clock::get;
 
     @BeforeAll
-    public static void generateTimes() {
+    static void generateTimes() {
         incrementalTimes = generateIncrementalTimes();
     }
 
@@ -58,7 +58,7 @@ public class RollCyclesTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldBe32bitShifted(String cycleName, RollCycle cycle) {
+    void shouldBe32bitShifted(String cycleName, RollCycle cycle) {
         long factor = (long) cycle.defaultIndexCount() * cycle.defaultIndexCount() * cycle.defaultIndexSpacing();
         if (factor < 1L << 32)
             factor = 1L << 32;
@@ -67,19 +67,19 @@ public class RollCyclesTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldDetermineCurrentCycle(String cycleName, RollCycle cycle) {
+    void shouldDetermineCurrentCycle(String cycleName, RollCycle cycle) {
         assertCycleRollTimes(cycle, NO_EPOCH_OFFSET, withDelta(timeProvider, NO_EPOCH_OFFSET));
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldTakeEpochIntoAccoutWhenCalculatingCurrentCycle(String cycleName, RollCycle cycle) {
+    void shouldTakeEpochIntoAccoutWhenCalculatingCurrentCycle(String cycleName, RollCycle cycle) {
         assertCycleRollTimes(cycle, SOME_EPOCH_OFFSET, withDelta(timeProvider, SOME_EPOCH_OFFSET));
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldHandleReasonableDateRange(String cycleName, RollCycle cycle) {
+    void shouldHandleReasonableDateRange(String cycleName, RollCycle cycle) {
         final int currentCycle = DefaultCycleCalculator.INSTANCE.currentCycle(cycle, timeProvider, 0);
         // ~ 14 Jul 2017 to 18 May 2033
         for (long nowMillis = 1_500_000_000_000L; nowMillis < 2_000_000_000_000L; nowMillis += (long) 3e10) {
@@ -111,7 +111,7 @@ public class RollCyclesTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void lexicographicOrderShouldCorrelateToChronologicalOrder(String cycleName, RollCycle cycle) {
+    void lexicographicOrderShouldCorrelateToChronologicalOrder(String cycleName, RollCycle cycle) {
         String lastName = null;
         Instant lastDate = null;
         final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(cycle.format()).withZone(ZoneId.of("UTC"));

--- a/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
@@ -23,7 +23,7 @@ import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilde
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class SingleChroniclePerfMainTest extends QueueTestCommon {
+class SingleChroniclePerfMainTest extends QueueTestCommon {
     private static final int count = 1_000_000;
     private static final int size = 4 << 10;
     // blackholes to avoid code elimination.
@@ -109,7 +109,7 @@ public class SingleChroniclePerfMainTest extends QueueTestCommon {
     }
 
     @Test
-    public void testFacade() {
+    void testFacade() {
         IFacade f = Values.newNativeReference(IFacade.class);
         Byteable byteable = (Byteable) f;
         long capacity = byteable.maxSize();

--- a/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/SingleChroniclePerfMainTest.java
@@ -15,13 +15,12 @@ import net.openhft.chronicle.values.Array;
 import net.openhft.chronicle.values.MaxUtf8Length;
 import net.openhft.chronicle.values.Values;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.single;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class SingleChroniclePerfMainTest extends QueueTestCommon {

--- a/src/test/java/net/openhft/chronicle/queue/Stackoveflow52274284Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/Stackoveflow52274284Test.java
@@ -7,7 +7,7 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.Wire;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/test/java/net/openhft/chronicle/queue/Stackoveflow52274284Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/Stackoveflow52274284Test.java
@@ -13,9 +13,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-public class Stackoveflow52274284Test extends QueueTestCommon {
+class Stackoveflow52274284Test extends QueueTestCommon {
     @Test
-    public void fails() throws IOException {
+    void fails() throws IOException {
         String basePath = OS.getTarget();
         String path = Files.createTempDirectory(Paths.get(basePath), "chronicle-")
                 .toAbsolutePath()

--- a/src/test/java/net/openhft/chronicle/queue/StoreTailerNotReachedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/StoreTailerNotReachedTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class StoreTailerNotReachedTest extends QueueTestCommon {
+class StoreTailerNotReachedTest extends QueueTestCommon {
     @Test
-    public void afterNotReached() {
+    void afterNotReached() {
         String path = OS.getTarget() + "/afterNotReached-" + Time.uniqueId();
         try (ChronicleQueue q = SingleChronicleQueueBuilder.binary(path)
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/StoreTailerNotReachedTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/StoreTailerNotReachedTest.java
@@ -7,10 +7,9 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StoreTailerNotReachedTest extends QueueTestCommon {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/StridingAQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/StridingAQueueTest.java
@@ -9,13 +9,13 @@ import net.openhft.chronicle.core.util.Mocker;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.StringWriter;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_SECONDLY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StridingAQueueTest extends QueueTestCommon {
     @Test
@@ -59,8 +59,7 @@ public class StridingAQueueTest extends QueueTestCommon {
                             "hi[2, 5]\n" +
                             "hi[2, 1]\n" +
                             "hi[1, 4]\n" +
-                            "hi[1, 0]\n",
-                    sw.toString().replace("\r", ""));
+                            "hi[1, 0]\n", sw.toString().replace("\r", ""));
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/StridingAQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/StridingAQueueTest.java
@@ -17,9 +17,9 @@ import java.io.StringWriter;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_SECONDLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class StridingAQueueTest extends QueueTestCommon {
+class StridingAQueueTest extends QueueTestCommon {
     @Test
-    public void testStriding() {
+    void testStriding() {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.currentTimeMillis(1_567_498_753_000L);
         File tmpDir = getTmpDir();
@@ -49,17 +49,17 @@ public class StridingAQueueTest extends QueueTestCommon {
             MethodReader reader = tailer.methodReader(Mocker.logging(SAQMessage.class, "", sw));
             while (reader.readOne()) ;
             assertEquals("hi[4, 9]\n" +
-                            "hi[4, 8]\n" +
-                            "hi[4, 4]\n" +
-                            "hi[4, 0]\n" +
-                            "hi[3, 8]\n" +
-                            "hi[3, 4]\n" +
-                            "hi[3, 0]\n" +
-                            "hi[2, 7]\n" +
-                            "hi[2, 5]\n" +
-                            "hi[2, 1]\n" +
-                            "hi[1, 4]\n" +
-                            "hi[1, 0]\n", sw.toString().replace("\r", ""));
+                    "hi[4, 8]\n" +
+                    "hi[4, 4]\n" +
+                    "hi[4, 0]\n" +
+                    "hi[3, 8]\n" +
+                    "hi[3, 4]\n" +
+                    "hi[3, 0]\n" +
+                    "hi[2, 7]\n" +
+                    "hi[2, 5]\n" +
+                    "hi[2, 1]\n" +
+                    "hi[1, 4]\n" +
+                    "hi[1, 0]\n", sw.toString().replace("\r", ""));
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/SurefireInterruptFlagTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/SurefireInterruptFlagTest.java
@@ -5,8 +5,7 @@ package net.openhft.chronicle.queue;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SurefireInterruptFlagTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
@@ -7,13 +7,12 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TableStorePutGetTest extends QueueTestCommon {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TableStorePutGetTest.java
@@ -14,9 +14,9 @@ import java.io.File;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TableStorePutGetTest extends QueueTestCommon {
+class TableStorePutGetTest extends QueueTestCommon {
     @Test
-    public void indexEntry() {
+    void indexEntry() {
         SetTimeProvider stp = new SetTimeProvider("2020/10/15T01:01:01");
         try (SingleChronicleQueue cq = ChronicleQueue.singleBuilder(DirectoryUtils.tempDir("indexEntry"))
                 .rollCycle(TEST_DAILY)
@@ -101,7 +101,7 @@ public class TableStorePutGetTest extends QueueTestCommon {
     }
 
     @Test
-    public void manyEntries() {
+    void manyEntries() {
         final File tempDir = DirectoryUtils.tempDir("manyEntries");
         try (SingleChronicleQueue cq = ChronicleQueue.singleBuilder(tempDir)
                 .rollCycle(TEST_DAILY)
@@ -125,7 +125,7 @@ public class TableStorePutGetTest extends QueueTestCommon {
      * (see https://github.com/OpenHFT/Chronicle-Queue/issues/1025)
      */
     @Test
-    public void testCanGrowBeyondInitialSize() {
+    void testCanGrowBeyondInitialSize() {
         try (SingleChronicleQueue cq = ChronicleQueue.singleBuilder(DirectoryUtils.tempDir("canGrow"))
                 .rollCycle(TEST_DAILY)
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/TailerCloseInParallelTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerCloseInParallelTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 // Run until failure (several thousand times) to detect tailer parallel closing issues
-public class TailerCloseInParallelTest extends QueueTestCommon {
+class TailerCloseInParallelTest extends QueueTestCommon {
     private static String file = OS.getTarget() + "/deleteme-" + Time.uniqueId();
 
     private static final int size = 1 << 10;
@@ -43,12 +43,12 @@ public class TailerCloseInParallelTest extends QueueTestCommon {
     }
 
     @AfterAll
-    public static void cleanup() {
+    static void cleanup() {
         IOTools.deleteDirWithFiles(file, 3);
     }
 
     @Test
-    public void runTenTimes() throws InterruptedException {
+    void runTenTimes() throws InterruptedException {
         finishedNormally = false;
         assumeTrue(OS.is64Bit());
 

--- a/src/test/java/net/openhft/chronicle/queue/TailerCloseInParallelTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerCloseInParallelTest.java
@@ -14,16 +14,14 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.util.Histogram;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 import java.nio.file.Paths;
 import java.util.Random;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.single;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 // Run until failure (several thousand times) to detect tailer parallel closing issues
 public class TailerCloseInParallelTest extends QueueTestCommon {
@@ -39,12 +37,12 @@ public class TailerCloseInParallelTest extends QueueTestCommon {
     private static Random random = new Random();
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() {
         IOTools.deleteDirWithFiles(file, 3);
     }

--- a/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
@@ -13,6 +13,7 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -200,7 +201,7 @@ class TailerDirectionTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 10_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
     void testTailerBackwardsReadBeyondStartWhenStartIsZero() {
         File basePath = getTmpDir();
         SetTimeProvider timeProvider = new SetTimeProvider();

--- a/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
@@ -201,7 +201,7 @@ class TailerDirectionTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(10)
     void testTailerBackwardsReadBeyondStartWhenStartIsZero() {
         File basePath = getTmpDir();
         SetTimeProvider timeProvider = new SetTimeProvider();

--- a/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
@@ -26,7 +26,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class TailerDirectionTest extends QueueTestCommon {
+class TailerDirectionTest extends QueueTestCommon {
 
     private static final String TEST_MESSAGE_PREFIX = "Test entry: ";
 
@@ -81,7 +81,7 @@ public class TailerDirectionTest extends QueueTestCommon {
     // 3) Redo step 1)
     //
     @Test
-    public void testTailerForwardBackwardRead() {
+    void testTailerForwardBackwardRead() {
         String basePath = OS.getTarget() + "/tailerForwardBackward-" + Time.uniqueId();
 
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(basePath)
@@ -133,7 +133,7 @@ public class TailerDirectionTest extends QueueTestCommon {
     }
 
     @Test
-    public void uninitialisedTailerCreatedBeforeFirstAppendWithDirectionNoneShouldNotFindDocument() {
+    void uninitialisedTailerCreatedBeforeFirstAppendWithDirectionNoneShouldNotFindDocument() {
         final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
         String path = OS.getTarget() + "/" + getClass().getSimpleName() + "-" + Time.uniqueId();
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.single(path).timeProvider(clock::get).testBlockSize()
@@ -156,7 +156,7 @@ public class TailerDirectionTest extends QueueTestCommon {
     }
 
     @Test
-    public void testTailerBackwardsReadBeyondCycle() {
+    void testTailerBackwardsReadBeyondCycle() {
         File basePath = getTmpDir();
         SetTimeProvider timeProvider = new SetTimeProvider();
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(basePath)
@@ -201,7 +201,7 @@ public class TailerDirectionTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 10_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testTailerBackwardsReadBeyondStartWhenStartIsZero() {
+    void testTailerBackwardsReadBeyondStartWhenStartIsZero() {
         File basePath = getTmpDir();
         SetTimeProvider timeProvider = new SetTimeProvider();
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(basePath)

--- a/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerDirectionTest.java
@@ -12,7 +12,7 @@ import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class TailerDirectionTest extends QueueTestCommon {
@@ -103,31 +103,31 @@ public class TailerDirectionTest extends QueueTestCommon {
                 msgIndexes.put(msg, idx);
             }
 
-            assertEquals("[Forward 1] Wrong message 0", testMessage(0), readNextEntry(tailer));
-            assertEquals("[Forward 1] Wrong Tailer index after reading msg 0", msgIndexes.get(testMessage(1)).longValue(), tailer.index());
-            assertEquals("[Forward 1] Wrong message 1", testMessage(1), readNextEntry(tailer));
-            assertEquals("[Forward 1] Wrong Tailer index after reading msg 1", msgIndexes.get(testMessage(2)).longValue(), tailer.index());
+            assertEquals(testMessage(0), readNextEntry(tailer), "[Forward 1] Wrong message 0");
+            assertEquals(msgIndexes.get(testMessage(1)).longValue(), tailer.index(), "[Forward 1] Wrong Tailer index after reading msg 0");
+            assertEquals(testMessage(1), readNextEntry(tailer), "[Forward 1] Wrong message 1");
+            assertEquals(msgIndexes.get(testMessage(2)).longValue(), tailer.index(), "[Forward 1] Wrong Tailer index after reading msg 1");
 
             tailer.direction(TailerDirection.BACKWARD);
 
-            assertEquals("[Backward] Wrong message 2", testMessage(2), readNextEntry(tailer));
-            assertEquals("[Backward] Wrong Tailer index after reading msg 2", msgIndexes.get(testMessage(1)).longValue(), tailer.index());
-            assertEquals("[Backward] Wrong message 1", testMessage(1), readNextEntry(tailer));
-            assertEquals("[Backward] Wrong Tailer index after reading msg 1", msgIndexes.get(testMessage(0)).longValue(), tailer.index());
-            assertEquals("[Backward] Wrong message 0", testMessage(0), readNextEntry(tailer));
+            assertEquals(testMessage(2), readNextEntry(tailer), "[Backward] Wrong message 2");
+            assertEquals(msgIndexes.get(testMessage(1)).longValue(), tailer.index(), "[Backward] Wrong Tailer index after reading msg 2");
+            assertEquals(testMessage(1), readNextEntry(tailer), "[Backward] Wrong message 1");
+            assertEquals(msgIndexes.get(testMessage(0)).longValue(), tailer.index(), "[Backward] Wrong Tailer index after reading msg 1");
+            assertEquals(testMessage(0), readNextEntry(tailer), "[Backward] Wrong message 0");
 
             String res = readNextEntry(tailer);
-            assertNull("Backward: res is" + res, res);
+            assertNull(res, "Backward: res is" + res);
 
             tailer.direction(TailerDirection.FORWARD);
 
             res = readNextEntry(tailer);
-            assertNull("Forward: res is" + res, res);
+            assertNull(res, "Forward: res is" + res);
 
-            assertEquals("[Forward 2] Wrong message 0", testMessage(0), readNextEntry(tailer));
-            assertEquals("[Forward 2] Wrong Tailer index after reading msg 0", msgIndexes.get(testMessage(1)).longValue(), tailer.index());
-            assertEquals("[Forward 2] Wrong message 1", testMessage(1), readNextEntry(tailer));
-            assertEquals("[Forward 2] Wrong Tailer index after reading msg 1", msgIndexes.get(testMessage(2)).longValue(), tailer.index());
+            assertEquals(testMessage(0), readNextEntry(tailer), "[Forward 2] Wrong message 0");
+            assertEquals(msgIndexes.get(testMessage(1)).longValue(), tailer.index(), "[Forward 2] Wrong Tailer index after reading msg 0");
+            assertEquals(testMessage(1), readNextEntry(tailer), "[Forward 2] Wrong message 1");
+            assertEquals(msgIndexes.get(testMessage(2)).longValue(), tailer.index(), "[Forward 2] Wrong Tailer index after reading msg 1");
         }
         IOTools.deleteDirWithFiles(basePath);
     }
@@ -190,15 +190,17 @@ public class TailerDirectionTest extends QueueTestCommon {
                     long index = indexes.get(i);
                     String msg = messages.get(i);
 
-                    assertEquals("[Backward] Wrong index " + i, index, tailer.index());
-                    assertEquals("[Backward] Wrong message " + i, msg, readNextEntry(tailer));
+                    assertEquals(index, tailer.index(), "[Backward] Wrong index " + i);
+                    assertEquals(msg, readNextEntry(tailer), "[Backward] Wrong message " + i);
                 }
             }
         }
         IOTools.deleteDirWithFiles(basePath);
     }
 
-    @Test(timeout = 10_000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 10_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testTailerBackwardsReadBeyondStartWhenStartIsZero() {
         File basePath = getTmpDir();
         SetTimeProvider timeProvider = new SetTimeProvider();

--- a/src/test/java/net/openhft/chronicle/queue/TestCallingToEndOnRoll.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestCallingToEndOnRoll.java
@@ -5,7 +5,11 @@ package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
-import org.junit.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.LockSupport;
@@ -13,24 +17,25 @@ import java.util.concurrent.locks.LockSupport;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCallingToEndOnRoll extends QueueTestCommon implements TimeProvider {
 
     private long currentTime = 0;
     private SingleChronicleQueue queue;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         queue = binary(getTmpDir()).rollCycle(TEST_SECONDLY).timeProvider(this).build();
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() {
         closeQuietly(queue);
     }
 
-    @Ignore("long running soak test to check https://github.com/OpenHFT/Chronicle-Queue/issues/702")
+    @Disabled("long running soak test to check https://github.com/OpenHFT/Chronicle-Queue/issues/702")
     @Test
     public void test() {
         Executors.newSingleThreadExecutor().submit(this::append);
@@ -60,12 +65,9 @@ public class TestCallingToEndOnRoll extends QueueTestCommon implements TimeProvi
 
     private void toEnd0(ExcerptTailer tailer) {
         try {
-            long index = tailer.toEnd().index();
-            // System.out.println("index = " + index);
+            tailer.toEnd().index();
         } catch (IllegalStateException e) {
-            e.printStackTrace();
-            Assert.fail();
-            System.exit(-1);
+            throw new AssertionError("tailer.toEnd() should not throw during the soak run", e);
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/TestCallingToEndOnRoll.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestCallingToEndOnRoll.java
@@ -5,11 +5,7 @@ package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.LockSupport;
@@ -17,7 +13,6 @@ import java.util.concurrent.locks.LockSupport;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.jupiter.api.Assertions.*;
 
 class TestCallingToEndOnRoll extends QueueTestCommon implements TimeProvider {
 
@@ -35,8 +30,8 @@ class TestCallingToEndOnRoll extends QueueTestCommon implements TimeProvider {
         closeQuietly(queue);
     }
 
-    @Disabled("long running soak test to check https://github.com/OpenHFT/Chronicle-Queue/issues/702")
     @Test
+    @Disabled("long running soak test to check https://github.com/OpenHFT/Chronicle-Queue/issues/702")
     void test() {
         Executors.newSingleThreadExecutor().submit(this::append);
 

--- a/src/test/java/net/openhft/chronicle/queue/TestCallingToEndOnRoll.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestCallingToEndOnRoll.java
@@ -19,25 +19,25 @@ import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilde
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestCallingToEndOnRoll extends QueueTestCommon implements TimeProvider {
+class TestCallingToEndOnRoll extends QueueTestCommon implements TimeProvider {
 
     private long currentTime = 0;
     private SingleChronicleQueue queue;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         queue = binary(getTmpDir()).rollCycle(TEST_SECONDLY).timeProvider(this).build();
     }
 
     @Override
     @AfterEach
-    public void tearDown() {
+    protected void tearDown() {
         closeQuietly(queue);
     }
 
     @Disabled("long running soak test to check https://github.com/OpenHFT/Chronicle-Queue/issues/702")
     @Test
-    public void test() {
+    void test() {
         Executors.newSingleThreadExecutor().submit(this::append);
 
         Executors.newSingleThreadExecutor().submit(this::toEnd);

--- a/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
@@ -92,8 +92,8 @@ class TestDeleteQueueFile extends QueueTestCommon {
         }
     }
 
-    @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
     @Test
+    @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
     void tailerToStartFromStartWorksInFaceOfDeletedStoreFile() throws IOException {
         assumeFalse(OS.isWindows());
 
@@ -143,8 +143,8 @@ class TestDeleteQueueFile extends QueueTestCommon {
         }
     }
 
-    @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
     @Test
+    @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
     void tailerToEndFromEndWorksInFaceOfDeletedStoreFile() throws IOException {
         assumeFalse(OS.isWindows());
 

--- a/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
@@ -37,14 +37,14 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 @SuppressWarnings("this-escape")
-public class TestDeleteQueueFile extends QueueTestCommon {
+class TestDeleteQueueFile extends QueueTestCommon {
 
     private static final int NUM_REPEATS = 10;
     private static final int CYCLES_TO_DELETE_PER_ITERATION = 20;
     private final Path tempQueueDir = getTmpDir().toPath();
 
     @Test
-    public void testRefreshDirectoryListingWillUpdateFirstAndLastIndicesCorrectly() throws IOException {
+    void testRefreshDirectoryListingWillUpdateFirstAndLastIndicesCorrectly() throws IOException {
         assumeFalse(OS.isWindows());
 
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(3, null)) {
@@ -68,7 +68,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void tailerToStartWorksInFaceOfDeletedStoreFile() throws IOException {
+    void tailerToStartWorksInFaceOfDeletedStoreFile() throws IOException {
         assumeFalse(OS.isWindows());
 
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(3, null)) {
@@ -94,7 +94,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
 
     @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
     @Test
-    public void tailerToStartFromStartWorksInFaceOfDeletedStoreFile() throws IOException {
+    void tailerToStartFromStartWorksInFaceOfDeletedStoreFile() throws IOException {
         assumeFalse(OS.isWindows());
 
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(3, null)) {
@@ -119,7 +119,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void tailerToEndWorksInFaceOfDeletedStoreFile() throws IOException {
+    void tailerToEndWorksInFaceOfDeletedStoreFile() throws IOException {
         assumeFalse(OS.isWindows());
 
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(3, null)) {
@@ -145,7 +145,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
 
     @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
     @Test
-    public void tailerToEndFromEndWorksInFaceOfDeletedStoreFile() throws IOException {
+    void tailerToEndFromEndWorksInFaceOfDeletedStoreFile() throws IOException {
         assumeFalse(OS.isWindows());
 
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(3, null)) {
@@ -170,7 +170,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void firstAndLastIndexAreRefreshedAfterForceRefreshInterval() throws IOException {
+    void firstAndLastIndexAreRefreshedAfterForceRefreshInterval() throws IOException {
         assumeFalse(OS.isWindows());
 
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(3, builder -> builder.forceDirectoryListingRefreshIntervalMs(250))) {
@@ -202,12 +202,12 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void tailingThroughDeletedCyclesWillRefreshThenRetry_Writable() throws IOException {
+    void tailingThroughDeletedCyclesWillRefreshThenRetry_Writable() throws IOException {
         tailingThroughDeletedCyclesWillRefreshThenRetry(qwcd -> qwcd.queue);
     }
 
     @Test
-    public void tailingThroughDeletedCyclesWillRefreshThenRetry_ReadOnly() throws IOException {
+    void tailingThroughDeletedCyclesWillRefreshThenRetry_ReadOnly() throws IOException {
         tailingThroughDeletedCyclesWillRefreshThenRetry(qwcd -> SingleChronicleQueueBuilder.binary(qwcd.queue.fileAbsolutePath())
                 .rollCycle(RollCycles.FAST_DAILY)
                 .readOnly(true)
@@ -215,7 +215,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void deletingOldFilesChaosTest() throws InterruptedException {
+    void deletingOldFilesChaosTest() throws InterruptedException {
         ignoreException("The current cycle seems to have been deleted from under the queue, scanning to find the next remaining cycle");
         final int numberOfCycles = 300;
         final AtomicBoolean running = new AtomicBoolean(true);
@@ -235,17 +235,17 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void deleteFileFromUnderTailerTest_StartOfRange() throws IOException {
+    void deleteFileFromUnderTailerTest_StartOfRange() throws IOException {
         deleteFileFromUnderTailerTest(10, 0);
     }
 
     @Test
-    public void deleteFileFromUnderTailerTest_MiddleOfRange() throws IOException {
+    void deleteFileFromUnderTailerTest_MiddleOfRange() throws IOException {
         deleteFileFromUnderTailerTest(10, 5);
     }
 
     @Test
-    public void deleteFileFromUnderTailerTest_EndOfRange() throws IOException {
+    void deleteFileFromUnderTailerTest_EndOfRange() throws IOException {
         deleteFileFromUnderTailerTest(10, 8);
     }
 
@@ -327,7 +327,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void deletingRandomRollCyclesChaosTest() throws InterruptedException {
+    void deletingRandomRollCyclesChaosTest() throws InterruptedException {
         assumeFalse(OS.isWindows());
         ignoreException("The current cycle seems to have been deleted from under the queue, scanning to find the next remaining cycle");
         final int numberOfCycles = 300;

--- a/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
@@ -13,8 +13,8 @@ import net.openhft.chronicle.queue.impl.StoreFileListener;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,8 +33,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.lang.Long.toHexString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 @SuppressWarnings("this-escape")
 public class TestDeleteQueueFile extends QueueTestCommon {
@@ -92,7 +92,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
         }
     }
 
-    @Ignore("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
+    @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
     @Test
     public void tailerToStartFromStartWorksInFaceOfDeletedStoreFile() throws IOException {
         assumeFalse(OS.isWindows());
@@ -143,7 +143,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
         }
     }
 
-    @Ignore("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
+    @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1151")
     @Test
     public void tailerToEndFromEndWorksInFaceOfDeletedStoreFile() throws IOException {
         assumeFalse(OS.isWindows());

--- a/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
@@ -9,10 +9,12 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.WireType;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -31,7 +33,7 @@ class ThreadedQueueTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     void testMultipleThreads() throws InterruptedException, ExecutionException, TimeoutException {
 
         final File path = getTmpDir();

--- a/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.*;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -33,7 +32,7 @@ class ThreadedQueueTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(10)
     void testMultipleThreads() throws InterruptedException, ExecutionException, TimeoutException {
 
         final File path = getTmpDir();

--- a/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
@@ -19,7 +19,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ThreadedQueueTest extends QueueTestCommon {
+class ThreadedQueueTest extends QueueTestCommon {
 
     private static final int REQUIRED_COUNT = 10;
 
@@ -32,7 +32,7 @@ public class ThreadedQueueTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testMultipleThreads() throws InterruptedException, ExecutionException, TimeoutException {
+    void testMultipleThreads() throws InterruptedException, ExecutionException, TimeoutException {
 
         final File path = getTmpDir();
 
@@ -91,7 +91,7 @@ public class ThreadedQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testTailerReadingEmptyQueue() {
+    void testTailerReadingEmptyQueue() {
         final File path = getTmpDir();
 
         try (final ChronicleQueue rqueue = SingleChronicleQueueBuilder.builder(path, WireType.FIELDLESS_BINARY)

--- a/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ThreadedQueueTest.java
@@ -8,8 +8,8 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.*;
@@ -17,19 +17,21 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ThreadedQueueTest extends QueueTestCommon {
 
     private static final int REQUIRED_COUNT = 10;
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
 
-    @Test(timeout = 10000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testMultipleThreads() throws InterruptedException, ExecutionException, TimeoutException {
 
         final File path = getTmpDir();

--- a/src/test/java/net/openhft/chronicle/queue/ToEndPaddingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ToEndPaddingTest.java
@@ -6,11 +6,10 @@ package net.openhft.chronicle.queue;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST8_DAILY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ToEndPaddingTest extends QueueTestCommon {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/ToEndPaddingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ToEndPaddingTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST8_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ToEndPaddingTest extends QueueTestCommon {
+class ToEndPaddingTest extends QueueTestCommon {
     @Test
-    public void toEndWorksWithDifferentlyPaddedMessages() {
+    void toEndWorksWithDifferentlyPaddedMessages() {
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(getTmpDir()).testBlockSize().rollCycle(TEST8_DAILY).build();
              final ExcerptAppender appender = queue.createAppender()) {
 

--- a/src/test/java/net/openhft/chronicle/queue/ValueStringArrayTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ValueStringArrayTest.java
@@ -5,10 +5,10 @@ package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ValueStringArrayTest extends QueueTestCommon {
 
@@ -37,7 +37,7 @@ public class ValueStringArrayTest extends QueueTestCommon {
                 dc.wire().read("data").marshallable(using);
                 CharSequence actual = using.getCsArr().getCharSequenceWrapperAt(1).getCharSequence();
                 // System.out.println(actual);
-                Assert.assertEquals(EXPECTED, actual.toString());
+                assertEquals(EXPECTED, actual.toString());
             }
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/ValueStringArrayTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ValueStringArrayTest.java
@@ -8,15 +8,16 @@ import net.openhft.chronicle.wire.DocumentContext;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ValueStringArrayTest extends QueueTestCommon {
+class ValueStringArrayTest extends QueueTestCommon {
 
     private static final String EXPECTED = "hello world";
     private final ValueStringArray using = new ValueStringArray();
 
     @Test
-    public void test() {
+    void test() {
         // No explicit support of putting a Value into Wire.
         expectException("BytesMarshallable found in field which is not matching exactly");
 

--- a/src/test/java/net/openhft/chronicle/queue/VisibilityOfMessagesBetweenTailorsAndAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/VisibilityOfMessagesBetweenTailorsAndAppenderTest.java
@@ -18,7 +18,7 @@ import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class VisibilityOfMessagesBetweenTailorsAndAppenderTest extends QueueTestCommon {
+class VisibilityOfMessagesBetweenTailorsAndAppenderTest extends QueueTestCommon {
 
     private volatile long lastWrittenIndex = Long.MIN_VALUE;
 
@@ -32,7 +32,7 @@ public class VisibilityOfMessagesBetweenTailorsAndAppenderTest extends QueueTest
      * check if a message is written with an appender its visible to the tailor, without locks etc.
      */
     @Test
-    public void test() throws InterruptedException, ExecutionException {
+    void test() throws InterruptedException, ExecutionException {
 
         try (ChronicleQueue x = SingleChronicleQueueBuilder
                 .binary(getTmpDir())

--- a/src/test/java/net/openhft/chronicle/queue/VisibilityOfMessagesBetweenTailorsAndAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/VisibilityOfMessagesBetweenTailorsAndAppenderTest.java
@@ -8,14 +8,14 @@ import net.openhft.chronicle.core.annotation.RequiredForClient;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.*;
 
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
 public class VisibilityOfMessagesBetweenTailorsAndAppenderTest extends QueueTestCommon {
@@ -23,7 +23,7 @@ public class VisibilityOfMessagesBetweenTailorsAndAppenderTest extends QueueTest
     private volatile long lastWrittenIndex = Long.MIN_VALUE;
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }

--- a/src/test/java/net/openhft/chronicle/queue/WeeklyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WeeklyRollCycleTest.java
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class WeeklyRollCycleTest extends QueueTestCommon {
+class WeeklyRollCycleTest extends QueueTestCommon {
 
     @Test
-    public void testWeekly() {
+    void testWeekly() {
         @NotNull String tmpDir = OS.getTarget() + "/testWeekly";
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(tmpDir).rollCycle(RollCycles.WEEKLY).build()) {
             // 1970-02-01 is a Sunday

--- a/src/test/java/net/openhft/chronicle/queue/WeeklyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WeeklyRollCycleTest.java
@@ -9,9 +9,9 @@ import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WeeklyRollCycleTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/WriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WriteBytesTest.java
@@ -24,13 +24,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 @RequiredForClient
-public class WriteBytesTest extends QueueTestCommon {
+class WriteBytesTest extends QueueTestCommon {
     private final Bytes<?> outgoingBytes = Bytes.elasticByteBuffer();
     private final byte[] incomingMsgBytes = new byte[100];
     private final byte[] outgoingMsgBytes = new byte[100];
 
     @Test
-    public void testWriteBytes() {
+    void testWriteBytes() {
         File dir = getTmpDir();
         try (ChronicleQueue queue = binary(dir)
                 .testBlockSize()
@@ -65,7 +65,7 @@ public class WriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void testWriteBytesAndDump() {
+    void testWriteBytesAndDump() {
         File dir = getTmpDir();
         assumeFalse(PageUtil.isHugePage(dir.getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
         final SingleChronicleQueueBuilder builder = binary(dir)
@@ -1052,7 +1052,7 @@ public class WriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void testWriteBytesWithDirectBufferReuse() {
+    void testWriteBytesWithDirectBufferReuse() {
         File dir = getTmpDir();
         try (ChronicleQueue queue = binary(dir)
                 .testBlockSize()
@@ -1087,7 +1087,7 @@ public class WriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void testRollCycleCapacityConsistency() {
+    void testRollCycleCapacityConsistency() {
         File dir = getTmpDir();
         SetTimeProvider timeProvider = new SetTimeProvider("2024/01/01T00:00:00")
                 .autoIncrement(0, TimeUnit.MILLISECONDS);

--- a/src/test/java/net/openhft/chronicle/queue/WriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WriteBytesTest.java
@@ -13,16 +13,15 @@ import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 @RequiredForClient
 public class WriteBytesTest extends QueueTestCommon {
@@ -68,7 +67,7 @@ public class WriteBytesTest extends QueueTestCommon {
     @Test
     public void testWriteBytesAndDump() {
         File dir = getTmpDir();
-        Assume.assumeFalse("Ignored on hugetlbfs as byte offsets will be different due to page size", PageUtil.isHugePage(dir.getAbsolutePath()));
+        assumeFalse(PageUtil.isHugePage(dir.getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
         final SingleChronicleQueueBuilder builder = binary(dir)
                 .blockSize(OS.SAFE_PAGE_SIZE)
                 .rollCycle(TEST4_DAILY)
@@ -1070,7 +1069,7 @@ public class WriteBytesTest extends QueueTestCommon {
                     directPayload.readPositionRemaining(0, directPayload.writePosition());
                     appender.writeBytes(directPayload);
 
-                    assertTrue("entry " + i + " should be readable", tailer.readBytes(readBuffer));
+                    assertTrue(tailer.readBytes(readBuffer), "entry " + i + " should be readable");
                     assertEquals("direct-entry-" + i, readBuffer.readUtf8());
                     readBuffer.clear();
                 }
@@ -1115,7 +1114,7 @@ public class WriteBytesTest extends QueueTestCommon {
                 postRollCapacity = bytes.bytesStore().capacity();
                 bytes.writeUtf8("cycle-2");
             }
-            assertEquals("Wire buffer capacity should remain stable across rolls", initialCapacity, postRollCapacity);
+            assertEquals(initialCapacity, postRollCapacity, "Wire buffer capacity should remain stable across rolls");
             assertNextUtf8(tailer, "cycle-2");
         } finally {
             try {
@@ -1128,7 +1127,7 @@ public class WriteBytesTest extends QueueTestCommon {
 
     private static void assertNextUtf8(ExcerptTailer tailer, String expected) {
         try (DocumentContext dc = tailer.readingDocument()) {
-            assertTrue("Document should be present for " + expected, dc.isPresent());
+            assertTrue(dc.isPresent(), "Document should be present for " + expected);
             assertEquals(expected, dc.wire().bytes().readUtf8());
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/WriteReadTextTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WriteReadTextTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 @RequiredForClient
-public class WriteReadTextTest extends QueueTestCommon {
+class WriteReadTextTest extends QueueTestCommon {
 
     private static final String CONSTRUCTED = "[\"abc\",\"comm_link\"," + "[[1469743199691,1469743199691],"
             + "[\"ABCDEFXH\",\"ABCDEFXH\"]," + "[321,456]," + "[\"\",\"\"]]]";
@@ -124,23 +124,23 @@ public class WriteReadTextTest extends QueueTestCommon {
     }
 
     @Test
-    public void testConstructed() {
+    void testConstructed() {
         doTest(CONSTRUCTED);
     }
 
     @Test
-    public void testExtremelyLarge() {
+    void testExtremelyLarge() {
         assumeTrue(Jvm.is64bit());
         doTest(EXTREMELY_LARGE);
     }
 
     @Test
-    public void testMinimal() {
+    void testMinimal() {
         doTest(MINIMAL);
     }
 
     @Test
-    public void testRealistic() {
+    void testRealistic() {
         doTest(REALISTIC);
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/WriteReadTextTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/WriteReadTextTest.java
@@ -11,10 +11,10 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 @RequiredForClient
 public class WriteReadTextTest extends QueueTestCommon {
@@ -169,7 +169,7 @@ public class WriteReadTextTest extends QueueTestCommon {
                 }
                 for (int p = 0; p < problematic.length; p++) {
                     tailer.readText(tmpReadback);
-                    Assert.assertEquals("write/readText", problematic[p], tmpReadback.toString());
+                    assertEquals(problematic[p], tmpReadback.toString(), "write/readText");
                 }
             }
 
@@ -180,10 +180,10 @@ public class WriteReadTextTest extends QueueTestCommon {
 
                     tailer.readDocument(reader -> reader.getValueIn().textTo(tmpReadback));
                     String actual = tmpReadback.toString();
-                    Assert.assertEquals(problematic[p].length(), actual.length());
+                    assertEquals(problematic[p].length(), actual.length());
                     for (int i = 0; i < actual.length(); i += 1024)
-                        Assert.assertEquals("i: " + i, problematic[p].substring(i, Math.min(actual.length(), i + 1024)), actual.substring(i, Math.min(actual.length(), i + 1024)));
-                    Assert.assertEquals(problematic[p], actual);
+                        assertEquals(problematic[p].substring(i, Math.min(actual.length(), i + 1024)), actual.substring(i, Math.min(actual.length(), i + 1024)), "i: " + i);
+                    assertEquals(problematic[p], actual);
                 }
             }
         }

--- a/src/test/java/net/openhft/chronicle/queue/cleanup/OnReleaseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/cleanup/OnReleaseTest.java
@@ -15,13 +15,12 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.testframework.FlakyTestRunner;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OnReleaseTest extends QueueTestCommon {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/cleanup/OnReleaseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/cleanup/OnReleaseTest.java
@@ -22,9 +22,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class OnReleaseTest extends QueueTestCommon {
+class OnReleaseTest extends QueueTestCommon {
     @Test
-    public void onRelease() throws Throwable {
+    void onRelease() throws Throwable {
         FlakyTestRunner.builder(this::onRelease0).build().run();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingChronicleQueueTest.java
@@ -19,10 +19,10 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST2_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RollingChronicleQueueTest extends QueueTestCommon {
+class RollingChronicleQueueTest extends QueueTestCommon {
 
     @Test
-    public void testCountExcerptsWhenTheCycleIsRolled() {
+    void testCountExcerptsWhenTheCycleIsRolled() {
 
         final AtomicLong time = new AtomicLong();
 
@@ -201,8 +201,8 @@ public class RollingChronicleQueueTest extends QueueTestCommon {
             Thread.yield();
             // on a roll, the file might be truncated making the size remaining just a few bytes
             assertEquals(expected
-                            .replaceAll(" \\d+ (bytes remaining)", " X $1"), q.dump()
-                                    .replaceAll(" \\d+ (bytes remaining)", " X $1"));
+                    .replaceAll(" \\d+ (bytes remaining)", " X $1"), q.dump()
+                    .replaceAll(" \\d+ (bytes remaining)", " X $1"));
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingChronicleQueueTest.java
@@ -8,7 +8,7 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST2_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RollingChronicleQueueTest extends QueueTestCommon {
 
@@ -201,9 +201,8 @@ public class RollingChronicleQueueTest extends QueueTestCommon {
             Thread.yield();
             // on a roll, the file might be truncated making the size remaining just a few bytes
             assertEquals(expected
-                            .replaceAll(" \\d+ (bytes remaining)", " X $1"),
-                    q.dump()
-                            .replaceAll(" \\d+ (bytes remaining)", " X $1"));
+                            .replaceAll(" \\d+ (bytes remaining)", " X $1"), q.dump()
+                                    .replaceAll(" \\d+ (bytes remaining)", " X $1"));
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheCompatTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheCompatTest.java
@@ -6,18 +6,12 @@ package net.openhft.chronicle.queue.impl;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.queue.harness.WeeklyRollCycle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Compatibility coverage lifted from adv/code-review branch to boost coverage of

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheCompatTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheCompatTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Compatibility coverage lifted from adv/code-review branch to boost coverage of
  * RollingResourcesCache date/format arithmetic across epochs, cycles, and formats.
  */
-public class RollingResourcesCacheCompatTest extends QueueTestCommon {
+class RollingResourcesCacheCompatTest extends QueueTestCommon {
     private static final long SEED = 2983472039423847L;
 
     private static final long AM_EPOCH = 1523498933145L; //2018-04-12 02:08:53.145 UTC
@@ -71,7 +71,7 @@ public class RollingResourcesCacheCompatTest extends QueueTestCommon {
     private static final String NEGATIVE_RELATIVE_MINUTELY_FILE_NAME_10 = "19761019-0010";
 
     @Test
-    public void testToLong() {
+    void testToLong() {
         doTestToLong(DAILY, AM_EPOCH, 0, Long.valueOf("17633"));
         doTestToLong(HOURLY, AM_EPOCH, 0, Long.valueOf("423192"));
         doTestToLong(MINUTELY, AM_EPOCH, 0, Long.valueOf("25391520"));

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RollingResourcesCacheTest extends QueueTestCommon {
+class RollingResourcesCacheTest extends QueueTestCommon {
     private static final long SEED = 2983472039423847L;
 
     private static final long AM_EPOCH = 1523498933145L; //2018-04-12 02:08:53.145 UTC
@@ -96,7 +96,7 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
     }
 
     @Test
-    public void resourceLookupIsCached() {
+    void resourceLookupIsCached() {
         final File dir = getTmpDir();
         final RollingResourcesCache cache = newCache(dir);
 
@@ -113,7 +113,7 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
     }
 
     @Test
-    public void toLongCachesAndClearsWhenFull() {
+    void toLongCachesAndClearsWhenFull() {
         final File dir = getTmpDir();
         final RollingResourcesCache cache = newCache(dir);
 
@@ -134,7 +134,7 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
     }
 
     @Test
-    public void parseWeeklyFormatValid() {
+    void parseWeeklyFormatValid() {
         // round-trip property: resourceFor(cycle).text parses back to the same cycle
         final RollingResourcesCache weeklyCache = new RollingResourcesCache(
                 WeeklyRollCycle.INSTANCE, 0, File::new, File::getName);
@@ -148,7 +148,7 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldConvertCyclesToResourceNamesWithNoEpoch() {
+    void shouldConvertCyclesToResourceNamesWithNoEpoch() {
         final int epoch = 0;
         final RollingResourcesCache cache =
                 new RollingResourcesCache(DAILY, epoch, File::new, File::getName);
@@ -166,7 +166,7 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldCorrectlyConvertCyclesToResourceNamesWithEpoch() {
+    void shouldCorrectlyConvertCyclesToResourceNamesWithEpoch() {
         // AM_EPOCH is 2018-04-12 02:08:53.145 UTC
         // cycle 24 should be formatted as:
         // 2018-04-12 00:00:00 UTC (1523491200000) +
@@ -247,7 +247,7 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
     }
 
     @Test
-    public void parseIncorrectlyFormattedName() {
+    void parseIncorrectlyFormattedName() {
         assertThrows(RuntimeException.class, () -> {
             final RollingResourcesCache cache =
                     new RollingResourcesCache(HOURLY, PM_EPOCH, File::new, File::getName);
@@ -256,7 +256,7 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
     }
 
     @Test
-    public void fuzzyConversionTest() {
+    void fuzzyConversionTest() {
         final int maxAddition = (int) ChronoUnit.DECADES.getDuration().toMillis();
         final Random random = new Random(SEED);
 
@@ -308,7 +308,7 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
     }
 
     @Test
-    public void testToLong() {
+    void testToLong() {
         doTestToLong(DAILY, AM_EPOCH, 0, Long.valueOf("17633"));
         doTestToLong(HOURLY, AM_EPOCH, 0, Long.valueOf("423192"));
         doTestToLong(MINUTELY, AM_EPOCH, 0, Long.valueOf("25391520"));

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
@@ -6,8 +6,9 @@ package net.openhft.chronicle.queue.impl;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.queue.harness.WeeklyRollCycle;
+import net.openhft.chronicle.queue.rollcycles.LegacyRollCycles;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.time.Instant;
@@ -18,8 +19,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.*;
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RollingResourcesCacheTest extends QueueTestCommon {
     private static final long SEED = 2983472039423847L;
@@ -104,8 +104,8 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
         final RollingResourcesCache.Resource repeat = cache.resourceFor(0);
         final RollingResourcesCache.Resource next = cache.resourceFor(1);
 
-        assertSame("Expected identical instance for cached cycle", first, repeat);
-        assertNotSame("Different cycle should produce a new resource", first, next);
+        assertSame(first, repeat, "Expected identical instance for cached cycle");
+        assertNotSame(first, next, "Different cycle should produce a new resource");
 
         final int firstCount = cache.parseCount(first.text);
         final int cachedCount = cache.parseCount(first.text);
@@ -246,11 +246,13 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
         doTestCycleAndResourceNames(BIG_NEGATIVE_RELATIVE_EPOCH, WeeklyRollCycle.INSTANCE, 354, "1976287");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void parseIncorrectlyFormattedName() {
-        final RollingResourcesCache cache =
-                new RollingResourcesCache(HOURLY, PM_EPOCH, File::new, File::getName);
-        cache.parseCount("foobar-qux");
+        assertThrows(RuntimeException.class, () -> {
+            final RollingResourcesCache cache =
+                    new RollingResourcesCache(HOURLY, PM_EPOCH, File::new, File::getName);
+            cache.parseCount("foobar-qux");
+        });
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
@@ -6,7 +6,6 @@ package net.openhft.chronicle.queue.impl;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.queue.harness.WeeklyRollCycle;
-import net.openhft.chronicle.queue.rollcycles.LegacyRollCycles;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import org.junit.jupiter.api.Test;
 
@@ -248,11 +247,10 @@ class RollingResourcesCacheTest extends QueueTestCommon {
 
     @Test
     void parseIncorrectlyFormattedName() {
-        assertThrows(RuntimeException.class, () -> {
-            final RollingResourcesCache cache =
-                    new RollingResourcesCache(HOURLY, PM_EPOCH, File::new, File::getName);
-            cache.parseCount("foobar-qux");
-        });
+        final RollingResourcesCache cache =
+                new RollingResourcesCache(HOURLY, PM_EPOCH, File::new, File::getName);
+
+        assertThrows(RuntimeException.class, () -> cache.parseCount("foobar-qux"));
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
@@ -20,9 +20,9 @@ import static net.openhft.chronicle.queue.DirectoryUtils.tempDir;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class TableStoreTest extends QueueTestCommon {
+class TableStoreTest extends QueueTestCommon {
     @Test
-    public void acquireValueFor() throws IOException {
+    void acquireValueFor() throws IOException {
 
         final File file = tempDir("table");
         assumeFalse(PageUtil.isHugePage(file.getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
@@ -77,7 +77,7 @@ public class TableStoreTest extends QueueTestCommon {
     }
 
     @Test
-    public void acquireValueForReadOnly() throws IOException {
+    void acquireValueForReadOnly() throws IOException {
 
         final File file = tempDir("table");
         file.mkdir();

--- a/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
@@ -10,22 +10,22 @@ import net.openhft.chronicle.queue.impl.table.Metadata;
 import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
 import net.openhft.chronicle.queue.impl.table.SingleTableStore;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
 import static net.openhft.chronicle.queue.DirectoryUtils.tempDir;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class TableStoreTest extends QueueTestCommon {
     @Test
     public void acquireValueFor() throws IOException {
 
         final File file = tempDir("table");
-        Assume.assumeFalse("Ignored on hugetlbfs as byte offsets will be different due to page size", PageUtil.isHugePage(file.getAbsolutePath()));
+        assumeFalse(PageUtil.isHugePage(file.getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
         file.mkdir();
 
         final File tempFile = Files.createTempFile(file.toPath(), "table", SingleTableStore.SUFFIX).toFile();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
@@ -40,7 +40,7 @@ import static net.openhft.chronicle.testframework.GcControls.requestGcCycle;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public final class AppenderFileHandleLeakTest extends QueueTestCommon {
+final class AppenderFileHandleLeakTest extends QueueTestCommon {
     private static final int THREAD_COUNT = Runtime.getRuntime().availableProcessors() * 2;
     private static final int MESSAGES_PER_THREAD = 50;
     private static final SystemTimeProvider SYSTEM_TIME_PROVIDER = SystemTimeProvider.INSTANCE;
@@ -82,14 +82,14 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
      * on Linux
      */
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         assumeTrue(OS.isLinux());
         System.gc();
         queuePath = getTmpDir();
     }
 
     @Test
-    public void appenderAndTailerResourcesShouldBeCleanedUpByGarbageCollection() throws InterruptedException, TimeoutException, ExecutionException {
+    void appenderAndTailerResourcesShouldBeCleanedUpByGarbageCollection() throws InterruptedException, TimeoutException, ExecutionException {
         finishedNormally = false;
         try (ChronicleQueue queue = createQueue(SYSTEM_TIME_PROVIDER)) {
 
@@ -125,7 +125,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
     }
 
     @Test
-    public void tailerResourcesCanBeReleasedManually() throws Exception {
+    void tailerResourcesCanBeReleasedManually() throws Exception {
         FlakyTestRunner.builder(this::tailerResourcesCanBeReleasedManually0).build().run();
     }
 
@@ -160,7 +160,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
     }
 
     @Test
-    public void tailerShouldReleaseFileHandlesAsQueueRolls() throws InterruptedException {
+    void tailerShouldReleaseFileHandlesAsQueueRolls() throws InterruptedException {
 
         System.gc();
         Thread.sleep(100);
@@ -208,7 +208,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
     }
 
     @Test
-    public void appenderShouldOnlyKeepCurrentRollCycleOpen_deflaked() {
+    void appenderShouldOnlyKeepCurrentRollCycleOpen_deflaked() {
         FlakyTestRunner.<RuntimeException>builder(this::appenderShouldOnlyKeepCurrentRollCycleOpen)
                 .withMaxIterations(3)
                 .build()
@@ -229,7 +229,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
     }
 
     @Test
-    public void tailerShouldOnlyKeepCurrentRollCycleOpen_deflaked() {
+    void tailerShouldOnlyKeepCurrentRollCycleOpen_deflaked() {
         FlakyTestRunner.<RuntimeException>builder(this::tailerShouldOnlyKeepCurrentRollCycleOpen)
                 .withMaxIterations(3)
                 .build()

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderFileHandleLeakTest.java
@@ -19,9 +19,8 @@ import net.openhft.chronicle.testframework.mappedfiles.MappedFileUtil;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -38,8 +37,8 @@ import java.util.stream.IntStream;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 import static net.openhft.chronicle.testframework.GcControls.requestGcCycle;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public final class AppenderFileHandleLeakTest extends QueueTestCommon {
     private static final int THREAD_COUNT = Runtime.getRuntime().availableProcessors() * 2;
@@ -82,7 +81,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
      * These only run on Linux because {@link MappedFileUtil#getAllMappedFiles()} only works
      * on Linux
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         assumeTrue(OS.isLinux());
         System.gc();
@@ -121,7 +120,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
 
         }
 
-        Assert.assertTrue(queueFilesAreAllClosed());
+        assertTrue(queueFilesAreAllClosed());
         finishedNormally = true;
     }
 
@@ -156,7 +155,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
             assertFalse(gcGuard.isEmpty());
         }
 
-        Assert.assertTrue(queueFilesAreAllClosed());
+        assertTrue(queueFilesAreAllClosed());
 
     }
 
@@ -205,7 +204,7 @@ public final class AppenderFileHandleLeakTest extends QueueTestCommon {
 
         }
 
-        Assert.assertTrue(queueFilesAreAllClosed());
+        assertTrue(queueFilesAreAllClosed());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CheckIndicesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CheckIndicesTest.java
@@ -30,8 +30,8 @@ class CheckIndicesTest extends QueueTestCommon {
         super.threadDump();
     }
 
-    @Disabled("stress test to run manually")
     @Test
+    @Disabled("stress test to run manually")
     void test() throws ExecutionException, InterruptedException {
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.binary(getTmpDir()).epoch(System.currentTimeMillis()).build()) {
             queue0 = queue;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CheckIndicesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CheckIndicesTest.java
@@ -8,9 +8,9 @@ import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -25,12 +25,12 @@ public class CheckIndicesTest extends QueueTestCommon {
     private ChronicleQueue queue0;
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
 
-    @Ignore("stress test to run manually")
+    @Disabled("stress test to run manually")
     @Test
     public void test() throws ExecutionException, InterruptedException {
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.binary(getTmpDir()).epoch(System.currentTimeMillis()).build()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CheckIndicesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CheckIndicesTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
-public class CheckIndicesTest extends QueueTestCommon {
+class CheckIndicesTest extends QueueTestCommon {
 
     private static final int BATCH_SIZE = 10;
     private ChronicleQueue queue0;
@@ -32,7 +32,7 @@ public class CheckIndicesTest extends QueueTestCommon {
 
     @Disabled("stress test to run manually")
     @Test
-    public void test() throws ExecutionException, InterruptedException {
+    void test() throws ExecutionException, InterruptedException {
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.binary(getTmpDir()).epoch(System.currentTimeMillis()).build()) {
             queue0 = queue;
             newSingleThreadScheduledExecutor().scheduleAtFixedRate(this::appendToQueue, 0, 1, TimeUnit.MICROSECONDS);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
@@ -9,11 +9,11 @@ import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CycleOverflowTest extends QueueTestCommon {
 
@@ -24,7 +24,7 @@ public class CycleOverflowTest extends QueueTestCommon {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.set(System.currentTimeMillis());
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().timeProvider(timeProvider).rollCycle(rollCycle).path(path).build(); ExcerptAppender appender = queue.createAppender();) {
-            assertThrows("Unable to index 64, the number of entries exceeds max number for the current rollcycle", IllegalStateException.class, () -> {
+            assertThrows(IllegalStateException.class, () -> {
                 for (int i = 0; i < rollCycle.maxMessagesPerCycle() + 1; i++) {
                     appender.writeText(Integer.toString(i));
                 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
@@ -15,10 +15,10 @@ import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class CycleOverflowTest extends QueueTestCommon {
+class CycleOverflowTest extends QueueTestCommon {
 
     @Test
-    public void overflowingMaxMessagesInCycleShouldThrowException() {
+    void overflowingMaxMessagesInCycleShouldThrowException() {
         File path = getTmpDir();
         RollCycle rollCycle = TestRollCycles.TEST_DAILY;
         SetTimeProvider timeProvider = new SetTimeProvider();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
@@ -24,11 +24,12 @@ class CycleOverflowTest extends QueueTestCommon {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.set(System.currentTimeMillis());
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().timeProvider(timeProvider).rollCycle(rollCycle).path(path).build(); ExcerptAppender appender = queue.createAppender();) {
-            assertThrows(IllegalStateException.class, () -> {
-                for (int i = 0; i < rollCycle.maxMessagesPerCycle() + 1; i++) {
-                    appender.writeText(Integer.toString(i));
-                }
-            });
+            for (int i = 0; i < rollCycle.maxMessagesPerCycle(); i++) {
+                appender.writeText(Integer.toString(i));
+            }
+
+            assertThrows(IllegalStateException.class,
+                    () -> appender.writeText(Long.toString(rollCycle.maxMessagesPerCycle())));
         } finally {
             IOTools.deleteDirWithFiles(path);
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
@@ -40,7 +40,7 @@ final class DocumentOrderingTest extends QueueTestCommon {
 
     @BeforeEach
     void beforeEachDocumentOrderingTest() {
-        public threadDump();
+        threadDump();
         multiCPU();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
@@ -8,9 +8,8 @@ import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.ValueOut;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.*;
@@ -19,7 +18,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public final class DocumentOrderingTest extends QueueTestCommon {
     private static final RollCycle ROLL_CYCLE = TEST_SECONDLY;
@@ -38,8 +38,13 @@ public final class DocumentOrderingTest extends QueueTestCommon {
 
     private Thread thread;
 
+    @BeforeEach
+    public void beforeEachDocumentOrderingTest() {
+        threadDump();
+        multiCPU();
+    }
+
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
@@ -258,7 +263,7 @@ public final class DocumentOrderingTest extends QueueTestCommon {
             }
             return new RecordInfo(counterValue);
         });
-        assertTrue("Task did not start", startedLatch.await(1, TimeUnit.MINUTES));
+        assertTrue(startedLatch.await(1, TimeUnit.MINUTES), "Task did not start");
         return future;
     }
 
@@ -276,8 +281,7 @@ public final class DocumentOrderingTest extends QueueTestCommon {
         }
     }
 
-    @Before
     public void multiCPU() {
-        Assume.assumeTrue(Runtime.getRuntime().availableProcessors() > 1);
+        assumeTrue(Runtime.getRuntime().availableProcessors() > 1);
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentOrderingTest.java
@@ -21,7 +21,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public final class DocumentOrderingTest extends QueueTestCommon {
+final class DocumentOrderingTest extends QueueTestCommon {
     private static final RollCycle ROLL_CYCLE = TEST_SECONDLY;
     private final ExecutorService executorService = Executors.newCachedThreadPool(
             new NamedThreadFactory("test"));
@@ -39,8 +39,8 @@ public final class DocumentOrderingTest extends QueueTestCommon {
     private Thread thread;
 
     @BeforeEach
-    public void beforeEachDocumentOrderingTest() {
-        threadDump();
+    void beforeEachDocumentOrderingTest() {
+        public threadDump();
         multiCPU();
     }
 
@@ -50,7 +50,7 @@ public final class DocumentOrderingTest extends QueueTestCommon {
     }
 
     @Test
-    public void queuedWriteInPreviousCycleShouldRespectTotalOrdering() throws InterruptedException, TimeoutException, ExecutionException {
+    void queuedWriteInPreviousCycleShouldRespectTotalOrdering() throws InterruptedException, TimeoutException, ExecutionException {
         try (final ChronicleQueue queue =
                      builder(getTmpDir(), 1_000L).build();
              final ExcerptAppender excerptAppender = queue.createAppender()) {
@@ -88,7 +88,7 @@ public final class DocumentOrderingTest extends QueueTestCommon {
     }
 
     @Test
-    public void multipleThreadsMustWaitUntilPreviousCycleFileIsCompleted() throws InterruptedException, TimeoutException, ExecutionException {
+    void multipleThreadsMustWaitUntilPreviousCycleFileIsCompleted() throws InterruptedException, TimeoutException, ExecutionException {
         finishedNormally = false;
         final File dir = getTmpDir();
         // must be different instances of queue to work around synchronization on acquireStore()
@@ -138,7 +138,7 @@ public final class DocumentOrderingTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldRecoverFromUnfinishedFirstMessageInPreviousQueue() throws InterruptedException, TimeoutException, ExecutionException {
+    void shouldRecoverFromUnfinishedFirstMessageInPreviousQueue() throws InterruptedException, TimeoutException, ExecutionException {
         finishedNormally = false;
         System.setProperty("queue.force.unlock.mode", "ALWAYS");
         expectException("Couldn't acquire write lock");
@@ -170,7 +170,7 @@ public final class DocumentOrderingTest extends QueueTestCommon {
     }
 
     @Test
-    public void codeWithinPriorDocumentMustExecuteBeforeSubsequentDocumentWhenQueueIsEmpty() throws InterruptedException, TimeoutException, ExecutionException {
+    void codeWithinPriorDocumentMustExecuteBeforeSubsequentDocumentWhenQueueIsEmpty() throws InterruptedException, TimeoutException, ExecutionException {
         finishedNormally = false;
         try (final ChronicleQueue queue =
                      builder(getTmpDir(), 3_000L).build();
@@ -201,7 +201,7 @@ public final class DocumentOrderingTest extends QueueTestCommon {
     }
 
     @Test
-    public void codeWithinPriorDocumentMustExecuteBeforeSubsequentDocumentWhenQueueIsNotEmpty() throws InterruptedException, TimeoutException, ExecutionException {
+    void codeWithinPriorDocumentMustExecuteBeforeSubsequentDocumentWhenQueueIsNotEmpty() throws InterruptedException, TimeoutException, ExecutionException {
         finishedNormally = false;
         try (final ChronicleQueue queue =
                      builder(getTmpDir(), 3_000L).build();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
@@ -11,8 +11,6 @@ import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -95,7 +93,7 @@ class EmptyRollCycleTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 6_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(6)
     void appropriateExceptionIsThrownWhenLockCannotBeAcquiredForRecovery() throws IOException, InterruptedException {
         createQueueWithEmptyRollCycleAtEnd();
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
@@ -10,9 +10,9 @@ import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -23,20 +23,19 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class EmptyRollCycleTest extends QueueTestCommon {
 
     private static final String EMPTY_ROLL_CYCLE_NAME = "19700101-0020X.cq4";
     private Path dataDirectory;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         dataDirectory = IOTools.createTempDirectory("EmptyRollCycleTest");
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         IOTools.deleteDirWithFiles(dataDirectory.toFile());
     }
@@ -95,7 +94,8 @@ public class EmptyRollCycleTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 6_000)
+    @Test
+    @Timeout(value = 6_000, unit = TimeUnit.MILLISECONDS)
     public void appropriateExceptionIsThrownWhenLockCannotBeAcquiredForRecovery() throws IOException, InterruptedException {
         createQueueWithEmptyRollCycleAtEnd();
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
@@ -116,7 +116,7 @@ class EmptyRollCycleTest extends QueueTestCommon {
                         assertTrue(readingDocument.isPresent());
                     }
                 }
-                assertEquals(false, tailer.readingDocument().isPresent());
+                assertFalse(tailer.readingDocument().isPresent());
             }
         } finally {
             start.destroy();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EmptyRollCycleTest.java
@@ -25,23 +25,23 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class EmptyRollCycleTest extends QueueTestCommon {
+class EmptyRollCycleTest extends QueueTestCommon {
 
     private static final String EMPTY_ROLL_CYCLE_NAME = "19700101-0020X.cq4";
     private Path dataDirectory;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         dataDirectory = IOTools.createTempDirectory("EmptyRollCycleTest");
     }
 
     @AfterEach
-    public void tearDown() {
+    protected void tearDown() {
         IOTools.deleteDirWithFiles(dataDirectory.toFile());
     }
 
     @Test
-    public void tailerShouldTolerateEmptyRollCycleAtEnd() throws IOException {
+    void tailerShouldTolerateEmptyRollCycleAtEnd() throws IOException {
         ignoreException("Channel closed while unlocking");
         createQueueWithEmptyRollCycleAtEnd();
 
@@ -65,7 +65,7 @@ public class EmptyRollCycleTest extends QueueTestCommon {
     }
 
     @Test
-    public void appenderShouldTolerateEmptyRollCycleAtEnd() throws IOException {
+    void appenderShouldTolerateEmptyRollCycleAtEnd() throws IOException {
         ignoreException("Channel closed while unlocking");
         ignoreException("Renamed un-acquirable segment file");
         createQueueWithEmptyRollCycleAtEnd();
@@ -96,7 +96,7 @@ public class EmptyRollCycleTest extends QueueTestCommon {
 
     @Test
     @Timeout(value = 6_000, unit = TimeUnit.MILLISECONDS)
-    public void appropriateExceptionIsThrownWhenLockCannotBeAcquiredForRecovery() throws IOException, InterruptedException {
+    void appropriateExceptionIsThrownWhenLockCannotBeAcquiredForRecovery() throws IOException, InterruptedException {
         createQueueWithEmptyRollCycleAtEnd();
 
         final Path emptyRollCycle = dataDirectory.resolve(EMPTY_ROLL_CYCLE_NAME);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
@@ -9,8 +9,8 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,13 +22,13 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class EntryCountNotBehindReadTest extends QueueTestCommon {
     private static final int TOTAL_EVENTS = 100_000;
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EntryCountNotBehindReadTest.java
@@ -24,7 +24,7 @@ import java.util.function.LongConsumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public final class EntryCountNotBehindReadTest extends QueueTestCommon {
+final class EntryCountNotBehindReadTest extends QueueTestCommon {
     private static final int TOTAL_EVENTS = 100_000;
 
     @Override
@@ -34,7 +34,7 @@ public final class EntryCountNotBehindReadTest extends QueueTestCommon {
     }
 
     @Test
-    public void testExcerptsPerCycleNotBehind() throws IOException {
+    void testExcerptsPerCycleNotBehind() throws IOException {
         final File file = Files.createTempDirectory("exact-excerpts-per-cycle").toFile();
         try (final SingleChronicleQueue queue =
                      SingleChronicleQueueBuilder.binary(file).build();
@@ -61,7 +61,7 @@ public final class EntryCountNotBehindReadTest extends QueueTestCommon {
     }
 
     @Test
-    public void testToEndNotBehind() throws IOException {
+    void testToEndNotBehind() throws IOException {
         final File file = Files.createTempDirectory("to-end").toFile();
         try (final SingleChronicleQueue queue =
                      SingleChronicleQueueBuilder.binary(file).build()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EofMarkerOnEmptyQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EofMarkerOnEmptyQueueTest.java
@@ -29,7 +29,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public final class EofMarkerOnEmptyQueueTest extends QueueTestCommon {
+final class EofMarkerOnEmptyQueueTest extends QueueTestCommon {
     private static final ReferenceOwner test = ReferenceOwner.temporary("test");
     @TempDir
     Path tmpFolder;
@@ -41,7 +41,7 @@ public final class EofMarkerOnEmptyQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldRecoverFromEmptyQueueOnRoll() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    void shouldRecoverFromEmptyQueueOnRoll() throws IOException, InterruptedException, ExecutionException, TimeoutException {
         assumeFalse(OS.isWindows());
         System.setProperty("queue.force.unlock.mode", "ALWAYS");
         expectException("Couldn't acquire write lock");

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/EofMarkerOnEmptyQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/EofMarkerOnEmptyQueueTest.java
@@ -15,41 +15,41 @@ import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.ValueIn;
 import net.openhft.chronicle.wire.Wires;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public final class EofMarkerOnEmptyQueueTest extends QueueTestCommon {
     private static final ReferenceOwner test = ReferenceOwner.temporary("test");
-    @Rule
-    public TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    Path tmpFolder;
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
 
     @Test
     public void shouldRecoverFromEmptyQueueOnRoll() throws IOException, InterruptedException, ExecutionException, TimeoutException {
-        Assume.assumeFalse(OS.isWindows());
+        assumeFalse(OS.isWindows());
         System.setProperty("queue.force.unlock.mode", "ALWAYS");
         expectException("Couldn't acquire write lock");
         expectException("Forced unlock for the lock");
 
         final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
         try (final RollingChronicleQueue queue =
-                     ChronicleQueue.singleBuilder(tmpFolder.newFolder()).
+                     ChronicleQueue.singleBuilder(Files.createTempDirectory(tmpFolder, "queue").toFile()).
                              rollCycle(TEST_SECONDLY).
                              timeProvider(clock::get).
                              timeoutMS(1_000).

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ExcerptsSkippedWhenTailerDirectionNoneTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ExcerptsSkippedWhenTailerDirectionNoneTest.java
@@ -14,8 +14,8 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
 final class ExcerptsSkippedWhenTailerDirectionNoneTest extends QueueTestCommon {
-    @SuppressWarnings("try")
     @Test
+    @SuppressWarnings("try")
     void shouldNotSkipMessageAtStartOfQueue() {
         final File tmpDir = getTmpDir();
         try (final ChronicleQueue writeQueue =

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ExcerptsSkippedWhenTailerDirectionNoneTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ExcerptsSkippedWhenTailerDirectionNoneTest.java
@@ -13,10 +13,10 @@ import java.io.File;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public final class ExcerptsSkippedWhenTailerDirectionNoneTest extends QueueTestCommon {
+final class ExcerptsSkippedWhenTailerDirectionNoneTest extends QueueTestCommon {
     @SuppressWarnings("try")
     @Test
-    public void shouldNotSkipMessageAtStartOfQueue() {
+    void shouldNotSkipMessageAtStartOfQueue() {
         final File tmpDir = getTmpDir();
         try (final ChronicleQueue writeQueue =
                      ChronicleQueue.singleBuilder(tmpDir)

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ExcerptsSkippedWhenTailerDirectionNoneTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ExcerptsSkippedWhenTailerDirectionNoneTest.java
@@ -6,12 +6,12 @@ package net.openhft.chronicle.queue.impl.single;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.ValueIn;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class ExcerptsSkippedWhenTailerDirectionNoneTest extends QueueTestCommon {
     @SuppressWarnings("try")

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/FileModificationTimeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/FileModificationTimeTest.java
@@ -6,14 +6,14 @@ package net.openhft.chronicle.queue.impl.single;
 import net.openhft.chronicle.bytes.PageUtil;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.queue.QueueTestCommon;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongSupplier;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public final class FileModificationTimeTest extends QueueTestCommon {
     private final AtomicInteger fileCount = new AtomicInteger();
@@ -33,7 +33,7 @@ public final class FileModificationTimeTest extends QueueTestCommon {
     @Test
     public void shouldUpdateDirectoryModificationTime() {
         final File dir = getTmpDir();
-        Assume.assumeFalse(PageUtil.isHugePage(dir.getAbsolutePath()));
+        assumeFalse(PageUtil.isHugePage(dir.getAbsolutePath()));
         dir.mkdirs();
 
         final long startModTime = dir.lastModified();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/FileModificationTimeTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/FileModificationTimeTest.java
@@ -15,7 +15,7 @@ import java.util.function.LongSupplier;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public final class FileModificationTimeTest extends QueueTestCommon {
+final class FileModificationTimeTest extends QueueTestCommon {
     private final AtomicInteger fileCount = new AtomicInteger();
 
     private static void waitForDiff(final long a, final LongSupplier b) {
@@ -31,7 +31,7 @@ public final class FileModificationTimeTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldUpdateDirectoryModificationTime() {
+    void shouldUpdateDirectoryModificationTime() {
         final File dir = getTmpDir();
         assumeFalse(PageUtil.isHugePage(dir.getAbsolutePath()));
         dir.mkdirs();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexOffsetTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexOffsetTest.java
@@ -6,21 +6,22 @@ package net.openhft.chronicle.queue.impl.single;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.WireType;
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-public class IndexOffsetTest extends QueueTestCommon {
+class IndexOffsetTest extends QueueTestCommon {
 
     private static final SCQIndexing indexing = new SCQIndexing(WireType.BINARY, 1 << 17, 1 << 6);
     private static final SCQIndexing indexing2 = new SCQIndexing(WireType.BINARY, 1 << 7, 1 << 3);
 
     @Test
-    public void testFindExcerpt2() {
+    void testFindExcerpt2() {
         assertEquals(1, indexing.toAddress0(1L << (17L + 6L)));
         assertEquals(1, indexing2.toAddress0(1L << (7L + 3L)));
     }
 
     @Test
-    public void testFindExcerpt() {
+    void testFindExcerpt() {
         assertEquals(1, indexing.toAddress1(64));
         assertEquals(1, indexing.toAddress1(65));
         assertEquals(2, indexing.toAddress1(128));

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexOffsetTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexOffsetTest.java
@@ -5,8 +5,8 @@ package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IndexOffsetTest extends QueueTestCommon {
 
@@ -15,22 +15,22 @@ public class IndexOffsetTest extends QueueTestCommon {
 
     @Test
     public void testFindExcerpt2() {
-        Assert.assertEquals(1, indexing.toAddress0(1L << (17L + 6L)));
-        Assert.assertEquals(1, indexing2.toAddress0(1L << (7L + 3L)));
+        assertEquals(1, indexing.toAddress0(1L << (17L + 6L)));
+        assertEquals(1, indexing2.toAddress0(1L << (7L + 3L)));
     }
 
     @Test
     public void testFindExcerpt() {
-        Assert.assertEquals(1, indexing.toAddress1(64));
-        Assert.assertEquals(1, indexing.toAddress1(65));
-        Assert.assertEquals(2, indexing.toAddress1(128));
-        Assert.assertEquals(2, indexing.toAddress1(129));
-        Assert.assertEquals(3, indexing.toAddress1(128 + 64));
+        assertEquals(1, indexing.toAddress1(64));
+        assertEquals(1, indexing.toAddress1(65));
+        assertEquals(2, indexing.toAddress1(128));
+        assertEquals(2, indexing.toAddress1(129));
+        assertEquals(3, indexing.toAddress1(128 + 64));
 
-        Assert.assertEquals(1, indexing2.toAddress1(8));
-        Assert.assertEquals(1, indexing2.toAddress1(9));
-        Assert.assertEquals(16, indexing2.toAddress1(128));
-        Assert.assertEquals(16, indexing2.toAddress1(129));
-        Assert.assertEquals(17, indexing2.toAddress1(128 + 8));
+        assertEquals(1, indexing2.toAddress1(8));
+        assertEquals(1, indexing2.toAddress1(9));
+        assertEquals(16, indexing2.toAddress1(128));
+        assertEquals(16, indexing2.toAddress1(129));
+        assertEquals(17, indexing2.toAddress1(128 + 8));
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexTest.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import static net.openhft.chronicle.queue.impl.single.StoreTailer.INDEXING_LINEAR_SCAN_THRESHOLD;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class IndexTest extends QueueTestCommon {
+class IndexTest extends QueueTestCommon {
 
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
@@ -31,7 +31,7 @@ public class IndexTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void test(@NotNull WireType wireType) {
+    void test(@NotNull WireType wireType) {
         try (final RollingChronicleQueue queue = SingleChronicleQueueBuilder
                 .binary(getTmpDir())
                 .testBlockSize()
@@ -53,7 +53,7 @@ public class IndexTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldShortCircuitIndexLookupWhenNewIndexIsCloseToPreviousIndex(@NotNull WireType wireType) {
+    void shouldShortCircuitIndexLookupWhenNewIndexIsCloseToPreviousIndex(@NotNull WireType wireType) {
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder
                 .binary(getTmpDir())
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexTest.java
@@ -11,31 +11,17 @@ import net.openhft.chronicle.queue.impl.RollingChronicleQueue;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
 import static net.openhft.chronicle.queue.impl.single.StoreTailer.INDEXING_LINEAR_SCAN_THRESHOLD;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class IndexTest extends QueueTestCommon {
 
-    @NotNull
-    private final WireType wireType;
-
-    /**
-     * @param wireType the type of the wire
-     */
-    public IndexTest(@NotNull WireType wireType) {
-        this.wireType = wireType;
-    }
-
-    @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 // {WireType.TEXT}, // TEXT mode not supported here due to missing CAS in LongArrayReference
@@ -43,12 +29,13 @@ public class IndexTest extends QueueTestCommon {
         });
     }
 
-    @Test
-    public void test() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(@NotNull WireType wireType) {
         try (final RollingChronicleQueue queue = SingleChronicleQueueBuilder
                 .binary(getTmpDir())
                 .testBlockSize()
-                .wireType(this.wireType)
+                .wireType(wireType)
                 .build();
              final ExcerptAppender appender = queue.createAppender()) {
 
@@ -64,12 +51,13 @@ public class IndexTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void shouldShortCircuitIndexLookupWhenNewIndexIsCloseToPreviousIndex() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldShortCircuitIndexLookupWhenNewIndexIsCloseToPreviousIndex(@NotNull WireType wireType) {
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder
                 .binary(getTmpDir())
                 .testBlockSize()
-                .wireType(this.wireType)
+                .wireType(wireType)
                 .build();
              final ExcerptAppender appender = queue.createAppender()) {
 
@@ -109,6 +97,6 @@ public class IndexTest extends QueueTestCommon {
     }
 
     private void accessHexEquals(long index0, long indexA) {
-        assertEquals(Long.toHexString(index0) + " != " + Long.toHexString(indexA), index0, indexA);
+        assertEquals(index0, indexA, Long.toHexString(index0) + " != " + Long.toHexString(indexA));
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingLastSequenceNumberTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingLastSequenceNumberTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.StreamCorruptedException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests focussed on {@link Indexing#lastSequenceNumber(ExcerptContext)}.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingMoveToCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingMoveToCycleTest.java
@@ -5,8 +5,7 @@ package net.openhft.chronicle.queue.impl.single;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 class IndexingMoveToCycleTest extends IndexingTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingSpacingAndCountTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingSpacingAndCountTest.java
@@ -5,8 +5,7 @@ package net.openhft.chronicle.queue.impl.single;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class IndexingSpacingAndCountTest extends IndexingTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingToEndTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class IndexingToEndTest extends IndexingTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/InternalAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/InternalAppenderTest.java
@@ -7,12 +7,12 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.QueueTestCommon;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Files;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class InternalAppenderTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/InternalAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/InternalAppenderTest.java
@@ -14,10 +14,10 @@ import java.nio.file.Files;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class InternalAppenderTest extends QueueTestCommon {
+class InternalAppenderTest extends QueueTestCommon {
 
     @Test
-    public void replicationTest() throws Exception {
+    void replicationTest() throws Exception {
         final File file = Files.createTempDirectory("queue").toFile();
         try (final SingleChronicleQueue queue =
                      SingleChronicleQueueBuilder.single(file).build();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MappedMemoryUnmappingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MappedMemoryUnmappingTest.java
@@ -8,20 +8,21 @@ import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.testframework.GcControls;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class MappedMemoryUnmappingTest extends QueueTestCommon {
-    @Rule
-    public TemporaryFolder tmp = new TemporaryFolder();
+    @TempDir
+    Path tmp;
 
     @Test
     public void shouldUnmapMemoryAsCycleRolls() throws IOException {
@@ -29,7 +30,7 @@ public final class MappedMemoryUnmappingTest extends QueueTestCommon {
         long initialQueueMappedMemory = 0L;
 
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.
-                binary(tmp.newFolder()).testBlockSize().rollCycle(TEST_SECONDLY).
+                binary(Files.createTempDirectory(tmp, "queue").toFile()).testBlockSize().rollCycle(TEST_SECONDLY).
                 timeProvider(clock::get).build();
              final ExcerptAppender appender = queue.createAppender()) {
             for (int i = 0; i < 100; i++) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MappedMemoryUnmappingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MappedMemoryUnmappingTest.java
@@ -20,12 +20,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public final class MappedMemoryUnmappingTest extends QueueTestCommon {
+final class MappedMemoryUnmappingTest extends QueueTestCommon {
     @TempDir
     Path tmp;
 
     @Test
-    public void shouldUnmapMemoryAsCycleRolls() throws IOException {
+    void shouldUnmapMemoryAsCycleRolls() throws IOException {
         final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
         long initialQueueMappedMemory = 0L;
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
@@ -10,12 +10,8 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.TailerDirection;
 import net.openhft.chronicle.wire.MessageHistory;
 import net.openhft.chronicle.wire.VanillaMessageHistory;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.util.Arrays;
@@ -23,23 +19,14 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public final class MessageHistoryTest extends QueueTestCommon {
-    @Rule
-    public final TestName testName = new TestName();
     private final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
     private File inputQueueDir;
     private File middleQueueDir;
     private File outputQueueDir;
-    private final boolean named;
 
-    public MessageHistoryTest(boolean named) {
-        this.named = named;
-    }
-
-    @Parameterized.Parameters(name = "named={0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[]{true},
@@ -47,8 +34,7 @@ public final class MessageHistoryTest extends QueueTestCommon {
         );
     }
 
-    @Before
-    public void setUp() {
+    private void setUp() {
         inputQueueDir = getTmpDir();
         middleQueueDir = getTmpDir();
         outputQueueDir = getTmpDir();
@@ -57,11 +43,13 @@ public final class MessageHistoryTest extends QueueTestCommon {
         MessageHistory.set(messageHistory);
     }
 
-    @Test
-    public void shouldAccessMessageHistory() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldAccessMessageHistory(boolean named) {
+        setUp();
         try (final ChronicleQueue inputQueue = createQueue(inputQueueDir, 1);
              final ChronicleQueue outputQueue = createQueue(outputQueueDir, 2)) {
-            generateTestData(inputQueue, outputQueue);
+            generateTestData(inputQueue, outputQueue, named);
 
             final ExcerptTailer tailer = outputQueue.createTailer(named ? "named" : null);
 
@@ -73,11 +61,13 @@ public final class MessageHistoryTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void shouldAccessMessageHistoryWhenTailerIsMovedToEnd() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldAccessMessageHistoryWhenTailerIsMovedToEnd(boolean named) {
+        setUp();
         try (final ChronicleQueue inputQueue = createQueue(inputQueueDir, 1);
              final ChronicleQueue outputQueue = createQueue(outputQueueDir, 2)) {
-            generateTestData(inputQueue, outputQueue);
+            generateTestData(inputQueue, outputQueue, named);
 
             final ExcerptTailer tailer = outputQueue.createTailer(named ? "named" : null);
             tailer.direction(TailerDirection.BACKWARD).toEnd();
@@ -90,12 +80,14 @@ public final class MessageHistoryTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void chainedMessageHistory() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void chainedMessageHistory(boolean named) {
+        setUp();
         try (final ChronicleQueue inputQueue = createQueue(inputQueueDir, 1);
              final ChronicleQueue middleQueue = createQueue(middleQueueDir, 2);
              final ChronicleQueue outputQueue = createQueue(outputQueueDir, 3)) {
-            generateTestData(inputQueue, middleQueue);
+            generateTestData(inputQueue, middleQueue, named);
 
             ExcerptTailer tailerM1 = middleQueue.createTailer(named ? "named" : null);
             MethodReader reader = tailerM1.methodReader(outputQueue.methodWriter(First.class));
@@ -103,12 +95,12 @@ public final class MessageHistoryTest extends QueueTestCommon {
             tailerM1.toStart();
             MethodReader reader2nd = tailerM1.methodReader(outputQueue.methodWriter(Second.class));
             for (int i = 0; i < 3; i++)
-                assertTrue("i: " + i, reader2nd.readOne());
+                assertTrue(reader2nd.readOne(), "i: " + i);
             assertFalse(reader2nd.readOne());
 
             MethodReader reader2 = outputQueue.createTailer(named ? "named2" : null).methodReader((First) this::say3);
             for (int i = 0; i < 3; i++)
-                assertTrue("i: " + i, reader2.readOne());
+                assertTrue(reader2.readOne(), "i: " + i);
             assertFalse(reader2.readOne());
         }
     }
@@ -119,7 +111,7 @@ public final class MessageHistoryTest extends QueueTestCommon {
         assertEquals(2, messageHistory.sources());
     }
 
-    private void generateTestData(final ChronicleQueue inputQueue, final ChronicleQueue outputQueue) {
+    private void generateTestData(final ChronicleQueue inputQueue, final ChronicleQueue outputQueue, boolean named) {
         final First first = inputQueue.methodWriterBuilder(First.class)
                 .get();
         first.say("one");

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MessageHistoryTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public final class MessageHistoryTest extends QueueTestCommon {
+final class MessageHistoryTest extends QueueTestCommon {
     private final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
     private File inputQueueDir;
     private File middleQueueDir;
@@ -45,7 +45,7 @@ public final class MessageHistoryTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldAccessMessageHistory(boolean named) {
+    void shouldAccessMessageHistory(boolean named) {
         setUp();
         try (final ChronicleQueue inputQueue = createQueue(inputQueueDir, 1);
              final ChronicleQueue outputQueue = createQueue(outputQueueDir, 2)) {
@@ -63,7 +63,7 @@ public final class MessageHistoryTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldAccessMessageHistoryWhenTailerIsMovedToEnd(boolean named) {
+    void shouldAccessMessageHistoryWhenTailerIsMovedToEnd(boolean named) {
         setUp();
         try (final ChronicleQueue inputQueue = createQueue(inputQueueDir, 1);
              final ChronicleQueue outputQueue = createQueue(outputQueueDir, 2)) {
@@ -82,7 +82,7 @@ public final class MessageHistoryTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void chainedMessageHistory(boolean named) {
+    void chainedMessageHistory(boolean named) {
         setUp();
         try (final ChronicleQueue inputQueue = createQueue(inputQueueDir, 1);
              final ChronicleQueue middleQueue = createQueue(middleQueueDir, 2);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MetadataDeletionTests.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MetadataDeletionTests.java
@@ -17,7 +17,7 @@ import java.time.Duration;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.*;
 
 /**
  * Tests to demonstrate recovery from metadata file deletion.

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MetadataDeletionTests.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MetadataDeletionTests.java
@@ -152,5 +152,4 @@ class MetadataDeletionTests extends QueueTestCommon {
             IOTools.deleteDirWithFiles(queuePath);
         }
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MicroToucherTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MicroToucherTest.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MicroToucherTest extends QueueTestCommon {
+class MicroToucherTest extends QueueTestCommon {
 
     @Override
     @BeforeEach
@@ -26,7 +26,7 @@ public class MicroToucherTest extends QueueTestCommon {
     }
 
     @Test
-    public void touchPageTestBlockSize() {
+    void touchPageTestBlockSize() {
         touchPage(b -> b.blockSize(64 << 20), 66561);
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MicroToucherTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MicroToucherTest.java
@@ -10,17 +10,17 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MicroToucherTest extends QueueTestCommon {
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
@@ -61,7 +61,7 @@ public class MicroToucherTest extends QueueTestCommon {
                 boolean touch = page != lastPage && appender.wire().bytes().bytesStore().inside(page, 8);
                 lastPage = page;
                 if (touch != appender.microTouch())
-                    assertEquals("i: " + i, touch, appender.microTouch());
+                    assertEquals(touch, appender.microTouch(), "i: " + i);
                 if (touch)
                     pages++;
             }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToIndexTest.java
@@ -20,12 +20,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public final class MoveToIndexTest extends QueueTestCommon {
+final class MoveToIndexTest extends QueueTestCommon {
     @TempDir
     Path tmpFolder;
 
     @Test
-    public void shouldMoveToPreviousIndexAfterDocumentIsConsumed() throws IOException {
+    void shouldMoveToPreviousIndexAfterDocumentIsConsumed() throws IOException {
         File queuePath = Files.createDirectory(tmpFolder.resolve("cq")).toFile();
 
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(queuePath).build();
@@ -47,7 +47,7 @@ public final class MoveToIndexTest extends QueueTestCommon {
 
     // https://github.com/OpenHFT/Chronicle-Queue/issues/401
     @Test
-    public void testRandomMove() throws IOException {
+    void testRandomMove() throws IOException {
         final Map<Long, String> messageByIndex = new HashMap<>();
 
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.
@@ -83,7 +83,7 @@ public final class MoveToIndexTest extends QueueTestCommon {
      * @throws Exception If failed.
      */
     @Test
-    public void testNotReachedInCycle() throws Exception {
+    void testNotReachedInCycle() throws Exception {
         try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(Files.createTempDirectory(tmpFolder, "queue").toFile()).build();
              ExcerptAppender appender = q.createAppender()) {
             ExcerptTailer tailer = q.createTailer();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToIndexTest.java
@@ -8,25 +8,25 @@ import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class MoveToIndexTest extends QueueTestCommon {
-    @Rule
-    public TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir
+    Path tmpFolder;
 
     @Test
     public void shouldMoveToPreviousIndexAfterDocumentIsConsumed() throws IOException {
-        File queuePath = tmpFolder.newFolder("cq");
+        File queuePath = Files.createDirectory(tmpFolder.resolve("cq")).toFile();
 
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(queuePath).build();
              ExcerptAppender appender = queue.createAppender()) {
@@ -51,7 +51,7 @@ public final class MoveToIndexTest extends QueueTestCommon {
         final Map<Long, String> messageByIndex = new HashMap<>();
 
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.
-                binary(tmpFolder.newFolder()).build();
+                binary(Files.createTempDirectory(tmpFolder, "queue").toFile()).build();
              final ExcerptAppender appender = queue.createAppender()) {
             // create a queue and add some excerpts
             for (int i = 0; i < 10; i++) {
@@ -84,7 +84,7 @@ public final class MoveToIndexTest extends QueueTestCommon {
      */
     @Test
     public void testNotReachedInCycle() throws Exception {
-        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(tmpFolder.newFolder()).build();
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(Files.createTempDirectory(tmpFolder, "queue").toFile()).build();
              ExcerptAppender appender = q.createAppender()) {
             ExcerptTailer tailer = q.createTailer();
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToWrongIndexThenToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToWrongIndexThenToEndTest.java
@@ -11,9 +11,9 @@ import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.UnrecoverableTimeoutException;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.StreamCorruptedException;
 import java.nio.ByteBuffer;
@@ -26,8 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 import static net.openhft.chronicle.queue.RollCycles.DEFAULT;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * The ChronicleQueueIT class implements a test that causes Chronicle Queue to
@@ -57,12 +56,12 @@ public class MoveToWrongIndexThenToEndTest extends QueueTestCommon {
     }
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
 
-    @After
+    @AfterEach
     public void after() {
         outbound.releaseLast();
         closeQuietly(appender, queue);
@@ -71,7 +70,7 @@ public class MoveToWrongIndexThenToEndTest extends QueueTestCommon {
     private void waitFor(Semaphore semaphore, String message)
             throws InterruptedException {
         boolean ok = semaphore.tryAcquire(5, SECONDS);
-        assertTrue(message, ok);
+        assertTrue(ok, message);
     }
 
     private void append() {
@@ -123,7 +122,7 @@ public class MoveToWrongIndexThenToEndTest extends QueueTestCommon {
 
             waitFor(l1, "tailer finish");
 
-            assertNull("refThrowable", refThrowable.get());
+            assertNull(refThrowable.get(), "refThrowable");
 
         } finally {
             try {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToWrongIndexThenToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/MoveToWrongIndexThenToEndTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * The ChronicleQueueIT class implements a test that causes Chronicle Queue to
  * fail with a BufferUnderflowException whilst executing a tailer.toEnd() call.
  */
-public class MoveToWrongIndexThenToEndTest extends QueueTestCommon {
+class MoveToWrongIndexThenToEndTest extends QueueTestCommon {
 
     private static final int msgSize = 64;
 
@@ -62,7 +62,7 @@ public class MoveToWrongIndexThenToEndTest extends QueueTestCommon {
     }
 
     @AfterEach
-    public void after() {
+    void after() {
         outbound.releaseLast();
         closeQuietly(appender, queue);
     }
@@ -80,7 +80,7 @@ public class MoveToWrongIndexThenToEndTest extends QueueTestCommon {
     }
 
     @Test
-    public void testBufferUnderflowException() throws InterruptedException {
+    void testBufferUnderflowException() throws InterruptedException {
         finishedNormally = false;
         append();
         append();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NoOpConditionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NoOpConditionTest.java
@@ -10,10 +10,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class NoOpConditionTest {
+class NoOpConditionTest {
 
     @Test
-    public void noOpMethodsReturnImmediately() throws Exception {
+    void noOpMethodsReturnImmediately() throws Exception {
         NoOpCondition c = NoOpCondition.INSTANCE;
         c.await();
         c.awaitUninterruptibly();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NoOpConditionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NoOpConditionTest.java
@@ -3,12 +3,12 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NoOpConditionTest {
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
@@ -16,9 +16,9 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import net.openhft.chronicle.testframework.exception.ExceptionTracker;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -28,7 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NormaliseEOFsTest extends QueueTestCommon {
 
@@ -36,17 +36,21 @@ public class NormaliseEOFsTest extends QueueTestCommon {
     private static final File QUEUE_PATH = Paths.get(OS.getTarget(), "normaliseEOFsTest").toFile();
     private Map<ExceptionKey, Integer> exceptionMap;
 
-    @Before
+    @BeforeEach
+    public void beforeEachNormaliseEOFsTest() {
+        setLogLevelProperty();
+        clearDataFromPreviousRun();
+        recordExceptions();
+    }
+
     public void setLogLevelProperty() {
         System.setProperty(LOG_LEVEL_PROPERTY, "debug");
     }
 
-    @Before
     public void clearDataFromPreviousRun() {
         IOTools.deleteDirWithFilesOrThrow(QUEUE_PATH);
     }
 
-    @Before
     @Override
     public void recordExceptions() {
         super.recordExceptions();
@@ -57,12 +61,16 @@ public class NormaliseEOFsTest extends QueueTestCommon {
         ignoreException(ex -> true, "Ignore everything");
     }
 
-    @After
+    @AfterEach
+    public void afterEachNormaliseEOFsTest() {
+        clearLogLevelProperty();
+        cleanupQueueData();
+    }
+
     public void clearLogLevelProperty() {
         System.clearProperty(LOG_LEVEL_PROPERTY);
     }
 
-    @After
     public void cleanupQueueData() {
         BackgroundResourceReleaser.releasePendingResources();
         IOTools.deleteDirWithFilesOrThrow(QUEUE_PATH);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
@@ -30,14 +30,14 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class NormaliseEOFsTest extends QueueTestCommon {
+class NormaliseEOFsTest extends QueueTestCommon {
 
     private static final String LOG_LEVEL_PROPERTY = "org.slf4j.simpleLogger.log." + StoreAppender.class.getName();
     private static final File QUEUE_PATH = Paths.get(OS.getTarget(), "normaliseEOFsTest").toFile();
     private Map<ExceptionKey, Integer> exceptionMap;
 
     @BeforeEach
-    public void beforeEachNormaliseEOFsTest() {
+    void beforeEachNormaliseEOFsTest() {
         setLogLevelProperty();
         clearDataFromPreviousRun();
         recordExceptions();
@@ -62,7 +62,7 @@ public class NormaliseEOFsTest extends QueueTestCommon {
     }
 
     @AfterEach
-    public void afterEachNormaliseEOFsTest() {
+    void afterEachNormaliseEOFsTest() {
         clearLogLevelProperty();
         cleanupQueueData();
     }
@@ -77,7 +77,7 @@ public class NormaliseEOFsTest extends QueueTestCommon {
     }
 
     @Test
-    public void normaliseShouldResumeFromPreviousNormalisation() {
+    void normaliseShouldResumeFromPreviousNormalisation() {
         SetTimeProvider setTimeProvider = new SetTimeProvider();
         try (final SingleChronicleQueue queue = createQueue(setTimeProvider);
              final ExcerptAppender excerptAppender = queue.createAppender()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
@@ -14,9 +14,9 @@ import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.Marshallable;
 import net.openhft.chronicle.wire.WireOut;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.AccessDeniedException;
@@ -27,7 +27,7 @@ import java.util.function.BiConsumer;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * test for exceptions during serialisation out of messages, or for thread interrupts.
@@ -37,7 +37,7 @@ import static org.junit.Assert.*;
 public class NotCompleteTest extends QueueTestCommon {
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
@@ -82,7 +82,7 @@ public class NotCompleteTest extends QueueTestCommon {
 
                 try (final ChronicleQueue queue = createQueue(tmpDir)) {
                     String dump = cleanQueueDump(queue.dump());
-                    assertEquals("queue should be unchanged by the interrupted write", cleanedQueueDump, dump);
+                    assertEquals(cleanedQueueDump, dump, "queue should be unchanged by the interrupted write");
                 }
 
                 // check only 1 written
@@ -102,7 +102,7 @@ public class NotCompleteTest extends QueueTestCommon {
 
                 try (final ChronicleQueue queue = createQueue(tmpDir)) {
                     String dump = cleanQueueDump(queue.dump());
-                    assertEquals("queue should be unchanged by the failed (exception) write", cleanedQueueDump, dump);
+                    assertEquals(cleanedQueueDump, dump, "queue should be unchanged by the failed (exception) write");
 //                    System.err.println(queue.dump());
                 }
 
@@ -117,7 +117,7 @@ public class NotCompleteTest extends QueueTestCommon {
                 }
                 // check queue unchanged
                 String dump = cleanQueueDump(queueWriter.dump());
-                assertEquals("queue should be unchanged by the failed (rollback) write", cleanedQueueDump, dump);
+                assertEquals(cleanedQueueDump, dump, "queue should be unchanged by the failed (rollback) write");
                 // check nothing else written
                 assertFalse(reader.readOne());
 
@@ -160,7 +160,7 @@ public class NotCompleteTest extends QueueTestCommon {
         action.accept(personListener, queue);
     }
 
-    @After
+    @AfterEach
     public void clearInterrupt() {
         Thread.interrupted();
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * We want to ensure that messages are completely written or not written - no half measures.
  */
 @RequiredForClient
-public class NotCompleteTest extends QueueTestCommon {
+class NotCompleteTest extends QueueTestCommon {
 
     @Override
     @BeforeEach
@@ -43,7 +43,7 @@ public class NotCompleteTest extends QueueTestCommon {
     }
 
     @Test
-    public void testInterruptOrExceptionDuringSerialisation() throws InterruptedException {
+    void testInterruptOrExceptionDuringSerialisation() throws InterruptedException {
 
         final File tmpDir = DirectoryUtils.tempDir("testInterruptedDuringSerialisation");
         try {
@@ -161,7 +161,7 @@ public class NotCompleteTest extends QueueTestCommon {
     }
 
     @AfterEach
-    public void clearInterrupt() {
+    void clearInterrupt() {
         Thread.interrupted();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PartialUpdateTest extends QueueTestCommon {
+class PartialUpdateTest extends QueueTestCommon {
 
     private static final long LAST_INDEX = RollCycles.FAST_DAILY.toIndex(2, 2);
     private Path queuePath;
@@ -67,20 +67,20 @@ public class PartialUpdateTest extends QueueTestCommon {
     }
 
     @BeforeAll
-    public static void disableCheckIndexAssertions() {
+    static void disableCheckIndexAssertions() {
         // This turns off assertions, so we see what would happen in the real world
         originalCheckIndexValue = QueueSystemProperties.CHECK_INDEX;
         QueueSystemProperties.CHECK_INDEX = false;
     }
 
     @AfterAll
-    public static void restoreCheckIndexAssertions() {
+    static void restoreCheckIndexAssertions() {
         QueueSystemProperties.CHECK_INDEX = originalCheckIndexValue;
     }
 
     @ParameterizedTest
     @MethodSource("params")
-    public void testBackwardsToEndArrivesAtCorrectPosition(PartialQueueCreator queueCreator) {
+    void testBackwardsToEndArrivesAtCorrectPosition(PartialQueueCreator queueCreator) {
         setUp(queueCreator);
         try {
             try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
@@ -96,7 +96,7 @@ public class PartialUpdateTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("params")
-    public void testBackwardsToEndReportsCorrectIndex(PartialQueueCreator queueCreator) {
+    void testBackwardsToEndReportsCorrectIndex(PartialQueueCreator queueCreator) {
         setUp(queueCreator);
         try {
             try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
@@ -112,7 +112,7 @@ public class PartialUpdateTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("params")
-    public void testForwardsToEndArrivesAtCorrectPosition(PartialQueueCreator queueCreator) {
+    void testForwardsToEndArrivesAtCorrectPosition(PartialQueueCreator queueCreator) {
         setUp(queueCreator);
         try {
             try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
@@ -128,7 +128,7 @@ public class PartialUpdateTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("params")
-    public void testForwardsToEndReportsCorrectIndex(PartialQueueCreator queueCreator) {
+    void testForwardsToEndReportsCorrectIndex(PartialQueueCreator queueCreator) {
         setUp(queueCreator);
         try {
             try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
@@ -144,7 +144,7 @@ public class PartialUpdateTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("params")
-    public void testLastIndexIsCorrect(PartialQueueCreator queueCreator) {
+    void testLastIndexIsCorrect(PartialQueueCreator queueCreator) {
         setUp(queueCreator);
         try {
             try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath)) {
@@ -158,7 +158,7 @@ public class PartialUpdateTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("params")
-    public void testAppendReturnsCorrectLastAppendedIndex(PartialQueueCreator queueCreator) {
+    void testAppendReturnsCorrectLastAppendedIndex(PartialQueueCreator queueCreator) {
         setUp(queueCreator);
         try {
             try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
@@ -10,9 +10,7 @@ import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.*;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/PartialUpdateTest.java
@@ -9,23 +9,26 @@ import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.*;
 import org.jetbrains.annotations.NotNull;
-import org.junit.*;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.StreamCorruptedException;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class PartialUpdateTest extends QueueTestCommon {
 
     private static final long LAST_INDEX = RollCycles.FAST_DAILY.toIndex(2, 2);
-    private final PartialQueueCreator queueCreator;
     private Path queuePath;
     private SetTimeProvider setTimeProvider;
     private static boolean originalCheckIndexValue;
@@ -53,94 +56,119 @@ public class PartialUpdateTest extends QueueTestCommon {
         abstract void createQueue(SetTimeProvider timeProvider, Path path);
     }
 
-    public PartialUpdateTest(PartialQueueCreator queueCreator) {
-        this.queueCreator = queueCreator;
+    public static Iterable<Object[]> params() {
+        return Arrays.stream(PartialQueueCreator.values()).map(qc -> new Object[]{qc}).collect(Collectors.toList());
     }
 
-    @Parameterized.Parameters(name = "state={0}")
-    public static PartialQueueCreator[] params() {
-        return PartialQueueCreator.values();
-    }
-
-    @Before
-    public void setUp() {
+    private void setUp(PartialQueueCreator queueCreator) {
         queuePath = IOTools.createTempDirectory("partialUpdate");
         setTimeProvider = new SetTimeProvider();
         queueCreator.createQueue(setTimeProvider, queuePath);
     }
 
-    @After
-    public void tearDown() {
-        IOTools.deleteDirWithFiles(queuePath.toFile());
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void disableCheckIndexAssertions() {
         // This turns off assertions, so we see what would happen in the real world
         originalCheckIndexValue = QueueSystemProperties.CHECK_INDEX;
         QueueSystemProperties.CHECK_INDEX = false;
     }
 
-    @AfterClass
+    @AfterAll
     public static void restoreCheckIndexAssertions() {
         QueueSystemProperties.CHECK_INDEX = originalCheckIndexValue;
     }
 
-    @Test
-    public void testBackwardsToEndArrivesAtCorrectPosition() {
-        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
-             ExcerptTailer tailer = queue.createTailer()) {
-            tailer.direction(TailerDirection.BACKWARD).toEnd();
-            // toEnd in the backward direction positions the cursor at the last excerpt (ready to read it)
-            assertEquals("Six", tailer.readText());
+    @ParameterizedTest
+    @MethodSource("params")
+    public void testBackwardsToEndArrivesAtCorrectPosition(PartialQueueCreator queueCreator) {
+        setUp(queueCreator);
+        try {
+            try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+                 ExcerptTailer tailer = queue.createTailer()) {
+                tailer.direction(TailerDirection.BACKWARD).toEnd();
+                // toEnd in the backward direction positions the cursor at the last excerpt (ready to read it)
+                assertEquals("Six", tailer.readText());
+            }
+        } finally {
+            IOTools.deleteDirWithFiles(queuePath.toFile());
         }
     }
 
-    @Test
-    public void testBackwardsToEndReportsCorrectIndex() {
-        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
-             ExcerptTailer tailer = queue.createTailer()) {
-            tailer.direction(TailerDirection.BACKWARD).toEnd();
-            // toEnd in the backward direction positions the cursor at the last excerpt (ready to read it)
-            assertEquals(LAST_INDEX, tailer.index());
+    @ParameterizedTest
+    @MethodSource("params")
+    public void testBackwardsToEndReportsCorrectIndex(PartialQueueCreator queueCreator) {
+        setUp(queueCreator);
+        try {
+            try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+                 ExcerptTailer tailer = queue.createTailer()) {
+                tailer.direction(TailerDirection.BACKWARD).toEnd();
+                // toEnd in the backward direction positions the cursor at the last excerpt (ready to read it)
+                assertEquals(LAST_INDEX, tailer.index());
+            }
+        } finally {
+            IOTools.deleteDirWithFiles(queuePath.toFile());
         }
     }
 
-    @Test
-    public void testForwardsToEndArrivesAtCorrectPosition() {
-        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
-             ExcerptTailer tailer = queue.createTailer()) {
-            tailer.toEnd();
-            // toEnd in the forward direction positions the cursor AFTER the last excerpt
-            assertNull(tailer.readText());
+    @ParameterizedTest
+    @MethodSource("params")
+    public void testForwardsToEndArrivesAtCorrectPosition(PartialQueueCreator queueCreator) {
+        setUp(queueCreator);
+        try {
+            try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+                 ExcerptTailer tailer = queue.createTailer()) {
+                tailer.toEnd();
+                // toEnd in the forward direction positions the cursor AFTER the last excerpt
+                assertNull(tailer.readText());
+            }
+        } finally {
+            IOTools.deleteDirWithFiles(queuePath.toFile());
         }
     }
 
-    @Test
-    public void testForwardsToEndReportsCorrectIndex() {
-        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
-             ExcerptTailer tailer = queue.createTailer()) {
-            tailer.toEnd();
-            // toEnd in the forward direction positions the cursor AFTER the last excerpt
-            assertEquals(LAST_INDEX + 1, tailer.index());
+    @ParameterizedTest
+    @MethodSource("params")
+    public void testForwardsToEndReportsCorrectIndex(PartialQueueCreator queueCreator) {
+        setUp(queueCreator);
+        try {
+            try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+                 ExcerptTailer tailer = queue.createTailer()) {
+                tailer.toEnd();
+                // toEnd in the forward direction positions the cursor AFTER the last excerpt
+                assertEquals(LAST_INDEX + 1, tailer.index());
+            }
+        } finally {
+            IOTools.deleteDirWithFiles(queuePath.toFile());
         }
     }
 
-    @Test
-    public void testLastIndexIsCorrect() {
-        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath)) {
-            // Should report last index correctly
-            assertEquals(LAST_INDEX, queue.lastIndex());
+    @ParameterizedTest
+    @MethodSource("params")
+    public void testLastIndexIsCorrect(PartialQueueCreator queueCreator) {
+        setUp(queueCreator);
+        try {
+            try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath)) {
+                // Should report last index correctly
+                assertEquals(LAST_INDEX, queue.lastIndex());
+            }
+        } finally {
+            IOTools.deleteDirWithFiles(queuePath.toFile());
         }
     }
 
-    @Test
-    public void testAppendReturnsCorrectLastAppendedIndex() {
-        try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
-             ExcerptAppender appender = queue.createAppender()) {
-            // Should report last index correctly
-            appender.writeText("Seven");
-            assertEquals(LAST_INDEX + 1, appender.lastIndexAppended());
+    @ParameterizedTest
+    @MethodSource("params")
+    public void testAppendReturnsCorrectLastAppendedIndex(PartialQueueCreator queueCreator) {
+        setUp(queueCreator);
+        try {
+            try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
+                 ExcerptAppender appender = queue.createAppender()) {
+                // Should report last index correctly
+                appender.writeText("Seven");
+                assertEquals(LAST_INDEX + 1, appender.lastIndexAppended());
+            }
+        } finally {
+            IOTools.deleteDirWithFiles(queuePath.toFile());
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/QueueEpochTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/QueueEpochTest.java
@@ -10,7 +10,7 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.queue.impl.RollingChronicleQueue;
 import net.openhft.chronicle.queue.impl.StoreFileListener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.time.Instant;
@@ -19,7 +19,7 @@ import java.time.ZoneOffset;
 import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.DAILY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class QueueEpochTest extends QueueTestCommon {
     private static final boolean DEBUG = false;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/QueueEpochTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/QueueEpochTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public final class QueueEpochTest extends QueueTestCommon {
+final class QueueEpochTest extends QueueTestCommon {
     private static final boolean DEBUG = false;
     private static final long MIDNIGHT_UTC_BASE_TIME = 1504569600000L;
     // 17:15 EDT, 21:15 UTC
@@ -44,7 +44,7 @@ public final class QueueEpochTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldRollQueueFilesAccordingToUtcOffset() {
+    void shouldRollQueueFilesAccordingToUtcOffset() {
         logDebug("UTC offset is %dms%n", UTC_OFFSET);
         final File queueDir = getTmpDir();
         final CapturingStoreFileListener fileListener = new CapturingStoreFileListener();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/QueueLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/QueueLockTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class QueueLockTest extends QueueTestCommon {
+class QueueLockTest extends QueueTestCommon {
 
     @Override
     @BeforeEach
@@ -29,12 +29,12 @@ public class QueueLockTest extends QueueTestCommon {
     }
 
     @Test
-    public void testTimeout() throws InterruptedException {
+    void testTimeout() throws InterruptedException {
         check(true);
     }
 
     @Test
-    public void testRecover() throws InterruptedException {
+    void testRecover() throws InterruptedException {
         System.setProperty("queue.force.unlock.mode", "ALWAYS");
         try {
             check(false);
@@ -53,7 +53,7 @@ public class QueueLockTest extends QueueTestCommon {
             expectException("Forced unlock for the lock");
 
         try {
-            System.setProperty("queue.force.unlock.mode", shouldThrowException ? "NEVER" : "ALWAYS" );
+            System.setProperty("queue.force.unlock.mode", shouldThrowException ? "NEVER" : "ALWAYS");
 
             final long timeoutMs = 2_000;
             final File queueDir = DirectoryUtils.tempDir("check");

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/QueueLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/QueueLockTest.java
@@ -10,20 +10,20 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.RollingChronicleQueue;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.UnrecoverableTimeoutException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class QueueLockTest extends QueueTestCommon {
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
@@ -101,7 +101,7 @@ public class QueueLockTest extends QueueTestCommon {
                     long time = endTime - startTime;
                     assertEquals(shouldThrowException, threwException.get());
                     assertEquals(shouldThrowException, !recoveredAndAcquiredTheLock.get());
-                    assertTrue("timeout, time: " + time, time >= timeoutMs);
+                    assertTrue(time >= timeoutMs, "timeout, time: " + time);
                 }
             }
             finishedNormally = true;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
@@ -9,10 +9,8 @@ import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.io.ReferenceCounted;
 import net.openhft.chronicle.core.io.ReferenceOwner;
 import net.openhft.chronicle.queue.QueueTestCommon;
-import org.junit.Before;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -22,7 +20,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ReferenceCountedCacheTest extends QueueTestCommon {
 
@@ -33,13 +31,17 @@ class ReferenceCountedCacheTest extends QueueTestCommon {
     private AtomicInteger releasedCount;
     private ReferenceCountedCache<Integer, TestReferenceCounted, Reservation, RuntimeException> cache;
 
+    @BeforeEach
+    public void beforeEachReferenceCountedCacheTest() {
+        threadDump();
+        setUp();
+    }
+
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
 
-    @BeforeEach
     void setUp() {
         createdCount = new AtomicInteger(0);
         releasedCount = new AtomicInteger(0);
@@ -54,31 +56,41 @@ class ReferenceCountedCacheTest extends QueueTestCommon {
     @Test
     void shouldNeverGiveOutReleasedReferences() {
         final ExecutorService executorService = Executors.newCachedThreadPool();
-        int numThreads = Math.min(MAX_THREADS_TO_RUN, Math.max(MIN_THREADS_TO_RUN, Runtime.getRuntime().availableProcessors()));
-        AtomicBoolean running = new AtomicBoolean(true);
-        List<Future<?>> executors = new ArrayList<>();
-        for (int i = 0; i < numThreads; i++) {
-            executors.add(executorService.submit(new ReferenceGetter(NUM_RESOURCES, cache, running)));
-        }
-        Jvm.pause(5_000);
-        running.set(false);
-        executors.forEach(f -> {
+        try {
+            int numThreads = Math.min(MAX_THREADS_TO_RUN, Math.max(MIN_THREADS_TO_RUN, Runtime.getRuntime().availableProcessors()));
+            AtomicBoolean running = new AtomicBoolean(true);
+            List<Future<?>> executors = new ArrayList<>();
+            for (int i = 0; i < numThreads; i++) {
+                executors.add(executorService.submit(new ReferenceGetter(NUM_RESOURCES, cache, running)));
+            }
+            Jvm.pause(5_000);
+            running.set(false);
+            executors.forEach(f -> {
+                try {
+                    f.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            Closeable.closeQuietly(cache);
+            Jvm.startup().on(ReferenceCountedCache.class, "Created " + createdCount.get() + ", released " + releasedCount.get());
+            assertTrue(true); // if we got here without an exception, the test passes
+        } finally {
+            executorService.shutdownNow();
             try {
-                f.get();
-            } catch (InterruptedException | ExecutionException e) {
+                assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS), "Executor did not terminate");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
-        });
-        Closeable.closeQuietly(cache);
-        Jvm.startup().on(ReferenceCountedCache.class, "Created " + createdCount.get() + ", released " + releasedCount.get());
-        assertTrue(true); // if we got here without an exception, the test passes
+        }
     }
 
     @Test
     void shouldReturnSameObjectWhileNotReleased() {
         final Reservation reservation = cache.get(1);
         final Reservation otherReservation = cache.get(1);
-        Assertions.assertSame(reservation.referenceCounted, otherReservation.referenceCounted);
+        assertSame(reservation.referenceCounted, otherReservation.referenceCounted);
         reservation.release();
         otherReservation.release();
     }
@@ -89,7 +101,7 @@ class ReferenceCountedCacheTest extends QueueTestCommon {
         reservation.release();
         Jvm.pause(100);
         final Reservation otherReservation = cache.get(1);
-        Assertions.assertNotSame(reservation.referenceCounted, otherReservation.referenceCounted);
+        assertNotSame(reservation.referenceCounted, otherReservation.referenceCounted);
         otherReservation.release();
     }
 
@@ -149,7 +161,7 @@ class ReferenceCountedCacheTest extends QueueTestCommon {
 
         void assertNotReleased() {
             final int referenceCount = this.referenceCounted.refCount();
-            assertTrue("Expected reference count of at least 2, got " + referenceCount, referenceCount > 1);
+            assertTrue(referenceCount > 1, "Expected reference count of at least 2, got " + referenceCount);
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
@@ -33,7 +33,7 @@ class ReferenceCountedCacheTest extends QueueTestCommon {
 
     @BeforeEach
     void beforeEachReferenceCountedCacheTest() {
-        public threadDump();
+        threadDump();
         setUp();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ReferenceCountedCacheTest.java
@@ -32,8 +32,8 @@ class ReferenceCountedCacheTest extends QueueTestCommon {
     private ReferenceCountedCache<Integer, TestReferenceCounted, Reservation, RuntimeException> cache;
 
     @BeforeEach
-    public void beforeEachReferenceCountedCacheTest() {
-        threadDump();
+    void beforeEachReferenceCountedCacheTest() {
+        public threadDump();
         setUp();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RestartableTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RestartableTailerTest.java
@@ -14,9 +14,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RestartableTailerTest extends QueueTestCommon {
+class RestartableTailerTest extends QueueTestCommon {
     @Test
-    public void restartable() {
+    void restartable() {
         String tmp = OS.getTarget() + "/restartable-" + Time.uniqueId();
         try (ChronicleQueue cq = SingleChronicleQueueBuilder.binary(tmp).build();
              final ExcerptAppender excerptAppender = cq.createAppender()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RestartableTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RestartableTailerTest.java
@@ -10,10 +10,9 @@ import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RestartableTailerTest extends QueueTestCommon {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollAtEndOfCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollAtEndOfCycleTest.java
@@ -21,7 +21,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public final class RollAtEndOfCycleTest extends QueueTestCommon {
+final class RollAtEndOfCycleTest extends QueueTestCommon {
     private final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
 
     private static void assertQueueFileCount(final Path path, final long expectedCount) throws IOException {
@@ -34,7 +34,7 @@ public final class RollAtEndOfCycleTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldRollAndAppendToNewFile() throws IOException {
+    void shouldRollAndAppendToNewFile() throws IOException {
         assumeFalse(Jvm.isArm());
 
         try (final SingleChronicleQueue queue = createQueue();
@@ -80,7 +80,7 @@ public final class RollAtEndOfCycleTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldAppendToExistingQueueFile() throws IOException {
+    void shouldAppendToExistingQueueFile() throws IOException {
         try (final SingleChronicleQueue queue = createQueue();
              final ExcerptAppender appender = queue.createAppender()) {
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollAtEndOfCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollAtEndOfCycleTest.java
@@ -8,7 +8,7 @@ import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -18,8 +18,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public final class RollAtEndOfCycleTest extends QueueTestCommon {
     private final AtomicLong clock = new AtomicLong(System.currentTimeMillis());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleEncodeSequenceTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleEncodeSequenceTest.java
@@ -20,7 +20,7 @@ import static net.openhft.chronicle.queue.rollcycles.LargeRollCycles.HUGE_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RollCycleEncodeSequenceTest extends QueueTestCommon {
+class RollCycleEncodeSequenceTest extends QueueTestCommon {
 
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
@@ -34,7 +34,7 @@ public class RollCycleEncodeSequenceTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void forWritePosition(RollCycle cycle) {
+    void forWritePosition(RollCycle cycle) {
         BinaryTwoLongReference longValue = new BinaryTwoLongReference();
         Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
         try {
@@ -54,7 +54,7 @@ public class RollCycleEncodeSequenceTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void setGet(RollCycle cycle) {
+    void setGet(RollCycle cycle) {
         BinaryTwoLongReference longValue = new BinaryTwoLongReference();
         Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
         try {
@@ -73,7 +73,7 @@ public class RollCycleEncodeSequenceTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void setGetPositionNeedsMasking(RollCycle cycle) {
+    void setGetPositionNeedsMasking(RollCycle cycle) {
         BinaryTwoLongReference longValue = new BinaryTwoLongReference();
         Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
         try {
@@ -92,7 +92,7 @@ public class RollCycleEncodeSequenceTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void setGetPositionMinus1(RollCycle cycle) {
+    void setGetPositionMinus1(RollCycle cycle) {
         BinaryTwoLongReference longValue = new BinaryTwoLongReference();
         Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
         try {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleEncodeSequenceTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleEncodeSequenceTest.java
@@ -8,9 +8,8 @@ import net.openhft.chronicle.bytes.ref.BinaryTwoLongReference;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.wire.Sequence;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -19,22 +18,10 @@ import java.util.Collection;
 import static net.openhft.chronicle.queue.RollCycles.DEFAULT;
 import static net.openhft.chronicle.queue.rollcycles.LargeRollCycles.HUGE_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class RollCycleEncodeSequenceTest extends QueueTestCommon {
-    private final BinaryTwoLongReference longValue;
-    private final RollCycleEncodeSequence rollCycleEncodeSequence;
-    private final Bytes<ByteBuffer> bytes;
 
-    public RollCycleEncodeSequenceTest(final RollCycle cycle) {
-        longValue = new BinaryTwoLongReference();
-        bytes = Bytes.elasticByteBuffer();
-        longValue.bytesStore(bytes, 0, 16);
-        rollCycleEncodeSequence = new RollCycleEncodeSequence(longValue, cycle.defaultIndexCount(), cycle.defaultIndexSpacing());
-    }
-
-    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 {DAILY},
@@ -45,46 +32,80 @@ public class RollCycleEncodeSequenceTest extends QueueTestCommon {
         });
     }
 
-    @Override
-    public void preAfter() {
-        longValue.close();
-        bytes.releaseLast();
+    @ParameterizedTest
+    @MethodSource("data")
+    public void forWritePosition(RollCycle cycle) {
+        BinaryTwoLongReference longValue = new BinaryTwoLongReference();
+        Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
+        try {
+            longValue.bytesStore(bytes, 0, 16);
+            RollCycleEncodeSequence rollCycleEncodeSequence = new RollCycleEncodeSequence(longValue, cycle.defaultIndexCount(), cycle.defaultIndexSpacing());
+            longValue.setOrderedValue(1);
+            longValue.setOrderedValue2(2);
+            // a cast to int of this magic number was causing problems
+            long forWritePosition = 0x8001cc54L;
+            long sequence = rollCycleEncodeSequence.getSequence(forWritePosition);
+            assertEquals(Sequence.NOT_FOUND_RETRY, sequence);
+        } finally {
+            longValue.close();
+            bytes.releaseLast();
+        }
     }
 
-    @Test
-    public void forWritePosition() {
-        longValue.setOrderedValue(1);
-        longValue.setOrderedValue2(2);
-        // a cast to int of this magic number was causing problems
-        long forWritePosition = 0x8001cc54L;
-        long sequence = rollCycleEncodeSequence.getSequence(forWritePosition);
-        assertEquals(Sequence.NOT_FOUND_RETRY, sequence);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setGet(RollCycle cycle) {
+        BinaryTwoLongReference longValue = new BinaryTwoLongReference();
+        Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
+        try {
+            longValue.bytesStore(bytes, 0, 16);
+            RollCycleEncodeSequence rollCycleEncodeSequence = new RollCycleEncodeSequence(longValue, cycle.defaultIndexCount(), cycle.defaultIndexSpacing());
+            int sequenceInitial = 0xb;
+            int position = 0x40284;
+            rollCycleEncodeSequence.setSequence(sequenceInitial, position);
+            long sequence = rollCycleEncodeSequence.getSequence(position);
+            assertEquals(sequenceInitial, sequence);
+        } finally {
+            longValue.close();
+            bytes.releaseLast();
+        }
     }
 
-    @Test
-    public void setGet() {
-        int sequenceInitial = 0xb;
-        int position = 0x40284;
-        rollCycleEncodeSequence.setSequence(sequenceInitial, position);
-        long sequence = rollCycleEncodeSequence.getSequence(position);
-        assertEquals(sequenceInitial, sequence);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setGetPositionNeedsMasking(RollCycle cycle) {
+        BinaryTwoLongReference longValue = new BinaryTwoLongReference();
+        Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
+        try {
+            longValue.bytesStore(bytes, 0, 16);
+            RollCycleEncodeSequence rollCycleEncodeSequence = new RollCycleEncodeSequence(longValue, cycle.defaultIndexCount(), cycle.defaultIndexSpacing());
+            int sequenceInitial = 0xb;
+            long position = 0x123456789abL;
+            rollCycleEncodeSequence.setSequence(sequenceInitial, position);
+            long sequence = rollCycleEncodeSequence.getSequence(position);
+            assertEquals(sequenceInitial, sequence);
+        } finally {
+            longValue.close();
+            bytes.releaseLast();
+        }
     }
 
-    @Test
-    public void setGetPositionNeedsMasking() {
-        int sequenceInitial = 0xb;
-        long position = 0x123456789abL;
-        rollCycleEncodeSequence.setSequence(sequenceInitial, position);
-        long sequence = rollCycleEncodeSequence.getSequence(position);
-        assertEquals(sequenceInitial, sequence);
-    }
-
-    @Test
-    public void setGetPositionMinus1() {
-        int sequenceInitial = 0xb;
-        long position = (1L << 48) - 1;
-        rollCycleEncodeSequence.setSequence(sequenceInitial, position);
-        long sequence = rollCycleEncodeSequence.getSequence(position);
-        assertEquals(sequenceInitial, sequence);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void setGetPositionMinus1(RollCycle cycle) {
+        BinaryTwoLongReference longValue = new BinaryTwoLongReference();
+        Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
+        try {
+            longValue.bytesStore(bytes, 0, 16);
+            RollCycleEncodeSequence rollCycleEncodeSequence = new RollCycleEncodeSequence(longValue, cycle.defaultIndexCount(), cycle.defaultIndexSpacing());
+            int sequenceInitial = 0xb;
+            long position = (1L << 48) - 1;
+            rollCycleEncodeSequence.setSequence(sequenceInitial, position);
+            long sequence = rollCycleEncodeSequence.getSequence(position);
+            assertEquals(sequenceInitial, sequence);
+        } finally {
+            longValue.close();
+            bytes.releaseLast();
+        }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
@@ -13,10 +13,7 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.StoreFileListener;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -24,13 +21,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class RollCycleTest extends QueueTestCommon {
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
@@ -76,7 +73,7 @@ public class RollCycleTest extends QueueTestCommon {
     public void newRollCycleIgnored2() throws InterruptedException {
         finishedNormally = false;
         File path = getTmpDir();
-        Assume.assumeFalse("Ignored on hugetlbfs as byte offsets will be different due to page size", PageUtil.isHugePage(path.getAbsolutePath()));
+        assumeFalse(PageUtil.isHugePage(path.getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
 
         SetTimeProvider timeProvider = new SetTimeProvider();
         ParallelQueueObserver observer = new ParallelQueueObserver(timeProvider, path.toPath());
@@ -273,8 +270,7 @@ public class RollCycleTest extends QueueTestCommon {
                                 "--- !!data #binary\n" +
                                 "\"3\"\n" +
                                 "...\n" +
-                                "# 130660 bytes remaining\n",
-                        queue.dump().replaceAll("listing.modCount: \\d+", "listing.modCount: 9"));
+                                "# 130660 bytes remaining\n", queue.dump().replaceAll("listing.modCount: \\d+", "listing.modCount: 9"));
 
                 // allow parallel tailer to finish iteration
                 for (int i = 0; i < 5_000 && observer.documentsRead != 1 + cyclesToWrite; i++) {
@@ -289,7 +285,7 @@ public class RollCycleTest extends QueueTestCommon {
         finishedNormally = true;
     }
 
-    @After
+    @AfterEach
     public void clearInterrupt() {
         Thread.interrupted();
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
@@ -24,7 +24,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class RollCycleTest extends QueueTestCommon {
+class RollCycleTest extends QueueTestCommon {
 
     @Override
     @BeforeEach
@@ -33,7 +33,7 @@ public class RollCycleTest extends QueueTestCommon {
     }
 
     @Test
-    public void newRollCycleIgnored() throws InterruptedException {
+    void newRollCycleIgnored() throws InterruptedException {
         File path = getTmpDir();
         SetTimeProvider timeProvider = new SetTimeProvider();
         ParallelQueueObserver observer = new ParallelQueueObserver(timeProvider, path.toPath());
@@ -70,7 +70,7 @@ public class RollCycleTest extends QueueTestCommon {
     }
 
     @Test
-    public void newRollCycleIgnored2() throws InterruptedException {
+    void newRollCycleIgnored2() throws InterruptedException {
         finishedNormally = false;
         File path = getTmpDir();
         assumeFalse(PageUtil.isHugePage(path.getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
@@ -99,178 +99,178 @@ public class RollCycleTest extends QueueTestCommon {
                     appender.writeText(Integer.toString(i));
                 }
                 assertEquals("" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !STStore {\n" +
-                                "  wireType: !WireType BINARY_LIGHT,\n" +
-                                "  metadata: !SCQMeta {\n" +
-                                "    roll: !SCQSRoll { length: 86400000, format: yyyyMMdd'T1', epoch: 0 },\n" +
-                                "    sourceId: 0\n" +
-                                "  }\n" +
-                                "}\n" +
-                                "# position: 152, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "listing.highestCycle: 6\n" +
-                                "# position: 192, header: 1\n" +
-                                "--- !!data #binary\n" +
-                                "listing.lowestCycle: 0\n" +
-                                "# position: 232, header: 2\n" +
-                                "--- !!data #binary\n" +
-                                "listing.modCount: 9\n" +
-                                "# position: 264, header: 3\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.write.lock: -9223372036854775808\n" +
-                                "# position: 304, header: 4\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.append.lock: -9223372036854775808\n" +
-                                "# position: 344, header: 5\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.lastIndexReplicated: -1\n" +
-                                "# position: 392, header: 6\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.lastAcknowledgedIndexReplicated: -1\n" +
-                                "# position: 448, header: 7\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.lastIndexMSynced: -1\n" +
-                                "...\n" +
-                                "# 130572 bytes remaining\n" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !SCQStore {\n" +
-                                "  writePosition: [\n" +
-                                "    400,\n" +
-                                "    1717986918400\n" +
-                                "  ],\n" +
-                                "  indexing: !SCQSIndexing {\n" +
-                                "    indexCount: 8,\n" +
-                                "    indexSpacing: 1,\n" +
-                                "    index2Index: 200,\n" +
-                                "    lastIndex: 1\n" +
-                                "  },\n" +
-                                "  dataFormat: 1\n" +
-                                "}\n" +
-                                "# position: 200, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index2index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  304,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 304, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  400,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 400, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "\"0\"\n" +
-                                "# position: 408, header: 0 EOF\n" +
-                                "--- !!not-ready-meta-data #binary\n" +
-                                "...\n" +
-                                "# 130660 bytes remaining\n" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !SCQStore {\n" +
-                                "  writePosition: [\n" +
-                                "    400,\n" +
-                                "    1717986918400\n" +
-                                "  ],\n" +
-                                "  indexing: !SCQSIndexing {\n" +
-                                "    indexCount: 8,\n" +
-                                "    indexSpacing: 1,\n" +
-                                "    index2Index: 200,\n" +
-                                "    lastIndex: 1\n" +
-                                "  },\n" +
-                                "  dataFormat: 1\n" +
-                                "}\n" +
-                                "# position: 200, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index2index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  304,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 304, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  400,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 400, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "\"1\"\n" +
-                                "# position: 408, header: 0 EOF\n" +
-                                "--- !!not-ready-meta-data #binary\n" +
-                                "...\n" +
-                                "# 130660 bytes remaining\n" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !SCQStore {\n" +
-                                "  writePosition: [\n" +
-                                "    400,\n" +
-                                "    1717986918400\n" +
-                                "  ],\n" +
-                                "  indexing: !SCQSIndexing {\n" +
-                                "    indexCount: 8,\n" +
-                                "    indexSpacing: 1,\n" +
-                                "    index2Index: 200,\n" +
-                                "    lastIndex: 1\n" +
-                                "  },\n" +
-                                "  dataFormat: 1\n" +
-                                "}\n" +
-                                "# position: 200, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index2index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  304,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 304, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  400,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 400, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "\"2\"\n" +
-                                "# position: 408, header: 0 EOF\n" +
-                                "--- !!not-ready-meta-data #binary\n" +
-                                "...\n" +
-                                "# 130660 bytes remaining\n" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !SCQStore {\n" +
-                                "  writePosition: [\n" +
-                                "    400,\n" +
-                                "    1717986918400\n" +
-                                "  ],\n" +
-                                "  indexing: !SCQSIndexing {\n" +
-                                "    indexCount: 8,\n" +
-                                "    indexSpacing: 1,\n" +
-                                "    index2Index: 200,\n" +
-                                "    lastIndex: 1\n" +
-                                "  },\n" +
-                                "  dataFormat: 1\n" +
-                                "}\n" +
-                                "# position: 200, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index2index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  304,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 304, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  400,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 400, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "\"3\"\n" +
-                                "...\n" +
-                                "# 130660 bytes remaining\n", queue.dump().replaceAll("listing.modCount: \\d+", "listing.modCount: 9"));
+                        "--- !!meta-data #binary\n" +
+                        "header: !STStore {\n" +
+                        "  wireType: !WireType BINARY_LIGHT,\n" +
+                        "  metadata: !SCQMeta {\n" +
+                        "    roll: !SCQSRoll { length: 86400000, format: yyyyMMdd'T1', epoch: 0 },\n" +
+                        "    sourceId: 0\n" +
+                        "  }\n" +
+                        "}\n" +
+                        "# position: 152, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "listing.highestCycle: 6\n" +
+                        "# position: 192, header: 1\n" +
+                        "--- !!data #binary\n" +
+                        "listing.lowestCycle: 0\n" +
+                        "# position: 232, header: 2\n" +
+                        "--- !!data #binary\n" +
+                        "listing.modCount: 9\n" +
+                        "# position: 264, header: 3\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.write.lock: -9223372036854775808\n" +
+                        "# position: 304, header: 4\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.append.lock: -9223372036854775808\n" +
+                        "# position: 344, header: 5\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.lastIndexReplicated: -1\n" +
+                        "# position: 392, header: 6\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.lastAcknowledgedIndexReplicated: -1\n" +
+                        "# position: 448, header: 7\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.lastIndexMSynced: -1\n" +
+                        "...\n" +
+                        "# 130572 bytes remaining\n" +
+                        "--- !!meta-data #binary\n" +
+                        "header: !SCQStore {\n" +
+                        "  writePosition: [\n" +
+                        "    400,\n" +
+                        "    1717986918400\n" +
+                        "  ],\n" +
+                        "  indexing: !SCQSIndexing {\n" +
+                        "    indexCount: 8,\n" +
+                        "    indexSpacing: 1,\n" +
+                        "    index2Index: 200,\n" +
+                        "    lastIndex: 1\n" +
+                        "  },\n" +
+                        "  dataFormat: 1\n" +
+                        "}\n" +
+                        "# position: 200, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index2index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  304,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 304, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  400,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 400, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "\"0\"\n" +
+                        "# position: 408, header: 0 EOF\n" +
+                        "--- !!not-ready-meta-data #binary\n" +
+                        "...\n" +
+                        "# 130660 bytes remaining\n" +
+                        "--- !!meta-data #binary\n" +
+                        "header: !SCQStore {\n" +
+                        "  writePosition: [\n" +
+                        "    400,\n" +
+                        "    1717986918400\n" +
+                        "  ],\n" +
+                        "  indexing: !SCQSIndexing {\n" +
+                        "    indexCount: 8,\n" +
+                        "    indexSpacing: 1,\n" +
+                        "    index2Index: 200,\n" +
+                        "    lastIndex: 1\n" +
+                        "  },\n" +
+                        "  dataFormat: 1\n" +
+                        "}\n" +
+                        "# position: 200, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index2index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  304,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 304, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  400,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 400, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "\"1\"\n" +
+                        "# position: 408, header: 0 EOF\n" +
+                        "--- !!not-ready-meta-data #binary\n" +
+                        "...\n" +
+                        "# 130660 bytes remaining\n" +
+                        "--- !!meta-data #binary\n" +
+                        "header: !SCQStore {\n" +
+                        "  writePosition: [\n" +
+                        "    400,\n" +
+                        "    1717986918400\n" +
+                        "  ],\n" +
+                        "  indexing: !SCQSIndexing {\n" +
+                        "    indexCount: 8,\n" +
+                        "    indexSpacing: 1,\n" +
+                        "    index2Index: 200,\n" +
+                        "    lastIndex: 1\n" +
+                        "  },\n" +
+                        "  dataFormat: 1\n" +
+                        "}\n" +
+                        "# position: 200, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index2index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  304,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 304, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  400,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 400, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "\"2\"\n" +
+                        "# position: 408, header: 0 EOF\n" +
+                        "--- !!not-ready-meta-data #binary\n" +
+                        "...\n" +
+                        "# 130660 bytes remaining\n" +
+                        "--- !!meta-data #binary\n" +
+                        "header: !SCQStore {\n" +
+                        "  writePosition: [\n" +
+                        "    400,\n" +
+                        "    1717986918400\n" +
+                        "  ],\n" +
+                        "  indexing: !SCQSIndexing {\n" +
+                        "    indexCount: 8,\n" +
+                        "    indexSpacing: 1,\n" +
+                        "    index2Index: 200,\n" +
+                        "    lastIndex: 1\n" +
+                        "  },\n" +
+                        "  dataFormat: 1\n" +
+                        "}\n" +
+                        "# position: 200, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index2index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  304,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 304, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  400,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 400, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "\"3\"\n" +
+                        "...\n" +
+                        "# 130660 bytes remaining\n", queue.dump().replaceAll("listing.modCount: \\d+", "listing.modCount: 9"));
 
                 // allow parallel tailer to finish iteration
                 for (int i = 0; i < 5_000 && observer.documentsRead != 1 + cyclesToWrite; i++) {
@@ -286,7 +286,7 @@ public class RollCycleTest extends QueueTestCommon {
     }
 
     @AfterEach
-    public void clearInterrupt() {
+    void clearInterrupt() {
         Thread.interrupted();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
@@ -196,6 +196,55 @@ class RollingCycleTest extends QueueTestCommon {
                     "000001f0             10 6e 61 6d  65 5f 2d 31 31 35 34 37     ·nam e_-11547\n" +
                     "00000200 31 35 30 37 39 90 45 c5  e6 f7 b9 1a 4b ea c3 2f 15079·E· ····K··/\n" +
                     "00000210 7f 17 5f 10 01 5c 6e 62  fc cc 5e cc da          ··_··\\nb ··^··   \n" +
+                    "# position: 544, header: 2 EOF\n" +
+                    "--- !!not-ready-meta-data #binary\n" +
+                    "...\n" +
+                    "# 130524 bytes remaining\n" +
+                    "--- !!meta-data #binary\n" +
+                    "header: !SCQStore {\n" +
+                    "  writePosition: [\n" +
+                    "    496,\n" +
+                    "    2130303778818\n" +
+                    "  ],\n" +
+                    "  indexing: !SCQSIndexing {\n" +
+                    "    indexCount: 8,\n" +
+                    "    indexSpacing: 1,\n" +
+                    "    index2Index: 200,\n" +
+                    "    lastIndex: 3\n" +
+                    "  },\n" +
+                    "  dataFormat: 1\n" +
+                    "}\n" +
+                    "# position: 200, header: -1\n" +
+                    "--- !!meta-data #binary\n" +
+                    "index2index: [\n" +
+                    "  # length: 8, used: 1\n" +
+                    "  304,\n" +
+                    "  0, 0, 0, 0, 0, 0, 0\n" +
+                    "]\n" +
+                    "# position: 304, header: -1\n" +
+                    "--- !!meta-data #binary\n" +
+                    "index: [\n" +
+                    "  # length: 8, used: 3\n" +
+                    "  400,\n" +
+                    "  448,\n" +
+                    "  496,\n" +
+                    "  0, 0, 0, 0, 0\n" +
+                    "]\n" +
+                    "# position: 400, header: 0\n" +
+                    "--- !!data #binary\n" +
+                    "00000190             10 6e 61 6d  65 5f 2d 31 31 35 35 34     ·nam e_-11554\n" +
+                    "000001a0 38 34 35 37 36 7a cb 93  3d 38 51 d9 d4 f6 c9 2d 84576z·· =8Q····-\n" +
+                    "000001b0 a3 bd 70 39 9b b7 70 e9  8c 39 f0 1d 4f          ··p9··p· ·9··O   \n" +
+                    "# position: 448, header: 1\n" +
+                    "--- !!data #binary\n" +
+                    "000001c0             10 6e 61 6d  65 5f 2d 31 31 35 35 38     ·nam e_-11558\n" +
+                    "000001d0 36 39 33 32 35 6f 0e fb  68 d8 9c b8 19 fc cc 2c 69325o·· h······,\n" +
+                    "000001e0 35 92 f9 4d 68 e5 f1 2c  55 f0 b8 46 09          5··Mh··, U··F·   \n" +
+                    "# position: 496, header: 2\n" +
+                    "--- !!data #binary\n" +
+                    "000001f0             10 6e 61 6d  65 5f 2d 31 31 35 34 37     ·nam e_-11547\n" +
+                    "00000200 31 35 30 37 39 90 45 c5  e6 f7 b9 1a 4b ea c3 2f 15079·E· ····K··/\n" +
+                    "00000210 7f 17 5f 10 01 5c 6e 62  fc cc 5e cc da          ··_··\\nb ··^··   \n" +
                     "...\n" +
                     "# 130524 bytes remaining\n";
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
@@ -27,7 +27,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class RollingCycleTest extends QueueTestCommon {
+class RollingCycleTest extends QueueTestCommon {
 
     public static Collection<Object[]> data() {
         return Arrays.asList(
@@ -38,7 +38,7 @@ public class RollingCycleTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testRollCycle(boolean named) {
+    void testRollCycle(boolean named) {
         SetTimeProvider stp = new SetTimeProvider();
         long start = 19059 * 86_400_000L;
         stp.currentTimeMillis(start);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
@@ -15,10 +15,8 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.junit.Assume;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,17 +24,11 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
-@RunWith(Parameterized.class)
 public class RollingCycleTest extends QueueTestCommon {
-    private final boolean named;
 
-    public RollingCycleTest(boolean named) {
-        this.named = named;
-    }
-
-    @Parameterized.Parameters(name = "named={0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[]{true},
@@ -44,14 +36,15 @@ public class RollingCycleTest extends QueueTestCommon {
         );
     }
 
-    @Test
-    public void testRollCycle() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testRollCycle(boolean named) {
         SetTimeProvider stp = new SetTimeProvider();
         long start = 19059 * 86_400_000L;
         stp.currentTimeMillis(start);
 
         String basePath = OS.getTarget() + "/testRollCycle" + Time.uniqueId();
-        Assume.assumeFalse("Ignored on hugetlbfs as byte offsets will be different due to page size", PageUtil.isHugePage(basePath));
+        assumeFalse(PageUtil.isHugePage(basePath), "Ignored on hugetlbfs as byte offsets will be different due to page size");
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.single(basePath)
                 .blockSize(OS.SAFE_PAGE_SIZE)
                 .timeoutMS(5)
@@ -109,55 +102,6 @@ public class RollingCycleTest extends QueueTestCommon {
                             "# 130508 bytes remaining\n"
                             : "...\n" +
                             "# 130572 bytes remaining\n") +
-                    "--- !!meta-data #binary\n" +
-                    "header: !SCQStore {\n" +
-                    "  writePosition: [\n" +
-                    "    496,\n" +
-                    "    2130303778818\n" +
-                    "  ],\n" +
-                    "  indexing: !SCQSIndexing {\n" +
-                    "    indexCount: 8,\n" +
-                    "    indexSpacing: 1,\n" +
-                    "    index2Index: 200,\n" +
-                    "    lastIndex: 3\n" +
-                    "  },\n" +
-                    "  dataFormat: 1\n" +
-                    "}\n" +
-                    "# position: 200, header: -1\n" +
-                    "--- !!meta-data #binary\n" +
-                    "index2index: [\n" +
-                    "  # length: 8, used: 1\n" +
-                    "  304,\n" +
-                    "  0, 0, 0, 0, 0, 0, 0\n" +
-                    "]\n" +
-                    "# position: 304, header: -1\n" +
-                    "--- !!meta-data #binary\n" +
-                    "index: [\n" +
-                    "  # length: 8, used: 3\n" +
-                    "  400,\n" +
-                    "  448,\n" +
-                    "  496,\n" +
-                    "  0, 0, 0, 0, 0\n" +
-                    "]\n" +
-                    "# position: 400, header: 0\n" +
-                    "--- !!data #binary\n" +
-                    "00000190             10 6e 61 6d  65 5f 2d 31 31 35 35 34     ·nam e_-11554\n" +
-                    "000001a0 38 34 35 37 36 7a cb 93  3d 38 51 d9 d4 f6 c9 2d 84576z·· =8Q····-\n" +
-                    "000001b0 a3 bd 70 39 9b b7 70 e9  8c 39 f0 1d 4f          ··p9··p· ·9··O   \n" +
-                    "# position: 448, header: 1\n" +
-                    "--- !!data #binary\n" +
-                    "000001c0             10 6e 61 6d  65 5f 2d 31 31 35 35 38     ·nam e_-11558\n" +
-                    "000001d0 36 39 33 32 35 6f 0e fb  68 d8 9c b8 19 fc cc 2c 69325o·· h······,\n" +
-                    "000001e0 35 92 f9 4d 68 e5 f1 2c  55 f0 b8 46 09          5··Mh··, U··F·   \n" +
-                    "# position: 496, header: 2\n" +
-                    "--- !!data #binary\n" +
-                    "000001f0             10 6e 61 6d  65 5f 2d 31 31 35 34 37     ·nam e_-11547\n" +
-                    "00000200 31 35 30 37 39 90 45 c5  e6 f7 b9 1a 4b ea c3 2f 15079·E· ····K··/\n" +
-                    "00000210 7f 17 5f 10 01 5c 6e 62  fc cc 5e cc da          ··_··\\nb ··^··   \n" +
-                    "# position: 544, header: 2 EOF\n" +
-                    "--- !!not-ready-meta-data #binary\n" +
-                    "...\n" +
-                    "# 130524 bytes remaining\n" +
                     "--- !!meta-data #binary\n" +
                     "header: !SCQStore {\n" +
                     "  writePosition: [\n" +

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
@@ -27,7 +27,7 @@ import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilde
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SingleCQFormat2Test extends QueueTestCommon {
+class SingleCQFormat2Test extends QueueTestCommon {
 
     static {
         // init class
@@ -42,7 +42,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
     }
 
     @Test
-    public void testMyData() {
+    void testMyData() {
         @NotNull File dir = getTmpDir();
         ClassAliasPool.CLASS_ALIASES.addAlias(MyData.class);
 
@@ -71,7 +71,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
     }
 
     @Test
-    public void testWritingThreeMessages() throws FileNotFoundException {
+    void testWritingThreeMessages() throws FileNotFoundException {
         for (int m = 0; m <= 2; m++) {
             appendMode = m;
 
@@ -279,7 +279,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
     }
 
     @Test
-    public void testWritingTwentyMessagesTinyIndex1() throws FileNotFoundException {
+    void testWritingTwentyMessagesTinyIndex1() throws FileNotFoundException {
         doTestWritingTwentyMessagesTinyIndex(1, "" +
                 "--- !!meta-data #binary\n" +
                 "header: !SCQStore {\n" +
@@ -380,7 +380,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
     }
 
     @Test
-    public void testWritingTwentyMessagesTinyIndex2() throws FileNotFoundException {
+    void testWritingTwentyMessagesTinyIndex2() throws FileNotFoundException {
         doTestWritingTwentyMessagesTinyIndex(2, "" +
                 "--- !!meta-data #binary\n" +
                 "header: !SCQStore {\n" +
@@ -466,7 +466,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
     }
 
     @Test
-    public void testWritingTwentyMessagesTinyIndex4() throws FileNotFoundException {
+    void testWritingTwentyMessagesTinyIndex4() throws FileNotFoundException {
         doTestWritingTwentyMessagesTinyIndex(4, "--- !!meta-data #binary\n" +
                 "header: !SCQStore {\n" +
                 "  writePosition: [\n" +
@@ -541,7 +541,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
     }
 
     @BeforeEach
-    public void resetAppendMode() {
+    void resetAppendMode() {
         appendMode = 0;
     }
 
@@ -572,7 +572,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
     }
 
     @Test
-    public void writeMap() {
+    void writeMap() {
         @NotNull Map<String, Object> map = new TreeMap<>();
         map.put("abc", "def");
         map.put("hello", "world");
@@ -666,7 +666,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
     }
 
     @Test
-    public void writeMarshallable() {
+    void writeMarshallable() {
         ClassAliasPool.CLASS_ALIASES.addAlias(Order.class);
         @NotNull File dir = getTmpDir();
         try (@NotNull ChronicleQueue queue = binary(dir)
@@ -748,7 +748,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
     }
 
     @Test
-    public void testWritingIndex() {
+    void testWritingIndex() {
         finishedNormally = false;
         @NotNull File dir = getTmpDir();
         try (@NotNull ChronicleQueue queue = SingleChronicleQueueBuilder.single(dir)
@@ -818,30 +818,30 @@ public class SingleCQFormat2Test extends QueueTestCommon {
                 final Bytes<?> bytes = dc.wire().bytes();
                 final String s = bytes.toHexString(0, bytes.writePosition());
                 assertEquals("" +
-                                "00000000 c1 00 00 40 b9 06 68 65  61 64 65 72 b6 08 53 43 ···@··he ader··SC\n" +
-                                "00000010 51 53 74 6f 72 65 82 aa  00 00 00 cd 77 72 69 74 QStore·· ····writ\n" +
-                                "00000020 65 50 6f 73 69 74 69 6f  6e 8e 01 00 00 00 00 8d ePositio n·······\n" +
-                                "00000030 02 00 00 00 00 00 00 00  02 00 00 00 00 00 00 00 ········ ········\n" +
-                                "00000040 90 01 00 00 00 00 00 00  00 00 00 00 90 01 00 00 ········ ········\n" +
-                                "00000050 c8 69 6e 64 65 78 69 6e  67 b6 0c 53 43 51 53 49 ·indexin g··SCQSI\n" +
-                                "00000060 6e 64 65 78 69 6e 67 82  4c 00 00 00 ca 69 6e 64 ndexing· L····ind\n" +
-                                "00000070 65 78 43 6f 75 6e 74 a1  08 cc 69 6e 64 65 78 53 exCount· ··indexS\n" +
-                                "00000080 70 61 63 69 6e 67 a1 01  cb 69 6e 64 65 78 32 49 pacing·· ·index2I\n" +
-                                "00000090 6e 64 65 78 8f 8f 8f a7  c8 00 00 00 00 00 00 00 ndex···· ········\n" +
-                                "000000a0 c9 6c 61 73 74 49 6e 64  65 78 8e 00 00 00 00 a7 ·lastInd ex······\n" +
-                                "000000b0 01 00 00 00 00 00 00 00  ca 64 61 74 61 46 6f 72 ········ ·dataFor\n" +
-                                "000000c0 6d 61 74 a1 01 00 00 00  64 00 00 40 b9 0b 69 6e mat····· d··@··in\n" +
-                                "000000d0 64 65 78 32 69 6e 64 65  78 8e 01 00 00 00 00 8d dex2inde x·······\n" +
-                                "000000e0 08 00 00 00 00 00 00 00  01 00 00 00 00 00 00 00 ········ ········\n" +
-                                "000000f0 30 01 00 00 00 00 00 00  00 00 00 00 00 00 00 00 0······· ········\n" +
-                                "00000100 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 ········ ········\n" +
-                                "........\n" +
-                                "00000130 5c 00 00 40 b9 05 69 6e  64 65 78 8f 8f 8f 8f 8d \\··@··in dex·····\n" +
-                                "00000140 08 00 00 00 00 00 00 00  01 00 00 00 00 00 00 00 ········ ········\n" +
-                                "00000150 90 01 00 00 00 00 00 00  00 00 00 00 00 00 00 00 ········ ········\n" +
-                                "00000160 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 ········ ········\n" +
-                                "........\n" +
-                                "00000190 06 00 00 00 e5 6d 73 67  2d 31 00 00 00 00 00 00 ·····msg -1······\n", s);
+                        "00000000 c1 00 00 40 b9 06 68 65  61 64 65 72 b6 08 53 43 ···@··he ader··SC\n" +
+                        "00000010 51 53 74 6f 72 65 82 aa  00 00 00 cd 77 72 69 74 QStore·· ····writ\n" +
+                        "00000020 65 50 6f 73 69 74 69 6f  6e 8e 01 00 00 00 00 8d ePositio n·······\n" +
+                        "00000030 02 00 00 00 00 00 00 00  02 00 00 00 00 00 00 00 ········ ········\n" +
+                        "00000040 90 01 00 00 00 00 00 00  00 00 00 00 90 01 00 00 ········ ········\n" +
+                        "00000050 c8 69 6e 64 65 78 69 6e  67 b6 0c 53 43 51 53 49 ·indexin g··SCQSI\n" +
+                        "00000060 6e 64 65 78 69 6e 67 82  4c 00 00 00 ca 69 6e 64 ndexing· L····ind\n" +
+                        "00000070 65 78 43 6f 75 6e 74 a1  08 cc 69 6e 64 65 78 53 exCount· ··indexS\n" +
+                        "00000080 70 61 63 69 6e 67 a1 01  cb 69 6e 64 65 78 32 49 pacing·· ·index2I\n" +
+                        "00000090 6e 64 65 78 8f 8f 8f a7  c8 00 00 00 00 00 00 00 ndex···· ········\n" +
+                        "000000a0 c9 6c 61 73 74 49 6e 64  65 78 8e 00 00 00 00 a7 ·lastInd ex······\n" +
+                        "000000b0 01 00 00 00 00 00 00 00  ca 64 61 74 61 46 6f 72 ········ ·dataFor\n" +
+                        "000000c0 6d 61 74 a1 01 00 00 00  64 00 00 40 b9 0b 69 6e mat····· d··@··in\n" +
+                        "000000d0 64 65 78 32 69 6e 64 65  78 8e 01 00 00 00 00 8d dex2inde x·······\n" +
+                        "000000e0 08 00 00 00 00 00 00 00  01 00 00 00 00 00 00 00 ········ ········\n" +
+                        "000000f0 30 01 00 00 00 00 00 00  00 00 00 00 00 00 00 00 0······· ········\n" +
+                        "00000100 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 ········ ········\n" +
+                        "........\n" +
+                        "00000130 5c 00 00 40 b9 05 69 6e  64 65 78 8f 8f 8f 8f 8d \\··@··in dex·····\n" +
+                        "00000140 08 00 00 00 00 00 00 00  01 00 00 00 00 00 00 00 ········ ········\n" +
+                        "00000150 90 01 00 00 00 00 00 00  00 00 00 00 00 00 00 00 ········ ········\n" +
+                        "00000160 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 ········ ········\n" +
+                        "........\n" +
+                        "00000190 06 00 00 00 e5 6d 73 67  2d 31 00 00 00 00 00 00 ·····msg -1······\n", s);
                 dc.rollbackOnClose();
             }
             assertEquals(expectedEager, queue.dump().replaceAll("(?m)^#.+$\\n", ""));

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormat2Test.java
@@ -15,8 +15,8 @@ import net.openhft.chronicle.queue.micros.Order;
 import net.openhft.chronicle.queue.micros.Side;
 import net.openhft.chronicle.wire.*;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -25,7 +25,7 @@ import java.util.TreeMap;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SingleCQFormat2Test extends QueueTestCommon {
 
@@ -38,7 +38,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
 
     private static void assertHexEquals(long a, long b) {
         if (a != b)
-            assertEquals(Long.toHexString(a) + " != " + Long.toHexString(b), a, b);
+            assertEquals(a, b, Long.toHexString(a) + " != " + Long.toHexString(b));
     }
 
     @Test
@@ -61,12 +61,12 @@ public class SingleCQFormat2Test extends QueueTestCommon {
                 name2.writeMarshallable(dc.wire());
             }
             String dump = queue.dump();
-            assertTrue(dump, dump.contains("--- !!meta-data #binary\n" +
+            assertTrue(dump.contains("--- !!meta-data #binary\n" +
                     "index: [\n" +
                     "  # length: 8, used: 1\n" +
                     "  400,\n" +
                     "  0, 0, 0, 0, 0, 0, 0\n" +
-                    "]"));
+                    "]"), dump);
         }
     }
 
@@ -540,7 +540,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
                 "...\n");
     }
 
-    @Before
+    @BeforeEach
     public void resetAppendMode() {
         appendMode = 0;
     }
@@ -841,8 +841,7 @@ public class SingleCQFormat2Test extends QueueTestCommon {
                                 "00000150 90 01 00 00 00 00 00 00  00 00 00 00 00 00 00 00 ········ ········\n" +
                                 "00000160 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 ········ ········\n" +
                                 "........\n" +
-                                "00000190 06 00 00 00 e5 6d 73 67  2d 31 00 00 00 00 00 00 ·····msg -1······\n",
-                        s);
+                                "00000190 06 00 00 00 e5 6d 73 67  2d 31 00 00 00 00 00 00 ·····msg -1······\n", s);
                 dc.rollbackOnClose();
             }
             assertEquals(expectedEager, queue.dump().replaceAll("(?m)^#.+$\\n", ""));

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
@@ -17,7 +17,7 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.RollingChronicleQueue;
 import net.openhft.chronicle.wire.*;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -31,8 +31,8 @@ import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilde
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.DAILY;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class SingleCQFormatTest extends QueueTestCommon {
     static {
@@ -74,8 +74,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
                     tailer.toEnd();
                     fail();
                 } catch (Exception e) {
-                    assertEquals("java.io.StreamCorruptedException: Unexpected magic number 783f3c37",
-                            e.toString());
+                    assertEquals("java.io.StreamCorruptedException: Unexpected magic number 783f3c37", e.toString());
                 }
             }
         }
@@ -169,8 +168,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
                 }
             }
 
-            assertEquals(1,
-                    dir.listFiles((d, name) -> name.startsWith(file.getName()) && name.endsWith("discard")).length);
+            assertEquals(1, dir.listFiles((d, name) -> name.startsWith(file.getName()) && name.endsWith("discard")).length);
         } finally {
             IOTools.shallowDeleteDirWithFiles(dir.getAbsolutePath());
         }
@@ -291,8 +289,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
                 "8e 02 00 00 00 00 00 a7 00 00 00 00 00 00 00 00 # 0\n";
         assertEquals(bytes instanceof HexDumpBytes
                         ? expectedHexDump
-                        : expected,
-                bytes.toHexString());
+                        : expected, bytes.toHexString());
 
         assertEquals("" +
                 "--- !!meta-data #binary\n" +
@@ -382,8 +379,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
             testQueue(queue);
             fail();
         } catch (Exception e) {
-            assertEquals("net.openhft.chronicle.core.io.IORuntimeException: net.openhft.chronicle.core.io.IORuntimeException: field writePosition required",
-                    e.toString());
+            assertEquals("net.openhft.chronicle.core.io.IORuntimeException: net.openhft.chronicle.core.io.IORuntimeException: field writePosition required", e.toString());
         }
         System.gc();
         try {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleCQFormatTest.java
@@ -34,13 +34,13 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class SingleCQFormatTest extends QueueTestCommon {
+class SingleCQFormatTest extends QueueTestCommon {
     static {
         SingleChronicleQueueBuilder.addAliases();
     }
 
     @Test
-    public void testEmptyDirectory() {
+    void testEmptyDirectory() {
         final File dir = new File(OS.getTarget(), getClass().getSimpleName() + "-" + Time.uniqueId());
         dir.mkdir();
         try (RollingChronicleQueue queue = binary(dir).testBlockSize().build()) {
@@ -53,7 +53,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
     }
 
     @Test
-    public void testInvalidFile() throws FileNotFoundException {
+    void testInvalidFile() throws FileNotFoundException {
         // based on the file name
         expectException("Overriding roll cycle from TEST4_DAILY to DAILY");
 
@@ -87,7 +87,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
     }
 
     @Test
-    public void testNoHeader() throws IOException {
+    void testNoHeader() throws IOException {
         ignoreException("Channel closed while unlocking");
         final File dir = new File(OS.getTarget() + "/deleteme-" + Time.uniqueId());
         assumeFalse(PageUtil.isHugePage(dir.getAbsolutePath()));
@@ -117,7 +117,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
     }
 
     @Test
-    public void testDeadHeader() throws IOException {
+    void testDeadHeader() throws IOException {
         ignoreException("Channel closed while unlocking");
         final File dir = getTmpDir();
 
@@ -141,7 +141,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
     }
 
     @Test
-    public void testDeadHeaderAppend() throws IOException {
+    void testDeadHeaderAppend() throws IOException {
         ignoreException("Channel closed while unlocking");
         expectException("Renamed un-acquirable segment file to");
         final File dir = getTmpDir();
@@ -183,7 +183,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
 
     // "see https://github.com/OpenHFT/Chronicle-Queue/issues/719")
     @Test
-    public void testCompleteHeader() throws FileNotFoundException {
+    void testCompleteHeader() throws FileNotFoundException {
         finishedNormally = false;
         ignoreException("reading control code as text");
         expectException("Unexpected field lastAcknowledgedIndexReplicated");
@@ -288,8 +288,8 @@ public class SingleCQFormatTest extends QueueTestCommon {
                 "64 49 6e 64 65 78 52 65 70 6c 69 63 61 74 65 64 # int64 for binding\n" +
                 "8e 02 00 00 00 00 00 a7 00 00 00 00 00 00 00 00 # 0\n";
         assertEquals(bytes instanceof HexDumpBytes
-                        ? expectedHexDump
-                        : expected, bytes.toHexString());
+                ? expectedHexDump
+                : expected, bytes.toHexString());
 
         assertEquals("" +
                 "--- !!meta-data #binary\n" +
@@ -312,7 +312,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
     }
 
     @Test
-    public void testCompleteHeader2() throws FileNotFoundException {
+    void testCompleteHeader2() throws FileNotFoundException {
         final File dir = new File(OS.getTarget(), getClass().getSimpleName() + "-" + Time.uniqueId());
         dir.mkdir();
 
@@ -357,7 +357,7 @@ public class SingleCQFormatTest extends QueueTestCommon {
     }
 
     @Test
-    public void testIncompleteHeader() throws FileNotFoundException {
+    void testIncompleteHeader() throws FileNotFoundException {
         final File dir = new File(OS.getTarget(), getClass().getSimpleName() + "-" + Time.uniqueId());
         dir.mkdir();
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -72,12 +72,10 @@ class SingleChronicleQueueBuilderTest extends QueueTestCommon {
 
     @Test
     void shouldThrowExceptionIfQueuePathIsFileWithIncorrectExtension() throws IOException {
-        assertThrows(IllegalArgumentException.class, () -> {
-            final File tempFile = File.createTempFile(SingleChronicleQueueBuilderTest.class.getSimpleName(), ".txt");
-            tempFile.deleteOnExit();
-            SingleChronicleQueueBuilder.
-                    binary(tempFile);
-        });
+        final File tempFile = File.createTempFile(SingleChronicleQueueBuilderTest.class.getSimpleName(), ".txt");
+        tempFile.deleteOnExit();
+
+        assertThrows(IllegalArgumentException.class, () -> SingleChronicleQueueBuilder.binary(tempFile));
     }
 
     @Test
@@ -93,13 +91,12 @@ class SingleChronicleQueueBuilderTest extends QueueTestCommon {
 
     @Test
     void setAllNullFieldsShouldFailWithDifferentHierarchy() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            OneExtendedBuilder b1 = new OneExtendedBuilder();
-            OtherExtendedBuilder b2 = new OtherExtendedBuilder();
-            b2.bufferCapacity(98765);
-            b1.blockSize(1234567);
-            b2.setAllNullFields(b1);
-        });
+        OneExtendedBuilder b1 = new OneExtendedBuilder();
+        OtherExtendedBuilder b2 = new OtherExtendedBuilder();
+        b2.bufferCapacity(98765);
+        b1.blockSize(1234567);
+
+        assertThrows(IllegalArgumentException.class, () -> b2.setAllNullFields(b1));
     }
 
     static class OneExtendedBuilder extends SingleChronicleQueueBuilder {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -17,8 +17,8 @@ import net.openhft.chronicle.wire.Marshallable;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.Wires;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,14 +29,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     private static final String TEST_QUEUE_FILE = "src/test/resources/tr2/20170320.cq4";
     private static final String BASE_PATH = OS.getTarget() + "/singleChronicleQueueBuilderTest";
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         IOTools.deleteDirWithFiles(BASE_PATH, 2);
     }
@@ -70,12 +70,14 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
         assertTrue(new File(TEST_QUEUE_FILE).length() < (1 << 20));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfQueuePathIsFileWithIncorrectExtension() throws IOException {
-        final File tempFile = File.createTempFile(SingleChronicleQueueBuilderTest.class.getSimpleName(), ".txt");
-        tempFile.deleteOnExit();
-        SingleChronicleQueueBuilder.
-                binary(tempFile);
+        assertThrows(IllegalArgumentException.class, () -> {
+            final File tempFile = File.createTempFile(SingleChronicleQueueBuilderTest.class.getSimpleName(), ".txt");
+            tempFile.deleteOnExit();
+            SingleChronicleQueueBuilder.
+                    binary(tempFile);
+        });
     }
 
     @Test
@@ -89,13 +91,15 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
         assertEquals(98765, b2.bufferCapacity());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAllNullFieldsShouldFailWithDifferentHierarchy() {
-        OneExtendedBuilder b1 = new OneExtendedBuilder();
-        OtherExtendedBuilder b2 = new OtherExtendedBuilder();
-        b2.bufferCapacity(98765);
-        b1.blockSize(1234567);
-        b2.setAllNullFields(b1);
+        assertThrows(IllegalArgumentException.class, () -> {
+            OneExtendedBuilder b1 = new OneExtendedBuilder();
+            OtherExtendedBuilder b2 = new OtherExtendedBuilder();
+            b2.bufferCapacity(98765);
+            b1.blockSize(1234567);
+            b2.setAllNullFields(b1);
+        });
     }
 
     static class OneExtendedBuilder extends SingleChronicleQueueBuilder {
@@ -241,8 +245,8 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
                 .rollCycle(rollCycle)
                 .build();
              ExcerptTailer tailer = reopened.createTailer()) {
-            assertEquals("Roll cycle should be read from metadata", rollCycle, reopened.rollCycle());
-            assertEquals("SourceId should be read from metadata", sourceId, reopened.sourceId());
+            assertEquals(rollCycle, reopened.rollCycle(), "Roll cycle should be read from metadata");
+            assertEquals(sourceId, reopened.sourceId(), "SourceId should be read from metadata");
 
             for (String expected : messages) {
                 assertEquals(expected, tailer.readText());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -32,17 +32,17 @@ import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
+class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     private static final String TEST_QUEUE_FILE = "src/test/resources/tr2/20170320.cq4";
     private static final String BASE_PATH = OS.getTarget() + "/singleChronicleQueueBuilderTest";
 
     @AfterAll
-    public static void afterClass() {
+    static void afterClass() {
         IOTools.deleteDirWithFiles(BASE_PATH, 2);
     }
 
     @Test
-    public void shouldDetermineQueueDirectoryFromQueueFile() throws IOException {
+    void shouldDetermineQueueDirectoryFromQueueFile() throws IOException {
         ignoreException("reading control code as text");
         ignoreException("Unable to copy TimedStoreRecovery safely");
         expectException("Queues should be configured with the queue directory, not a specific filename");
@@ -71,7 +71,7 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldThrowExceptionIfQueuePathIsFileWithIncorrectExtension() throws IOException {
+    void shouldThrowExceptionIfQueuePathIsFileWithIncorrectExtension() throws IOException {
         assertThrows(IllegalArgumentException.class, () -> {
             final File tempFile = File.createTempFile(SingleChronicleQueueBuilderTest.class.getSimpleName(), ".txt");
             tempFile.deleteOnExit();
@@ -81,7 +81,7 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     }
 
     @Test
-    public void setAllNullFields() {
+    void setAllNullFields() {
         SingleChronicleQueueBuilder b1 = SingleChronicleQueueBuilder.builder();
         SingleChronicleQueueBuilder b2 = SingleChronicleQueueBuilder.builder();
         b1.blockSize(1234567);
@@ -92,7 +92,7 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     }
 
     @Test
-    public void setAllNullFieldsShouldFailWithDifferentHierarchy() {
+    void setAllNullFieldsShouldFailWithDifferentHierarchy() {
         assertThrows(IllegalArgumentException.class, () -> {
             OneExtendedBuilder b1 = new OneExtendedBuilder();
             OtherExtendedBuilder b2 = new OtherExtendedBuilder();
@@ -109,7 +109,7 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testReadMarshallable() {
+    void testReadMarshallable() {
         expectException("Overriding roll epoch from existing metadata");
         final String tmpDir = getTmpDir().toString();
         SingleChronicleQueueBuilder builder = Marshallable.fromString("!net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder {\n" +
@@ -133,7 +133,7 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testWriteMarshallableBinary() {
+    void testWriteMarshallableBinary() {
         final SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.single(BASE_PATH).rollCycle(HOURLY);
 
         builder.build().close();
@@ -149,7 +149,7 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testWriteMarshallable() {
+    void testWriteMarshallable() {
         final SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.single(BASE_PATH).rollCycle(HOURLY);
 
         builder.build().close();
@@ -161,7 +161,7 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     }
 
     @Test
-    public void tryOverrideSourceId() {
+    void tryOverrideSourceId() {
         expectException("Overriding sourceId from existing metadata");
 
         final File tmpDir = getTmpDir();
@@ -176,7 +176,7 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     }
 
     @Test
-    public void buildWillNotSetCreateAppenderConditionWhenQueueIsReadOnly() {
+    void buildWillNotSetCreateAppenderConditionWhenQueueIsReadOnly() {
         assumeFalse(OS.isWindows());
 
         final File tmpDir = getTmpDir();
@@ -201,13 +201,13 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
      * Ensure that drainer priority is set to default value on constructing a SingleChronicleQueueBuilder
      */
     @Test
-    public void drainerPriorityIsSetByDefault() {
+    void drainerPriorityIsSetByDefault() {
         SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.single();
         assertNotNull(builder.drainerPriority()); // priority may change from CONCURRENT in future
     }
 
     @Test
-    public void builderAppliesCoreOverridesForLoggerConfigs() {
+    void builderAppliesCoreOverridesForLoggerConfigs() {
         final File tmpDir = getTmpDir();
         final int blockSize = 512 << 10;
         final long requestedBufferCapacity = 64 << 10;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCloseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCloseTest.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 import static net.openhft.chronicle.queue.impl.single.ThreadLocalAppender.acquireThreadLocalAppender;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SingleChronicleQueueCloseTest extends QueueTestCommon {
+class SingleChronicleQueueCloseTest extends QueueTestCommon {
 
     @Test
-    public void testTailAfterClose() {
+    void testTailAfterClose() {
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.builder(getTmpDir(), WireType.BINARY).build()) {
             final ExcerptAppender appender = queue.createAppender();
             appender.writeDocument(w -> w.write(TestKey.test).int32(1));
@@ -32,7 +32,7 @@ public class SingleChronicleQueueCloseTest extends QueueTestCommon {
      * NOTE: Still uses thread local appender as that is the intent of the test.
      */
     @Test
-    public void reacquireAppenderAfterClose() {
+    void reacquireAppenderAfterClose() {
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.builder(getTmpDir(), WireType.BINARY).build()) {
             final ExcerptAppender appender = acquireThreadLocalAppender(queue);
             appender.writeText("hello1");

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCloseTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCloseTest.java
@@ -6,10 +6,10 @@ package net.openhft.chronicle.queue.impl.single;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.openhft.chronicle.queue.impl.single.ThreadLocalAppender.acquireThreadLocalAppender;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SingleChronicleQueueCloseTest extends QueueTestCommon {
 
@@ -21,7 +21,7 @@ public class SingleChronicleQueueCloseTest extends QueueTestCommon {
             Closeable.closeQuietly(queue);
             try {
                 appender.writeDocument(w -> w.write(TestKey.test).int32(2));
-                Assert.fail();
+                fail();
             } catch (IllegalStateException e) {
                 // ok
             }
@@ -48,14 +48,14 @@ public class SingleChronicleQueueCloseTest extends QueueTestCommon {
             final ExcerptAppender appender4 = acquireThreadLocalAppender(queue);
             appender2.writeText("hello4");
 
-            Assert.assertSame(appender3, appender4);
+            assertSame(appender3, appender4);
 
             final ExcerptTailer tailer = queue.createTailer();
 
-            Assert.assertEquals("hello1", tailer.readText());
-            Assert.assertEquals("hello2", tailer.readText());
-            Assert.assertEquals("hello3", tailer.readText());
-            Assert.assertEquals("hello4", tailer.readText());
+            assertEquals("hello1", tailer.readText());
+            assertEquals("hello2", tailer.readText());
+            assertEquals("hello3", tailer.readText());
+            assertEquals("hello4", tailer.readText());
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStoreTest.java
@@ -8,16 +8,16 @@ import net.openhft.chronicle.core.util.ThrowingConsumer;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.queue.impl.RollingChronicleQueue;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SingleChronicleQueueStoreTest extends QueueTestCommon {
     private static final int INDEX_SPACING = 4;
@@ -25,8 +25,8 @@ public class SingleChronicleQueueStoreTest extends QueueTestCommon {
     private static final RollCycles ROLL_CYCLE = RollCycles.DEFAULT;
     private static final ReferenceOwner test = ReferenceOwner.temporary("test");
     private final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
-    @Rule
-    public TemporaryFolder tmpDir = new TemporaryFolder();
+    @TempDir
+    Path tmpDir;
 
     private static void assertExcerptsAreIndexed(final RollingChronicleQueue queue, final long[] indices,
                                                  final Function<Integer, Boolean> shouldBeIndexed, final ScanResult expectedScanResult) {
@@ -57,7 +57,7 @@ public class SingleChronicleQueueStoreTest extends QueueTestCommon {
 
         for (int i = 0; i < RECORD_COUNT; i++) {
             try (final DocumentContext ctx = tailer.readingDocument()) {
-                assertTrue("Expected record at index " + i, ctx.isPresent());
+                assertTrue(ctx.isPresent(), "Expected record at index " + i);
                 indices[i] = tailer.index();
             }
         }
@@ -75,7 +75,7 @@ public class SingleChronicleQueueStoreTest extends QueueTestCommon {
     }
 
     private <T extends Exception> void runTest(final ThrowingConsumer<RollingChronicleQueue, T> testMethod) throws T, IOException {
-        try (final RollingChronicleQueue queue = ChronicleQueue.singleBuilder(tmpDir.newFolder()).
+        try (final RollingChronicleQueue queue = ChronicleQueue.singleBuilder(Files.createTempDirectory(tmpDir, "queue").toFile()).
                 testBlockSize().timeProvider(clock::get).
                 rollCycle(ROLL_CYCLE).indexSpacing(INDEX_SPACING).
                 build()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStoreTest.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SingleChronicleQueueStoreTest extends QueueTestCommon {
+class SingleChronicleQueueStoreTest extends QueueTestCommon {
     private static final int INDEX_SPACING = 4;
     private static final int RECORD_COUNT = INDEX_SPACING * 10;
     private static final RollCycles ROLL_CYCLE = RollCycles.DEFAULT;
@@ -65,7 +65,7 @@ public class SingleChronicleQueueStoreTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldPerformIndexingOnAppend() throws IOException {
+    void shouldPerformIndexingOnAppend() throws IOException {
         runTest(queue -> {
             try (ExcerptAppender appender = queue.createAppender()) {
                 final long[] indices = writeMessagesStoreIndices(appender, queue.createTailer());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.Closeable;
 import java.io.File;
@@ -54,12 +55,13 @@ import static net.openhft.chronicle.queue.rollcycles.SparseRollCycles.SMALL_DAIL
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings({"try", "serial"})
-public class SingleChronicleQueueTest extends QueueTestCommon {
+class SingleChronicleQueueTest extends QueueTestCommon {
 
     private static final long TIMES = (4L << 20L);
     @NotNull
@@ -117,7 +119,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAppend(@NotNull WireType wireType, boolean named) {
+    void testAppend(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue =
@@ -139,7 +141,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void createAppenderWillReturnANewAppenderEachTime(@NotNull WireType wireType, boolean named) {
+    void createAppenderWillReturnANewAppenderEachTime(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), wireType).build();
@@ -155,7 +157,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
      */
     @ParameterizedTest
     @MethodSource("data")
-    public void createAppenderWillThrowWhenQueueIsReadOnly(@NotNull WireType wireType, boolean named) {
+    void createAppenderWillThrowWhenQueueIsReadOnly(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         assumeFalse(OS.isWindows());
@@ -226,7 +228,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testTextReadWrite(@NotNull WireType wireType, boolean named) {
+    void testTextReadWrite(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         File tmpDir = getTmpDir();
@@ -252,7 +254,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCleanupDir(@NotNull WireType wireType, boolean named) throws Throwable {
+    void testCleanupDir(@NotNull WireType wireType, boolean named) throws Throwable {
         this.wireType = wireType;
         this.named = named;
         if (OS.isWindows())
@@ -280,7 +282,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testRollbackOnAppend(@NotNull WireType wireType, boolean named) {
+    void testRollbackOnAppend(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue =
@@ -315,7 +317,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testWriteWithDocumentReadBytesDifferentThreads(@NotNull WireType wireType, boolean named) throws InterruptedException, TimeoutException, ExecutionException {
+    void testWriteWithDocumentReadBytesDifferentThreads(@NotNull WireType wireType, boolean named) throws InterruptedException, TimeoutException, ExecutionException {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), wireType)
@@ -374,7 +376,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldBlowUpIfTryingToCreateQueueWithUnparseableRollCycle(@NotNull WireType wireType, boolean named) {
+    void shouldBlowUpIfTryingToCreateQueueWithUnparseableRollCycle(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         assertThrows(IllegalStateException.class, () -> {
@@ -395,14 +397,14 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCanAppendMetadataIfAppendLockIsSet(@NotNull WireType wireType, boolean named) {
+    void testCanAppendMetadataIfAppendLockIsSet(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         File tmpDir = getTmpDir();
         try (final ChronicleQueue queue = builder(tmpDir, wireType).build()) {
             ((SingleChronicleQueue) queue).appendLock().lock();
             try (final ExcerptAppender appender = queue.createAppender()) {
-                assumeTrue("Failing in CQE", appender instanceof StoreAppender);
+                assumeTrue(appender instanceof StoreAppender, "Failing in CQE");
                 try (DocumentContext dc = appender.writingDocument(true)) {
                     dc.wire().write("Hello World");
                 }
@@ -412,7 +414,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCantAppendIfAppendLockIsSet(@NotNull WireType wireType, boolean named) {
+    void testCantAppendIfAppendLockIsSet(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         assertThrows(IllegalStateException.class, () -> {
@@ -428,7 +430,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCantAppendIfAppendLockIsSetInDifferentQueue(@NotNull WireType wireType, boolean named) {
+    void testCantAppendIfAppendLockIsSetInDifferentQueue(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         assertThrows(IllegalStateException.class, () -> {
@@ -449,7 +451,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCanAppendWriteBytesInternalIfAppendLockIsSet(@NotNull WireType wireType, boolean named) {
+    void testCanAppendWriteBytesInternalIfAppendLockIsSet(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         @NotNull Bytes<byte[]> test = Bytes.from("hello world");
@@ -479,7 +481,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldNotBlowUpIfTryingToCreateQueueWithIncorrectRollCycle(@NotNull WireType wireType, boolean named) {
+    void shouldNotBlowUpIfTryingToCreateQueueWithIncorrectRollCycle(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         expectException("Overriding roll length from existing metadata");
@@ -502,7 +504,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldOverrideDifferentEpoch(@NotNull WireType wireType, boolean named) {
+    void shouldOverrideDifferentEpoch(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         expectException("Overriding roll epoch from existing metadata, was 10, overriding to 100");
@@ -522,7 +524,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadWriteHourly(@NotNull WireType wireType, boolean named) {
+    void testReadWriteHourly(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -549,7 +551,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldAllowDirectoryToBeDeletedWhenQueueIsClosed(@NotNull WireType wireType, boolean named) throws IOException {
+    void shouldAllowDirectoryToBeDeletedWhenQueueIsClosed(@NotNull WireType wireType, boolean named) throws IOException {
         this.wireType = wireType;
         this.named = named;
         if (OS.isWindows()) {
@@ -582,7 +584,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingLessBytesThanWritten(@NotNull WireType wireType, boolean named) {
+    void testReadingLessBytesThanWritten(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), wireType)
@@ -613,7 +615,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAppendAndRead(@NotNull WireType wireType, boolean named) {
+    void testAppendAndRead(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
@@ -648,7 +650,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadAndAppend(@NotNull WireType wireType, boolean named) throws InterruptedException {
+    void testReadAndAppend(@NotNull WireType wireType, boolean named) throws InterruptedException {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType).build();
@@ -697,7 +699,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCheckIndexWithWritingDocument(@NotNull WireType wireType, boolean named) {
+    void testCheckIndexWithWritingDocument(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         doTestCheckIndex(
@@ -710,7 +712,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCheckIndexWithWritingDocument2(@NotNull WireType wireType, boolean named) {
+    void testCheckIndexWithWritingDocument2(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         doTestCheckIndex(
@@ -726,7 +728,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCheckIndexWithWriteBytes(@NotNull WireType wireType, boolean named) {
+    void testCheckIndexWithWriteBytes(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         doTestCheckIndex(
@@ -735,7 +737,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCheckIndexWithWriteBytes2(@NotNull WireType wireType, boolean named) {
+    void testCheckIndexWithWriteBytes2(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         doTestCheckIndex(
@@ -744,7 +746,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCheckIndexWithWriteBytes3(@NotNull WireType wireType, boolean named) {
+    void testCheckIndexWithWriteBytes3(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         doTestCheckIndex(
@@ -757,7 +759,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCheckIndexWithWriteMap(@NotNull WireType wireType, boolean named) {
+    void testCheckIndexWithWriteMap(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         doTestCheckIndex(
@@ -768,7 +770,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCheckIndexWithWriteText(@NotNull WireType wireType, boolean named) {
+    void testCheckIndexWithWriteText(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         doTestCheckIndex(
@@ -805,7 +807,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAppendAndReadWithRollingB(@NotNull WireType wireType, boolean named) {
+    void testAppendAndReadWithRollingB(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         SetTimeProvider stp = new SetTimeProvider();
@@ -852,7 +854,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAppendAndReadAtIndex(@NotNull WireType wireType, boolean named) {
+    void testAppendAndReadAtIndex(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
@@ -884,7 +886,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testSimpleWire(@NotNull WireType wireType, boolean named) {
+    void testSimpleWire(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -907,7 +909,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testIndexWritingDocument(@NotNull WireType wireType, boolean named) {
+    void testIndexWritingDocument(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -930,7 +932,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingWritingMarshallableDocument(@NotNull WireType wireType, boolean named) {
+    void testReadingWritingMarshallableDocument(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -954,7 +956,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testMetaData(@NotNull WireType wireType, boolean named) {
+    void testMetaData(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         assumeFalse(named);
@@ -985,7 +987,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                     if (!StringUtils.isEqual(event, "FirstName"))
                         continue;
 
-                    in.text("Quartilla", Assert::assertEquals);
+                    in.text("Quartilla", Assertions::assertEquals);
                     break;
                 }
             }
@@ -994,7 +996,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             try (DocumentContext dc = tailer.readingDocument(true)) {
                 assertTrue(dc.isData());
                 robIndex = dc.index();
-                dc.wire().read("FirstName").text("Rob", Assert::assertEquals);
+                dc.wire().read("FirstName").text("Rob", Assertions::assertEquals);
             }
 
             while (true) {
@@ -1004,7 +1006,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                     if (!StringUtils.isEqual(event, "FirstName"))
                         continue;
 
-                    in.text("Steve", Assert::assertEquals);
+                    in.text("Steve", Assertions::assertEquals);
                     break;
                 }
             }
@@ -1012,14 +1014,14 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             assertTrue(tailer.moveToIndex(robIndex));
             try (DocumentContext dc = tailer.readingDocument(false)) {
                 assertTrue(dc.isData());
-                dc.wire().read("FirstName").text("Rob", Assert::assertEquals);
+                dc.wire().read("FirstName").text("Rob", Assertions::assertEquals);
             }
         }
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingSecondDocumentNotExist(@NotNull WireType wireType, boolean named) {
+    void testReadingSecondDocumentNotExist(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -1046,7 +1048,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testDocumentIndexTest(@NotNull WireType wireType, boolean named) {
+    void testDocumentIndexTest(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -1091,7 +1093,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingSecondDocumentNotExistIncludingMeta(@NotNull WireType wireType, boolean named) {
+    void testReadingSecondDocumentNotExistIncludingMeta(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -1112,7 +1114,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                     if (!StringUtils.isEqual(event, "FirstName"))
                         continue;
 
-                    in.text("Quartilla", Assert::assertEquals);
+                    in.text("Quartilla", Assertions::assertEquals);
                     break;
                 }
             }
@@ -1125,7 +1127,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testSimpleByteTest(@NotNull WireType wireType, boolean named) {
+    void testSimpleByteTest(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), wireType)
@@ -1156,7 +1158,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadAtIndex(@NotNull WireType wireType, boolean named) {
+    void testReadAtIndex(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final RollingChronicleQueue queue = builder(getTmpDir(), wireType)
@@ -1184,7 +1186,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             for (int i : new int[]{0, 8, 7, 9, 64, 65, 66}) {
                 final long index = queue.rollCycle().toIndex(cycle, i);
                 assertTrue(tailer.moveToIndex(
-                                index), "i: " + i);
+                        index), "i: " + i);
                 try (final DocumentContext context = tailer.readingDocument()) {
                     assertEquals(index, context.index());
                     context.wire().read("key").text(sb);
@@ -1197,7 +1199,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     @Disabled("long running test")
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadAtIndex4MB(@NotNull WireType wireType, boolean named) {
+    void testReadAtIndex4MB(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.builder(getTmpDir(), this.wireType).rollCycle(SMALL_DAILY)
@@ -1226,7 +1228,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testMetaIndexTest(@NotNull WireType wireType, boolean named) {
+    void testMetaIndexTest(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -1353,7 +1355,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testLastWrittenIndexPerAppender(@NotNull WireType wireType, boolean named) {
+    void testLastWrittenIndexPerAppender(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
@@ -1367,7 +1369,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testLastWrittenIndexPerAppenderNoData(@NotNull WireType wireType, boolean named) {
+    void testLastWrittenIndexPerAppenderNoData(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         assertThrows(IllegalStateException.class, () -> {
@@ -1380,8 +1382,9 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         });
     }
 
-    @Test //: no messages written
-    public void testNoMessagesWritten() {
+    @Test
+        //: no messages written
+    void testNoMessagesWritten() {
         assertThrows(IllegalStateException.class, () -> {
             try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                     .build();
@@ -1394,7 +1397,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testHeaderIndexReadAtIndex(@NotNull WireType wireType, boolean named) {
+    void testHeaderIndexReadAtIndex(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
@@ -1423,7 +1426,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
      */
     @ParameterizedTest
     @MethodSource("data")
-    public void testEPOC(@NotNull WireType wireType, boolean named) {
+    void testEPOC(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -1439,7 +1442,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldBeAbleToReadFromQueueWithNonZeroEpoch(@NotNull WireType wireType, boolean named) {
+    void shouldBeAbleToReadFromQueueWithNonZeroEpoch(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -1458,7 +1461,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldHandleLargeEpoch(@NotNull WireType wireType, boolean named) {
+    void shouldHandleLargeEpoch(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -1477,7 +1480,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testNegativeEPOC(@NotNull WireType wireType, boolean named) {
+    void testNegativeEPOC(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         for (int h = -14; h <= 14; h++) {
@@ -1497,7 +1500,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testIndex(@NotNull WireType wireType, boolean named) {
+    void testIndex(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
@@ -1534,7 +1537,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingDocument(@NotNull WireType wireType, boolean named) {
+    void testReadingDocument(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
@@ -1603,7 +1606,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingDocumentWithFirstAMove(@NotNull WireType wireType, boolean named) {
+    void testReadingDocumentWithFirstAMove(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -1660,7 +1663,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingDocumentWithFirstAMoveWithEpoch(@NotNull WireType wireType, boolean named) {
+    void testReadingDocumentWithFirstAMoveWithEpoch(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         Instant hourly = Instant.parse("2018-02-12T00:59:59.999Z");
@@ -1743,7 +1746,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAppendedBeforeToEnd(@NotNull WireType wireType, boolean named) {
+    void testAppendedBeforeToEnd(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         File dir = getTmpDir();
@@ -1762,7 +1765,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 tailer.toEnd();
 
             try (DocumentContext dc = tailer.readingDocument()) {
-                assertFalse(tailer.index() + " " + tailer.state(), dc.isPresent());
+                assertFalse(dc.isPresent(), tailer.index() + " " + tailer.state());
             }
 
             append.writeDocument(w -> w.write("test").text("text2"));
@@ -1776,7 +1779,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReentrant(@NotNull WireType wireType, boolean named) {
+    void testReentrant(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -1862,7 +1865,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testToEnd(@NotNull WireType wireType, boolean named) throws InterruptedException {
+    void testToEnd(@NotNull WireType wireType, boolean named) throws InterruptedException {
         this.wireType = wireType;
         this.named = named;
         File dir = getTmpDir();
@@ -1888,8 +1891,8 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             try (DocumentContext dc = tailer.readingDocument()) {
                 try (final SingleChronicleQueue build = builder(dir, wireType).rollCycle(HOURLY).build()) {
                     String message = "dump: " + build.dump();
-                    assertTrue(message, dc.isPresent());
-                    assertEquals(message, "text", dc.wire().read("test").text());
+                    assertTrue(dc.isPresent(), message);
+                    assertEquals("text", dc.wire().read("test").text(), message);
                 }
             }
         }
@@ -1897,7 +1900,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testToEnd2(@NotNull WireType wireType, boolean named) {
+    void testToEnd2(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         File dir = getTmpDir();
@@ -1916,13 +1919,13 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
             append.writeDocument(w -> w.write("test").text("text"));
 
-            assertTrue(tailer.readDocument(w -> w.read("test").text("text", Assert::assertEquals)));
+            assertTrue(tailer.readDocument(w -> w.read("test").text("text", Assertions::assertEquals)));
         }
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testToEndOnDeletedQueueFiles(@NotNull WireType wireType, boolean named) throws IOException {
+    void testToEndOnDeletedQueueFiles(@NotNull WireType wireType, boolean named) throws IOException {
         this.wireType = wireType;
         this.named = named;
         if (OS.isWindows()) {
@@ -1942,7 +1945,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
             append.writeDocument(w -> w.write("test").text("text"));
 
-            assertTrue(tailer.readDocument(w -> w.read("test").text("text", Assert::assertEquals)));
+            assertTrue(tailer.readDocument(w -> w.read("test").text("text", Assertions::assertEquals)));
 
             try (Stream<Path> cq4Files = Files.find(dir.toPath(), 1, (p, basicFileAttributes) -> p.toString().endsWith("cq4"), FileVisitOption.FOLLOW_LINKS)) {
                 final List<Path> unDeletable = cq4Files.filter(path -> !path.toFile().delete())
@@ -1957,14 +1960,14 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 assertEquals(TailerState.UNINITIALISED, tailer.state());
                 q2Appender.writeDocument(w -> w.write("test").text("before text"));
 
-                assertTrue(tailer.readDocument(w -> w.read("test").text("before text", Assert::assertEquals)));
+                assertTrue(tailer.readDocument(w -> w.read("test").text("before text", Assertions::assertEquals)));
             }
         }
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadWrite(@NotNull WireType wireType, boolean named) {
+    void testReadWrite(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         File dir = getTmpDir();
@@ -1992,19 +1995,19 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 if (i % 10000 == 0)
                     System.gc();
                 if (i % 2 == 0)
-                    assertTrue(tailer2.readDocument(w -> w.read("test - message").text("text", Assert::assertEquals)));
+                    assertTrue(tailer2.readDocument(w -> w.read("test - message").text("text", Assertions::assertEquals)));
                 if (i % 3 == 0)
-                    assertTrue(tailer3.readDocument(w -> w.read("test - message").text("text", Assert::assertEquals)));
+                    assertTrue(tailer3.readDocument(w -> w.read("test - message").text("text", Assertions::assertEquals)));
                 if (i % 4 == 0)
-                    assertTrue(tailer4.readDocument(w -> w.read("test - message").text("text", Assert::assertEquals)));
-                assertTrue(tailer.readDocument(w -> w.read("test - message").text("text", Assert::assertEquals)));
+                    assertTrue(tailer4.readDocument(w -> w.read("test - message").text("text", Assertions::assertEquals)));
+                assertTrue(tailer.readDocument(w -> w.read("test - message").text("text", Assertions::assertEquals)));
             }
         }
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingDocumentForEmptyQueue(@NotNull WireType wireType, boolean named) {
+    void testReadingDocumentForEmptyQueue(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         File dir = getTmpDir();
@@ -2029,7 +2032,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 // DocumentContext should not be empty as we know what the wire type will be.
                 try (DocumentContext dc = tailer.readingDocument()) {
                     assertTrue(dc.isPresent());
-                    dc.wire().read("test - message").text("text", Assert::assertEquals);
+                    dc.wire().read("test - message").text("text", Assertions::assertEquals);
                 }
             }
         }
@@ -2037,7 +2040,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testMetaData6(@NotNull WireType wireType, boolean named) {
+    void testMetaData6(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         assumeFalse(named);
@@ -2069,7 +2072,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                     if (!StringUtils.isEqual(event, "FirstName"))
                         continue;
 
-                    in.text("Quartilla", Assert::assertEquals);
+                    in.text("Quartilla", Assertions::assertEquals);
                     break;
                 }
             }
@@ -2077,7 +2080,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             try (DocumentContext dc = tailer.readingDocument(true)) {
                 assertTrue(dc.isData());
                 assertTrue(dc.isPresent());
-                dc.wire().read("FirstName").text("Helen", Assert::assertEquals);
+                dc.wire().read("FirstName").text("Helen", Assertions::assertEquals);
             }
 
             while (true) {
@@ -2087,7 +2090,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                     if (!StringUtils.isEqual(event, "FirstName"))
                         continue;
 
-                    in.text("Steve", Assert::assertEquals);
+                    in.text("Steve", Assertions::assertEquals);
                     break;
                 }
             }
@@ -2163,7 +2166,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testToEndBeforeWrite(@NotNull WireType wireType, boolean named) {
+    void testToEndBeforeWrite(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), wireType)
@@ -2178,14 +2181,14 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 tailer.toEnd();
                 int finalI = i;
                 appender.writeDocument(w -> w.writeEventName("hello").text("world" + finalI));
-                tailer.readDocument(w -> w.read().text("world" + finalI, Assert::assertEquals));
+                tailer.readDocument(w -> w.read().text("world" + finalI, Assertions::assertEquals));
             }
         }
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testForwardFollowedBackBackwardTailer(@NotNull WireType wireType, boolean named) {
+    void testForwardFollowedBackBackwardTailer(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -2208,7 +2211,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldReadBackwardFromEndOfQueueWhenDirectionIsSetAfterMoveToEnd(@NotNull WireType wireType, boolean named) {
+    void shouldReadBackwardFromEndOfQueueWhenDirectionIsSetAfterMoveToEnd(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
@@ -2276,7 +2279,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testOverreadForwardFromFutureCycleThenReadBackwardTailer(@NotNull WireType wireType, boolean named) {
+    void testOverreadForwardFromFutureCycleThenReadBackwardTailer(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         RollCycle cycle = TEST2_DAILY;
@@ -2320,7 +2323,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testSomeMessages(@NotNull WireType wireType, boolean named) {
+    void testSomeMessages(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), wireType)
@@ -2345,7 +2348,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testZeroLengthMessage(@NotNull WireType wireType, boolean named) {
+    void testZeroLengthMessage(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), wireType)
@@ -2365,7 +2368,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testMoveToWithAppender(@NotNull WireType wireType, boolean named) {
+    void testMoveToWithAppender(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (ChronicleQueue syncQ = builder(getTmpDir(), this.wireType)
@@ -2396,7 +2399,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testMapWrapper(@NotNull WireType wireType, boolean named) {
+    void testMapWrapper(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (ChronicleQueue syncQ = builder(getTmpDir(), this.wireType)
@@ -2424,7 +2427,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testLastIndexAppended(@NotNull WireType wireType, boolean named) {
+    void testLastIndexAppended(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
@@ -2442,7 +2445,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testAppendedSkipToEndMultiThreaded(@NotNull WireType wireType, boolean named) throws InterruptedException {
+    void testAppendedSkipToEndMultiThreaded(@NotNull WireType wireType, boolean named) throws InterruptedException {
         this.wireType = wireType;
         this.named = named;
         // some text to simulate load.
@@ -2496,7 +2499,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
      */
     @ParameterizedTest
     @MethodSource("data")
-    public void testAppendedSkipToEnd(@NotNull WireType wireType, boolean named) {
+    void testAppendedSkipToEnd(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -2523,7 +2526,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testToEndPrevCycleEOF(@NotNull WireType wireType, boolean named) {
+    void testToEndPrevCycleEOF(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
@@ -2593,7 +2596,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     @Disabled("Long Running Test")
     @ParameterizedTest
     @MethodSource("data")
-    public void testRandomConcurrentReadWrite(@NotNull WireType wireType, boolean named) throws
+    void testRandomConcurrentReadWrite(@NotNull WireType wireType, boolean named) throws
             InterruptedException {
         this.wireType = wireType;
         this.named = named;
@@ -2631,7 +2634,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testTailerWhenCyclesWhereSkippedOnWrite(@NotNull WireType wireType, boolean named) {
+    void testTailerWhenCyclesWhereSkippedOnWrite(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
@@ -2706,7 +2709,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testMultipleAppenders(@NotNull WireType wireType, boolean named) {
+    void testMultipleAppenders(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (ChronicleQueue syncQ = builder(getTmpDir(), this.wireType)
@@ -2824,7 +2827,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldNotGenerateGarbageReadingDocumentAfterEndOfFile(@NotNull WireType wireType, boolean named) {
+    void shouldNotGenerateGarbageReadingDocumentAfterEndOfFile(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
@@ -2856,15 +2859,15 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             final long endCollectionCount = GcControls.getGcCount();
             final long actualGcCycles = endCollectionCount - startCollectionCount;
 
-            assertTrue(String.format("Too many GC cycles. Expected <= %d, but was %d",
-                            maxAllowedGcCycles, actualGcCycles),
-                    actualGcCycles <= maxAllowedGcCycles);
+            assertTrue(actualGcCycles <= maxAllowedGcCycles,
+                    String.format("Too many GC cycles. Expected <= %d, but was %d",
+                            maxAllowedGcCycles, actualGcCycles));
         }
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingWritingWhenNextCycleIsInSequence(@NotNull WireType wireType, boolean named) {
+    void testReadingWritingWhenNextCycleIsInSequence(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
@@ -2899,7 +2902,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingWritingWhenCycleIsSkipped(@NotNull WireType wireType, boolean named) {
+    void testReadingWritingWhenCycleIsSkipped(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -2936,7 +2939,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadingWritingWhenCycleIsSkippedBackwards(@NotNull WireType wireType, boolean named) {
+    void testReadingWritingWhenCycleIsSkippedBackwards(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         final SetTimeProvider timeProvider = new SetTimeProvider();
@@ -2971,7 +2974,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadWritingWithTimeProvider(@NotNull WireType wireType, boolean named) {
+    void testReadWritingWithTimeProvider(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         final File dir = getTmpDir();
@@ -3018,7 +3021,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCountExceptsBetweenCycles(@NotNull WireType wireType, boolean named) {
+    void testCountExceptsBetweenCycles(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
@@ -3069,7 +3072,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testLongLivingTailerAppenderReAcquiredEachSecond(@NotNull WireType wireType, boolean named) {
+    void testLongLivingTailerAppenderReAcquiredEachSecond(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
@@ -3117,7 +3120,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCountExceptsWithRubbishData(@NotNull WireType wireType, boolean named) {
+    void testCountExceptsWithRubbishData(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         assertThrows(IllegalStateException.class, () -> {
@@ -3133,7 +3136,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testFromSizePrefixedBlobs(@NotNull WireType wireType, boolean named) {
+    void testFromSizePrefixedBlobs(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -3161,7 +3164,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void tailerRollBackTest(@NotNull WireType wireType, boolean named) {
+    void tailerRollBackTest(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         final File source = getTmpDir();
@@ -3180,7 +3183,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testCopyQueue(@NotNull WireType wireType, boolean named) {
+    void testCopyQueue(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         final File source = getTmpDir();
@@ -3224,7 +3227,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
      */
     @ParameterizedTest
     @MethodSource("data")
-    public void testIncorrectExcerptTailerReadsAfterSwitchingTailerDirection(@NotNull WireType wireType, boolean named) {
+    void testIncorrectExcerptTailerReadsAfterSwitchingTailerDirection(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -3277,7 +3280,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testExistingRollCycleIsMaintained(@NotNull WireType wireType, boolean named) {
+    void testExistingRollCycleIsMaintained(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         expectException("Overriding roll cycle from ");
@@ -3311,7 +3314,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void checkReferenceCountingAndCheckFileDeletion(@NotNull WireType wireType, boolean named) {
+    void checkReferenceCountingAndCheckFileDeletion(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -3346,7 +3349,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void checkReferenceCountingWhenRollingAndCheckFileDeletion(@NotNull WireType wireType, boolean named) {
+    void checkReferenceCountingWhenRollingAndCheckFileDeletion(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
@@ -3399,7 +3402,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testWritingDocumentIsAtomic(@NotNull WireType wireType, boolean named) {
+    void testWritingDocumentIsAtomic(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -3461,7 +3464,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldBeAbleToLoadQueueFromReadOnlyFiles(@NotNull WireType wireType, boolean named) throws IOException {
+    void shouldBeAbleToLoadQueueFromReadOnlyFiles(@NotNull WireType wireType, boolean named) throws IOException {
         this.wireType = wireType;
         this.named = named;
         if (OS.isWindows()) {
@@ -3492,7 +3495,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldCreateQueueInCurrentDirectory(@NotNull WireType wireType, boolean named) {
+    void shouldCreateQueueInCurrentDirectory(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         if (OS.isWindows()) {
@@ -3516,7 +3519,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testTailerSnappingRollWithNewAppender(@NotNull WireType wireType, boolean named) throws InterruptedException, ExecutionException, TimeoutException {
+    void testTailerSnappingRollWithNewAppender(@NotNull WireType wireType, boolean named) throws InterruptedException, ExecutionException, TimeoutException {
         this.wireType = wireType;
         this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
@@ -3601,7 +3604,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void writeBytesAndIndexFiveTimesWithOverwriteTest(@NotNull WireType wireType, boolean named) {
+    void writeBytesAndIndexFiveTimesWithOverwriteTest(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue sourceQueue =
@@ -3654,7 +3657,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 }
 
                 String dump = tidyDump(queue);
-                assertTrue(dump, dump.contains(
+                assertTrue(dump.contains(
                         "--- !!data #binary\n" +
                                 "hello: world0\n" +
                                 "--- !!data #binary\n" +
@@ -3666,7 +3669,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                                 "--- !!data #binary\n" +
                                 "hello: world4\n" +
                                 "--- !!data #binary\n" +
-                                "goodbye\n"));
+                                "goodbye\n"), dump);
 
             }
         }
@@ -3674,7 +3677,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void writeBytesAndIndexFiveTimesTest(@NotNull WireType wireType, boolean named) {
+    void writeBytesAndIndexFiveTimesTest(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         try (final ChronicleQueue sourceQueue =
@@ -3705,7 +3708,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
                 String dump = tidyDump(queue);
                 assertEquals(before, dump);
-                assertTrue(dump, dump.contains(
+                assertTrue(dump.contains(
                         "--- !!data #binary\n" +
                                 "hello: world0\n" +
                                 "--- !!data #binary\n" +
@@ -3715,14 +3718,14 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                                 "--- !!data #binary\n" +
                                 "hello: world3\n" +
                                 "--- !!data #binary\n" +
-                                "hello: world4"));
+                                "hello: world4"), dump);
             }
         }
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void rollbackTest(@NotNull WireType wireType, boolean named) {
+    void rollbackTest(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
 
@@ -3818,11 +3821,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void mappedSegmentsShouldBeUnmappedAsCycleRolls(@NotNull WireType wireType, boolean named) throws IOException, InterruptedException {
+    void mappedSegmentsShouldBeUnmappedAsCycleRolls(@NotNull WireType wireType, boolean named) throws IOException, InterruptedException {
         this.wireType = wireType;
         this.named = named;
 
-        assumeTrue("this test is slow and does not depend on wire type", wireType == WireType.BINARY);
+        assumeTrue(wireType == WireType.BINARY, "this test is slow and does not depend on wire type");
 
         long now = System.currentTimeMillis();
         long ONE_HOUR_IN_MILLIS = 60 * 60 * 1000;
@@ -3903,7 +3906,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
      */
     @ParameterizedTest
     @MethodSource("data")
-    public void testReadUsingReadOnly(@NotNull WireType wireType, boolean named) {
+    void testReadUsingReadOnly(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
@@ -3935,7 +3938,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void lastIndexShouldReturnLastIndexForPopulatedQueue(@NotNull WireType wireType, boolean named) {
+    void lastIndexShouldReturnLastIndexForPopulatedQueue(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         File tmpDir = getTmpDir();
@@ -3953,7 +3956,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void lastIndexShouldReturnNegativeOneForEmptyQueue(@NotNull WireType wireType, boolean named) {
+    void lastIndexShouldReturnNegativeOneForEmptyQueue(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         File tmpDir = getTmpDir();
@@ -3964,7 +3967,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void lastIndexShouldReturnNegativeOneForMetadataOnlyQueue(@NotNull WireType wireType, boolean named) {
+    void lastIndexShouldReturnNegativeOneForMetadataOnlyQueue(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
         File tmpDir = getTmpDir();
@@ -3980,7 +3983,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void shouldWaitForConditionWhenCreatingAppender(@NotNull WireType wireType, boolean named) throws TimeoutException {
+    void shouldWaitForConditionWhenCreatingAppender(@NotNull WireType wireType, boolean named) throws TimeoutException {
         this.wireType = wireType;
         this.named = named;
         File tmpDir = getTmpDir();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -21,10 +21,9 @@ import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.threads.YieldingPauser;
 import net.openhft.chronicle.wire.*;
 import org.jetbrains.annotations.NotNull;
-import org.junit.*;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.Closeable;
 import java.io.File;
@@ -53,26 +52,21 @@ import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueue.SUFFI
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.*;
 import static net.openhft.chronicle.queue.rollcycles.SparseRollCycles.SMALL_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.*;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 @SuppressWarnings({"try", "serial"})
 public class SingleChronicleQueueTest extends QueueTestCommon {
 
     private static final long TIMES = (4L << 20L);
     @NotNull
-    protected final WireType wireType;
-    protected final boolean named;
+    protected WireType wireType;
+    protected boolean named;
     private final Bytes<?> appenderListenerDump = Bytes.allocateElasticOnHeap(256);
 
-    public SingleChronicleQueueTest(@NotNull WireType wireType, boolean named) {
-        this.wireType = wireType;
-        this.named = named;
-    }
-
-    @Parameters(name = "wireType={0}, named={1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[]{WireType.BINARY_LIGHT, true},
@@ -82,7 +76,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
@@ -121,8 +115,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         fail(message);
     }
 
-    @Test
-    public void testAppend() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAppend(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue =
                      builderWithAppendListener(getTmpDir(), wireType)
                              .build();
@@ -140,8 +137,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 appenderListenerDump.toString());
     }
 
-    @Test
-    public void createAppenderWillReturnANewAppenderEachTime() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void createAppenderWillReturnANewAppenderEachTime(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), wireType).build();
              final ExcerptAppender appender1 = queue.createAppender();
              final ExcerptAppender appender2 = queue.createAppender()) {
@@ -153,8 +153,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
      * readOnly=true is not supported on Windows so this test does not run on Windows targets, please see
      * {@link SingleChronicleQueueBuilder#readOnly(boolean)}.
      */
-    @Test
-    public void createAppenderWillThrowWhenQueueIsReadOnly() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void createAppenderWillThrowWhenQueueIsReadOnly(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         assumeFalse(OS.isWindows());
         final File queueDir = getTmpDir();
         try (final ChronicleQueue queue = builder(queueDir, wireType).build();
@@ -221,8 +224,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 "\n";
     }
 
-    @Test
-    public void testTextReadWrite() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testTextReadWrite(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         File tmpDir = getTmpDir();
         try (final ChronicleQueue queue =
                      builderWithAppendListener(tmpDir, wireType)
@@ -244,8 +250,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 "\n";
     }
 
-    @Test
-    public void testCleanupDir() throws Throwable {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCleanupDir(@NotNull WireType wireType, boolean named) throws Throwable {
+        this.wireType = wireType;
+        this.named = named;
         if (OS.isWindows())
             FlakyTestRunner.builder(this::testCleanupDir0).build().run();
         else
@@ -269,8 +278,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         IOTools.deleteDirWithFilesOrThrow(tmpDir);
     }
 
-    @Test
-    public void testRollbackOnAppend() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testRollbackOnAppend(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue =
                      builder(getTmpDir(), wireType)
                              .build();
@@ -301,8 +313,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testWriteWithDocumentReadBytesDifferentThreads() throws InterruptedException, TimeoutException, ExecutionException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testWriteWithDocumentReadBytesDifferentThreads(@NotNull WireType wireType, boolean named) throws InterruptedException, TimeoutException, ExecutionException {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), wireType)
                 .build()) {
 
@@ -357,29 +372,37 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void shouldBlowUpIfTryingToCreateQueueWithUnparseableRollCycle() {
-        expectException("Overriding roll length from existing metadata");
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldBlowUpIfTryingToCreateQueueWithUnparseableRollCycle(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
+        assertThrows(IllegalStateException.class, () -> {
+            expectException("Overriding roll length from existing metadata");
 
-        File tmpDir = getTmpDir();
-        try (final ChronicleQueue queue = builder(tmpDir, wireType).rollCycle(new RollCycleDefaultingTest.MyRollcycle()).build();
-             final ExcerptAppender excerptAppender = queue.createAppender()) {
-            try (DocumentContext documentContext = excerptAppender.writingDocument()) {
-                documentContext.wire().write("somekey").text("somevalue");
+            File tmpDir = getTmpDir();
+            try (final ChronicleQueue queue = builder(tmpDir, wireType).rollCycle(new RollCycleDefaultingTest.MyRollcycle()).build();
+                 final ExcerptAppender excerptAppender = queue.createAppender()) {
+                try (DocumentContext documentContext = excerptAppender.writingDocument()) {
+                    documentContext.wire().write("somekey").text("somevalue");
+                }
             }
-        }
 
-        try (final ChronicleQueue ignored = builder(tmpDir, wireType).rollCycle(HOURLY).build()) {
-        }
+            try (final ChronicleQueue ignored = builder(tmpDir, wireType).rollCycle(HOURLY).build()) {
+            }
+        });
     }
 
-    @Test
-    public void testCanAppendMetadataIfAppendLockIsSet() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCanAppendMetadataIfAppendLockIsSet(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         File tmpDir = getTmpDir();
         try (final ChronicleQueue queue = builder(tmpDir, wireType).build()) {
             ((SingleChronicleQueue) queue).appendLock().lock();
             try (final ExcerptAppender appender = queue.createAppender()) {
-                Assume.assumeTrue("Failing in CQE", appender instanceof StoreAppender);
+                assumeTrue("Failing in CQE", appender instanceof StoreAppender);
                 try (DocumentContext dc = appender.writingDocument(true)) {
                     dc.wire().write("Hello World");
                 }
@@ -387,41 +410,54 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testCantAppendIfAppendLockIsSet() {
-        File tmpDir = getTmpDir();
-        try (final ChronicleQueue queue = builder(tmpDir, wireType).build()) {
-            ((SingleChronicleQueue) queue).appendLock().lock();
-            try (final ExcerptAppender appender = queue.createAppender()) {
-                appender.writeText("Hello World");
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCantAppendIfAppendLockIsSet(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
+        assertThrows(IllegalStateException.class, () -> {
+            File tmpDir = getTmpDir();
+            try (final ChronicleQueue queue = builder(tmpDir, wireType).build()) {
+                ((SingleChronicleQueue) queue).appendLock().lock();
+                try (final ExcerptAppender appender = queue.createAppender()) {
+                    appender.writeText("Hello World");
+                }
             }
-        }
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testCantAppendIfAppendLockIsSetInDifferentQueue() {
-        expectException("Overriding roll length from existing metadata");
-        expectException("Overriding roll cycle from");
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCantAppendIfAppendLockIsSetInDifferentQueue(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
+        assertThrows(IllegalStateException.class, () -> {
+            expectException("Overriding roll length from existing metadata");
+            expectException("Overriding roll cycle from");
 
-        File tmpDir = getTmpDir();
-        try (final ChronicleQueue queue = builder(tmpDir, wireType).build()) {
-            ((SingleChronicleQueue) queue).appendLock().lock();
-        }
+            File tmpDir = getTmpDir();
+            try (final ChronicleQueue queue = builder(tmpDir, wireType).build()) {
+                ((SingleChronicleQueue) queue).appendLock().lock();
+            }
 
-        try (final ChronicleQueue queue = builder(tmpDir, wireType).rollCycle(new RollCycleDefaultingTest.MyRollcycle()).build();
-             final ExcerptAppender excerptAppender = queue.createAppender()) {
-            excerptAppender.writeText("hello");
-        }
+            try (final ChronicleQueue queue = builder(tmpDir, wireType).rollCycle(new RollCycleDefaultingTest.MyRollcycle()).build();
+                 final ExcerptAppender excerptAppender = queue.createAppender()) {
+                excerptAppender.writeText("hello");
+            }
+        });
     }
 
-    @Test
-    public void testCanAppendWriteBytesInternalIfAppendLockIsSet() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCanAppendWriteBytesInternalIfAppendLockIsSet(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         @NotNull Bytes<byte[]> test = Bytes.from("hello world");
         File tmpDir = getTmpDir();
         try (final ChronicleQueue queue = builderWithAppendListener(tmpDir, wireType).build()) {
             ((SingleChronicleQueue) queue).appendLock().lock();
             try (final ExcerptAppender appender = queue.createAppender()) {
-                Assume.assumeTrue(appender instanceof StoreAppender);
+                assumeTrue(appender instanceof StoreAppender);
                 assumeTrue(appender instanceof StoreAppender);
                 StoreAppender storeAppender = (StoreAppender) appender;
                 ((SingleChronicleQueue) queue).writeLock().lock();
@@ -441,8 +477,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 "\n";
     }
 
-    @Test
-    public void shouldNotBlowUpIfTryingToCreateQueueWithIncorrectRollCycle() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldNotBlowUpIfTryingToCreateQueueWithIncorrectRollCycle(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         expectException("Overriding roll length from existing metadata");
         expectException("Overriding roll cycle from");
         File tmpDir = getTmpDir();
@@ -461,8 +500,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void shouldOverrideDifferentEpoch() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldOverrideDifferentEpoch(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         expectException("Overriding roll epoch from existing metadata, was 10, overriding to 100");
         File tmpDir = getTmpDir();
         final int shouldBeEpoch = 100;
@@ -478,8 +520,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadWriteHourly() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadWriteHourly(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         File tmpDir = getTmpDir();
         try (final ChronicleQueue qAppender = builder(tmpDir, wireType).rollCycle(HOURLY).build();
@@ -502,8 +547,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         return q.rollCycle().toSequenceNumber(index);
     }
 
-    @Test
-    public void shouldAllowDirectoryToBeDeletedWhenQueueIsClosed() throws IOException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldAllowDirectoryToBeDeletedWhenQueueIsClosed(@NotNull WireType wireType, boolean named) throws IOException {
+        this.wireType = wireType;
+        this.named = named;
         if (OS.isWindows()) {
             System.err.println("#460 Cannot test deleting after close on windows");
             return;
@@ -527,13 +575,16 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                     .filter(p -> !Files.isDirectory(p))
                     .filter(p -> !p.toFile().delete())
                     .collect(Collectors.toList());
-            assertTrue("Unable to delete " + unDeletable, unDeletable.isEmpty());
+            assertTrue(unDeletable.isEmpty(), "Unable to delete " + unDeletable);
         }
         assertTrue(dir.delete());
     }
 
-    @Test
-    public void testReadingLessBytesThanWritten() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingLessBytesThanWritten(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), wireType)
                 .build();
              final ExcerptAppender appender = queue.createAppender()) {
@@ -560,8 +611,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testAppendAndRead() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAppendAndRead(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = queue.createAppender()) {
@@ -585,15 +639,18 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             // Random read
             for (int i = 0; i < 10; i++) {
                 final int n = i;
-                assertTrue("n: " + n, tailer.moveToIndex(queue.rollCycle().toIndex(cycle, n)));
-                assertTrue("n: " + n, tailer.readDocument(r -> assertEquals(n, r.read(TestKey.test).int32())));
+                assertTrue(tailer.moveToIndex(queue.rollCycle().toIndex(cycle, n)), "n: " + n);
+                assertTrue(tailer.readDocument(r -> assertEquals(n, r.read(TestKey.test).int32())), "n: " + n);
                 assertEquals(n + 1, queue.rollCycle().toSequenceNumber(tailer.index()));
             }
         }
     }
 
-    @Test
-    public void testReadAndAppend() throws InterruptedException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadAndAppend(@NotNull WireType wireType, boolean named) throws InterruptedException {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType).build();
              final ExcerptAppender appender = queue.createAppender()) {
 
@@ -638,8 +695,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testCheckIndexWithWritingDocument() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCheckIndexWithWritingDocument(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         doTestCheckIndex(
                 (appender, n) -> {
                     try (final DocumentContext dc = appender.writingDocument()) {
@@ -648,8 +708,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 });
     }
 
-    @Test
-    public void testCheckIndexWithWritingDocument2() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCheckIndexWithWritingDocument2(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         doTestCheckIndex(
                 (appender, n) -> {
                     try (final DocumentContext dc = appender.writingDocument()) {
@@ -661,20 +724,29 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 });
     }
 
-    @Test
-    public void testCheckIndexWithWriteBytes() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCheckIndexWithWriteBytes(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         doTestCheckIndex(
                 (appender, n) -> appender.writeBytes(Bytes.from("Message-" + n)));
     }
 
-    @Test
-    public void testCheckIndexWithWriteBytes2() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCheckIndexWithWriteBytes2(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         doTestCheckIndex(
                 (appender, n) -> appender.writeBytes(b -> b.append8bit("Message-").append(n)));
     }
 
-    @Test
-    public void testCheckIndexWithWriteBytes3() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCheckIndexWithWriteBytes3(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         doTestCheckIndex(
                 (appender, n) -> appender.writeBytes(b ->
                         b.writeUtf8("Hello")
@@ -683,16 +755,22 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                                 .writeInt(1)));
     }
 
-    @Test
-    public void testCheckIndexWithWriteMap() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCheckIndexWithWriteMap(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         doTestCheckIndex(
                 (appender, n) -> appender.writeMap(new HashMap<String, String>() {{
                     put("key", "Message-" + n);
                 }}));
     }
 
-    @Test
-    public void testCheckIndexWithWriteText() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCheckIndexWithWriteText(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         doTestCheckIndex(
                 (appender, n) -> appender.writeText("Message-" + n)
         );
@@ -725,8 +803,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testAppendAndReadWithRollingB() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAppendAndReadWithRollingB(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         SetTimeProvider stp = new SetTimeProvider();
         stp.currentTimeMillis(System.currentTimeMillis() - 3 * 86400_000L);
 
@@ -758,19 +839,22 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 final int n = i;
                 boolean condition = tailer.readDocument(r -> assertEquals(n,
                         r.read(TestKey.test).int32()));
-                assertTrue("i : " + i, condition);
+                assertTrue(condition, "i : " + i);
                 assertEquals(cycle + i, tailer.cycle());
 
                 boolean condition2 = tailer.readDocument(r -> assertEquals(n + 1000,
                         r.read(TestKey.test2).int32()));
-                assertTrue("i2 : " + i, condition2);
+                assertTrue(condition2, "i2 : " + i);
                 assertEquals(cycle + i, tailer.cycle());
             }
         }
     }
 
-    @Test
-    public void testAppendAndReadAtIndex() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAppendAndReadAtIndex(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
                 .rollCycle(TEST2_DAILY)
                 .build();
@@ -798,8 +882,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testSimpleWire() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSimpleWire(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = chronicle.createAppender()) {
@@ -818,8 +905,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testIndexWritingDocument() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testIndexWritingDocument(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = chronicle.createAppender()) {
@@ -838,8 +928,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingWritingMarshallableDocument() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingWritingMarshallableDocument(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = chronicle.createAppender()) {
@@ -859,8 +952,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testMetaData() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMetaData(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         assumeFalse(named);
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
@@ -921,8 +1017,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingSecondDocumentNotExist() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingSecondDocumentNotExist(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = chronicle.createAppender()) {
@@ -945,8 +1044,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testDocumentIndexTest() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testDocumentIndexTest(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = chronicle.createAppender()) {
@@ -987,8 +1089,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingSecondDocumentNotExistIncludingMeta() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingSecondDocumentNotExistIncludingMeta(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = chronicle.createAppender()) {
@@ -1018,8 +1123,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testSimpleByteTest() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSimpleByteTest(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), wireType)
                 .rollCycle(TEST2_DAILY)
                 .build();
@@ -1046,8 +1154,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadAtIndex() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadAtIndex(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final RollingChronicleQueue queue = builder(getTmpDir(), wireType)
                 .indexCount(8)
                 .indexSpacing(8)
@@ -1072,9 +1183,8 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
             for (int i : new int[]{0, 8, 7, 9, 64, 65, 66}) {
                 final long index = queue.rollCycle().toIndex(cycle, i);
-                assertTrue("i: " + i,
-                        tailer.moveToIndex(
-                                index));
+                assertTrue(tailer.moveToIndex(
+                                index), "i: " + i);
                 try (final DocumentContext context = tailer.readingDocument()) {
                     assertEquals(index, context.index());
                     context.wire().read("key").text(sb);
@@ -1084,9 +1194,12 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Ignore("long running test")
-    @Test
-    public void testReadAtIndex4MB() {
+    @Disabled("long running test")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadAtIndex4MB(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.builder(getTmpDir(), this.wireType).rollCycle(SMALL_DAILY)
                 .build();
              final ExcerptAppender appender = queue.createAppender()) {
@@ -1111,8 +1224,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testMetaIndexTest() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMetaIndexTest(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         File tmpDir = getTmpDir();
         try (final ChronicleQueue q = builderWithAppendListener(tmpDir, wireType).rollCycle(HOURLY).build();
@@ -1235,8 +1351,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 appenderListenerDump.toString());
     }
 
-    @Test
-    public void testLastWrittenIndexPerAppender() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLastWrittenIndexPerAppender(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = queue.createAppender()) {
@@ -1246,28 +1365,38 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testLastWrittenIndexPerAppenderNoData() {
-        try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
-                .build();
-             final ExcerptAppender appender = chronicle.createAppender()) {
-            appender.lastIndexAppended();
-            fail();
-        }
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLastWrittenIndexPerAppenderNoData(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
+        assertThrows(IllegalStateException.class, () -> {
+            try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
+                    .build();
+                 final ExcerptAppender appender = chronicle.createAppender()) {
+                appender.lastIndexAppended();
+                fail();
+            }
+        });
     }
 
-    @Test(expected = IllegalStateException.class) //: no messages written
+    @Test //: no messages written
     public void testNoMessagesWritten() {
-        try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
-                .build();
-             final ExcerptAppender appender = chronicle.createAppender()) {
+        assertThrows(IllegalStateException.class, () -> {
+            try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
+                    .build();
+                 final ExcerptAppender appender = chronicle.createAppender()) {
 
-            appender.lastIndexAppended();
-        }
+                appender.lastIndexAppended();
+            }
+        });
     }
 
-    @Test
-    public void testHeaderIndexReadAtIndex() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testHeaderIndexReadAtIndex(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = queue.createAppender()) {
@@ -1292,8 +1421,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     /**
      * test that if we make EPOC the current time, then the cycle is == 0
      */
-    @Test
-    public void testEPOC() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testEPOC(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .epoch(System.currentTimeMillis())
                 .rollCycle(HOURLY)
@@ -1305,8 +1437,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void shouldBeAbleToReadFromQueueWithNonZeroEpoch() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldBeAbleToReadFromQueueWithNonZeroEpoch(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .epoch(System.currentTimeMillis())
                 .rollCycle(DEFAULT)
@@ -1321,8 +1456,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void shouldHandleLargeEpoch() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldHandleLargeEpoch(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .epoch(System.currentTimeMillis())
                 .epoch(1284739200000L)
@@ -1337,8 +1475,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testNegativeEPOC() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testNegativeEPOC(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         for (int h = -14; h <= 14; h++) {
             try (final ChronicleQueue chronicle = builder(getTmpDir(), wireType)
                     .epoch(TimeUnit.HOURS.toMillis(h))
@@ -1354,8 +1495,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testIndex() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testIndex(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
                 .rollCycle(HOURLY)
                 .build();
@@ -1388,8 +1532,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingDocument() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingDocument(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
                 .rollCycle(HOURLY)
                 .build();
@@ -1454,8 +1601,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingDocumentWithFirstAMove() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingDocumentWithFirstAMove(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
                 .rollCycle(HOURLY)
@@ -1508,8 +1658,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingDocumentWithFirstAMoveWithEpoch() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingDocumentWithFirstAMoveWithEpoch(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         Instant hourly = Instant.parse("2018-02-12T00:59:59.999Z");
         Instant minutely = Instant.parse("2018-02-12T00:00:59.999Z");
 
@@ -1588,8 +1741,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testAppendedBeforeToEnd() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAppendedBeforeToEnd(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         File dir = getTmpDir();
         try (ChronicleQueue chronicle = builder(dir, this.wireType)
                 .rollCycle(TEST_SECONDLY)
@@ -1618,8 +1774,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReentrant() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReentrant(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         File tmpDir = getTmpDir();
         try (final ChronicleQueue queue = binary(tmpDir)
@@ -1701,8 +1860,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         return "";
     }
 
-    @Test
-    public void testToEnd() throws InterruptedException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testToEnd(@NotNull WireType wireType, boolean named) throws InterruptedException {
+        this.wireType = wireType;
+        this.named = named;
         File dir = getTmpDir();
         try (ChronicleQueue queue = builder(dir, wireType)
                 .rollCycle(HOURLY)
@@ -1733,8 +1895,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testToEnd2() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testToEnd2(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         File dir = getTmpDir();
         try (ChronicleQueue chronicle = builder(dir, wireType)
                 .build();
@@ -1755,8 +1920,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testToEndOnDeletedQueueFiles() throws IOException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testToEndOnDeletedQueueFiles(@NotNull WireType wireType, boolean named) throws IOException {
+        this.wireType = wireType;
+        this.named = named;
         if (OS.isWindows()) {
             System.err.println("#460 Cannot test delete after close on windows");
             return;
@@ -1779,7 +1947,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             try (Stream<Path> cq4Files = Files.find(dir.toPath(), 1, (p, basicFileAttributes) -> p.toString().endsWith("cq4"), FileVisitOption.FOLLOW_LINKS)) {
                 final List<Path> unDeletable = cq4Files.filter(path -> !path.toFile().delete())
                         .collect(Collectors.toList());
-                assertTrue("Unable to delete" + unDeletable, unDeletable.isEmpty());
+                assertTrue(unDeletable.isEmpty(), "Unable to delete" + unDeletable);
             }
 
             try (ChronicleQueue q2 = builder(dir, wireType).build();
@@ -1794,8 +1962,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadWrite() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadWrite(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         File dir = getTmpDir();
         try (ChronicleQueue chronicle = builder(dir, wireType)
                 .rollCycle(HOURLY)
@@ -1831,8 +2002,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingDocumentForEmptyQueue() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingDocumentForEmptyQueue(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         File dir = getTmpDir();
         try (ChronicleQueue chronicle = builder(dir, this.wireType)
                 .rollCycle(HOURLY)
@@ -1861,8 +2035,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testMetaData6() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMetaData6(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         assumeFalse(named);
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .rollCycle(TEST2_DAILY)
@@ -1984,8 +2161,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         throw new IllegalStateException("unknown type " + wireType);
     }
 
-    @Test
-    public void testToEndBeforeWrite() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testToEndBeforeWrite(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), wireType)
                 .rollCycle(TEST2_DAILY)
                 .build();
@@ -2003,8 +2183,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testForwardFollowedBackBackwardTailer() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testForwardFollowedBackBackwardTailer(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .rollCycle(TEST2_DAILY)
                 .build();
@@ -2023,8 +2206,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void shouldReadBackwardFromEndOfQueueWhenDirectionIsSetAfterMoveToEnd() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldReadBackwardFromEndOfQueueWhenDirectionIsSetAfterMoveToEnd(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue queue = builder(getTmpDir(), this.wireType)
                 .rollCycle(TEST2_DAILY)
                 .build();
@@ -2073,7 +2259,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             try (DocumentContext documentContext = backwardTailer.readingDocument()) {
                 assertTrue(documentContext.isPresent());
                 final long index = documentContext.index();
-                assertEquals("index: " + index, i, (int) index);
+                assertEquals(i, (int) index, "index: " + index);
                 assertEquals(i, DEFAULT.toSequenceNumber(index));
                 assertTrue(documentContext.isPresent());
                 sb.setLength(0);
@@ -2088,8 +2274,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testOverreadForwardFromFutureCycleThenReadBackwardTailer() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testOverreadForwardFromFutureCycleThenReadBackwardTailer(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         RollCycle cycle = TEST2_DAILY;
         // when "forwardToFuture" flag is set, go one cycle to the future
         AtomicBoolean forwardToFuture = new AtomicBoolean(false);
@@ -2129,8 +2318,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testSomeMessages() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSomeMessages(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), wireType)
                 .rollCycle(TEST2_DAILY)
                 .build();
@@ -2151,8 +2343,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testZeroLengthMessage() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testZeroLengthMessage(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), wireType)
                 .rollCycle(TEST_DAILY)
                 .build();
@@ -2168,8 +2363,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testMoveToWithAppender() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMoveToWithAppender(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (ChronicleQueue syncQ = builder(getTmpDir(), this.wireType)
                 .build();
              InternalAppender sync = (InternalAppender) syncQ.createAppender()) {
@@ -2196,8 +2394,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testMapWrapper() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMapWrapper(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (ChronicleQueue syncQ = builder(getTmpDir(), this.wireType)
                 .build()) {
 
@@ -2221,8 +2422,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testLastIndexAppended() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLastIndexAppended(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
              ExcerptAppender appender = chronicle.createAppender()) {
@@ -2236,8 +2440,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testAppendedSkipToEndMultiThreaded() throws InterruptedException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAppendedSkipToEndMultiThreaded(@NotNull WireType wireType, boolean named) throws InterruptedException {
+        this.wireType = wireType;
+        this.named = named;
         // some text to simulate load.
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < 5; i++) sb.append(UUID.randomUUID());
@@ -2287,8 +2494,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
      * if one appender if much further ahead than the other, then the new append should jump straight to the end rather than attempting to write a
      * positions that are already occupied
      */
-    @Test
-    public void testAppendedSkipToEnd() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testAppendedSkipToEnd(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         try (ChronicleQueue q = builder(getTmpDir(), this.wireType)
                 .build();
@@ -2311,8 +2521,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testToEndPrevCycleEOF() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testToEndPrevCycleEOF(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
         File dir = getTmpDir();
         try (ChronicleQueue q = builder(dir, wireType)
@@ -2377,10 +2590,13 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     }
 
-    @Ignore("Long Running Test")
-    @Test
-    public void testRandomConcurrentReadWrite() throws
+    @Disabled("Long Running Test")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testRandomConcurrentReadWrite(@NotNull WireType wireType, boolean named) throws
             InterruptedException {
+        this.wireType = wireType;
+        this.named = named;
 
         // some text to simulate load.
         StringBuilder sb = new StringBuilder();
@@ -2413,8 +2629,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testTailerWhenCyclesWhereSkippedOnWrite() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testTailerWhenCyclesWhereSkippedOnWrite(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
 
         try (final ChronicleQueue queue = binary(getTmpDir())
@@ -2485,8 +2704,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testMultipleAppenders() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMultipleAppenders(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (ChronicleQueue syncQ = builder(getTmpDir(), this.wireType)
                 .rollCycle(TEST_DAILY)
                 .timeProvider(new SetTimeProvider("2020/10/19T01:01:01"))
@@ -2600,8 +2822,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         throw new IllegalStateException("unknown wiretype=" + wireType);
     }
 
-    @Test
-    public void shouldNotGenerateGarbageReadingDocumentAfterEndOfFile() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldNotGenerateGarbageReadingDocumentAfterEndOfFile(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
         File dir = getTmpDir();
         try (ChronicleQueue q = builder(dir, wireType)
@@ -2637,8 +2862,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingWritingWhenNextCycleIsInSequence() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingWritingWhenNextCycleIsInSequence(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
 
         final File dir = getTmpDir();
@@ -2669,8 +2897,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingWritingWhenCycleIsSkipped() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingWritingWhenCycleIsSkipped(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         SetTimeProvider timeProvider = new SetTimeProvider();
 
@@ -2703,8 +2934,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadingWritingWhenCycleIsSkippedBackwards() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadingWritingWhenCycleIsSkippedBackwards(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         final SetTimeProvider timeProvider = new SetTimeProvider();
         long time = System.currentTimeMillis();
         timeProvider.currentTimeMillis(time);
@@ -2735,8 +2969,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testReadWritingWithTimeProvider() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadWritingWithTimeProvider(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         final File dir = getTmpDir();
 
         long time = System.currentTimeMillis();
@@ -2779,8 +3016,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testCountExceptsBetweenCycles() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCountExceptsBetweenCycles(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
 
         try (final RollingChronicleQueue queue = binary(getTmpDir())
@@ -2827,8 +3067,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testLongLivingTailerAppenderReAcquiredEachSecond() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLongLivingTailerAppenderReAcquiredEachSecond(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
         final File dir = getTmpDir();
         final RollCycle rollCycle = TEST4_SECONDLY;
@@ -2872,20 +3115,27 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testCountExceptsWithRubbishData() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCountExceptsWithRubbishData(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
+        assertThrows(IllegalStateException.class, () -> {
+            try (final RollingChronicleQueue queue = binary(getTmpDir())
+                    .rollCycle(TEST_SECONDLY)
+                    .build()) {
 
-        try (final RollingChronicleQueue queue = binary(getTmpDir())
-                .rollCycle(TEST_SECONDLY)
-                .build()) {
-
-            // rubbish data
-            queue.countExcerpts(0x578F542D00000000L, 0x528F542D00000000L);
-        }
+                // rubbish data
+                queue.countExcerpts(0x578F542D00000000L, 0x528F542D00000000L);
+            }
+        });
     }
 
-    @Test
-    public void testFromSizePrefixedBlobs() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testFromSizePrefixedBlobs(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         try (final ChronicleQueue queue = binary(getTmpDir())
                 .build();
@@ -2909,8 +3159,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void tailerRollBackTest() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void tailerRollBackTest(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         final File source = getTmpDir();
         try (final ChronicleQueue q = binary(source).build();
              final ExcerptAppender appender = q.createAppender()) {
@@ -2925,8 +3178,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testCopyQueue() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testCopyQueue(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         final File source = getTmpDir();
         final File target = getTmpDir();
         {
@@ -2966,8 +3222,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     /**
      * see https://github.com/OpenHFT/Chronicle-Queue/issues/299
      */
-    @Test
-    public void testIncorrectExcerptTailerReadsAfterSwitchingTailerDirection() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testIncorrectExcerptTailerReadsAfterSwitchingTailerDirection(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         try (final ChronicleQueue queue = binary(getTmpDir())
                 .rollCycle(DAILY).build();
@@ -3016,8 +3275,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void testExistingRollCycleIsMaintained() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testExistingRollCycleIsMaintained(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         expectException("Overriding roll cycle from ");
         expectException("Overriding roll length from ");
 
@@ -3047,8 +3309,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void checkReferenceCountingAndCheckFileDeletion() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void checkReferenceCountingAndCheckFileDeletion(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         MappedFile mappedFile;
 
@@ -3079,8 +3344,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
     }
 
-    @Test
-    public void checkReferenceCountingWhenRollingAndCheckFileDeletion() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void checkReferenceCountingWhenRollingAndCheckFileDeletion(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
 
         @SuppressWarnings("unused")
@@ -3129,8 +3397,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         assertTrue(mappedFile2.file().delete());
     }
 
-    @Test(timeout = 10_000)
-    public void testWritingDocumentIsAtomic() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testWritingDocumentIsAtomic(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         final int threadCount = 8;
         final ExecutorService executorService = Executors.newFixedThreadPool(threadCount,
@@ -3188,8 +3459,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void shouldBeAbleToLoadQueueFromReadOnlyFiles() throws IOException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldBeAbleToLoadQueueFromReadOnlyFiles(@NotNull WireType wireType, boolean named) throws IOException {
+        this.wireType = wireType;
+        this.named = named;
         if (OS.isWindows()) {
             System.err.println("#460 Cannot test read only mode on windows");
             return;
@@ -3216,8 +3490,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void shouldCreateQueueInCurrentDirectory() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldCreateQueueInCurrentDirectory(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         if (OS.isWindows()) {
             System.err.println("#460 Cannot test delete after close on windows");
             return;
@@ -3237,8 +3514,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         return SingleChronicleQueueBuilder.builder(file, wireType).rollCycle(TEST4_DAILY).testBlockSize();
     }
 
-    @Test
-    public void testTailerSnappingRollWithNewAppender() throws InterruptedException, ExecutionException, TimeoutException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testTailerSnappingRollWithNewAppender(@NotNull WireType wireType, boolean named) throws InterruptedException, ExecutionException, TimeoutException {
+        this.wireType = wireType;
+        this.named = named;
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.currentTimeMillis(System.currentTimeMillis() - 2_000);
         final File dir = getTmpDir();
@@ -3319,8 +3599,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         return mappedFile;
     }
 
-    @Test
-    public void writeBytesAndIndexFiveTimesWithOverwriteTest() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void writeBytesAndIndexFiveTimesWithOverwriteTest(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue sourceQueue =
                      builder(getTmpDir(), wireType).
                              testBlockSize().build();
@@ -3389,8 +3672,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void writeBytesAndIndexFiveTimesTest() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void writeBytesAndIndexFiveTimesTest(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         try (final ChronicleQueue sourceQueue =
                      builder(getTmpDir(), wireType).
                              testBlockSize().build();
@@ -3434,8 +3720,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void rollbackTest() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void rollbackTest(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
 
         File file = getTmpDir();
         try (final ChronicleQueue sourceQueue =
@@ -3527,10 +3816,13 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void mappedSegmentsShouldBeUnmappedAsCycleRolls() throws IOException, InterruptedException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void mappedSegmentsShouldBeUnmappedAsCycleRolls(@NotNull WireType wireType, boolean named) throws IOException, InterruptedException {
+        this.wireType = wireType;
+        this.named = named;
 
-        Assume.assumeTrue("this test is slow and does not depend on wire type", wireType == WireType.BINARY);
+        assumeTrue("this test is slow and does not depend on wire type", wireType == WireType.BINARY);
 
         long now = System.currentTimeMillis();
         long ONE_HOUR_IN_MILLIS = 60 * 60 * 1000;
@@ -3609,9 +3901,12 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     /**
      * relates to https://github.com/OpenHFT/Chronicle-Queue/issues/699
      */
-    @Test
-    public void testReadUsingReadOnly() {
-        assumeFalse("Read-only mode is not supported on Windows", OS.isWindows());
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testReadUsingReadOnly(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
+        assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
         assumeFalse(named);
 
         File tmpDir = getTmpDir();
@@ -3634,12 +3929,15 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 dc.wire().getValueIn().text(sb);
             }
 
-            Assert.assertEquals(expected, sb.toString());
+            assertEquals(expected, sb.toString());
         }
     }
 
-    @Test
-    public void lastIndexShouldReturnLastIndexForPopulatedQueue() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void lastIndexShouldReturnLastIndexForPopulatedQueue(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         File tmpDir = getTmpDir();
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(tmpDir).wireType(wireType).build()) {
             assertEquals(-1, queue.lastIndex());
@@ -3653,16 +3951,22 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void lastIndexShouldReturnNegativeOneForEmptyQueue() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void lastIndexShouldReturnNegativeOneForEmptyQueue(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         File tmpDir = getTmpDir();
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(tmpDir).wireType(wireType).build()) {
             assertEquals(-1, queue.lastIndex());
         }
     }
 
-    @Test
-    public void lastIndexShouldReturnNegativeOneForMetadataOnlyQueue() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void lastIndexShouldReturnNegativeOneForMetadataOnlyQueue(@NotNull WireType wireType, boolean named) {
+        this.wireType = wireType;
+        this.named = named;
         File tmpDir = getTmpDir();
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.single(tmpDir).wireType(wireType).build()) {
             try (ExcerptAppender appender = queue.createAppender()) {
@@ -3674,8 +3978,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test
-    public void shouldWaitForConditionWhenCreatingAppender() throws TimeoutException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldWaitForConditionWhenCreatingAppender(@NotNull WireType wireType, boolean named) throws TimeoutException {
+        this.wireType = wireType;
+        this.named = named;
         File tmpDir = getTmpDir();
         AtomicBoolean gotAppender = new AtomicBoolean(false);
         ReentrantLock createAppenderLock = new ReentrantLock();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -1372,27 +1372,21 @@ class SingleChronicleQueueTest extends QueueTestCommon {
     void testLastWrittenIndexPerAppenderNoData(@NotNull WireType wireType, boolean named) {
         this.wireType = wireType;
         this.named = named;
-        assertThrows(IllegalStateException.class, () -> {
-            try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
-                    .build();
-                 final ExcerptAppender appender = chronicle.createAppender()) {
-                appender.lastIndexAppended();
-                fail();
-            }
-        });
+        try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
+                .build();
+             final ExcerptAppender appender = chronicle.createAppender()) {
+            assertThrows(IllegalStateException.class, appender::lastIndexAppended);
+        }
     }
 
     @Test
         //: no messages written
     void testNoMessagesWritten() {
-        assertThrows(IllegalStateException.class, () -> {
-            try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
-                    .build();
-                 final ExcerptAppender appender = chronicle.createAppender()) {
-
-                appender.lastIndexAppended();
-            }
-        });
+        try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
+                .build();
+             final ExcerptAppender appender = chronicle.createAppender()) {
+            assertThrows(IllegalStateException.class, appender::lastIndexAppended);
+        }
     }
 
     @ParameterizedTest

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
@@ -23,7 +23,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-public class SparseBinarySearchTest extends QueueTestCommon {
+class SparseBinarySearchTest extends QueueTestCommon {
 
     private static final GapTolerantComparator GAP_TOLERANT_COMPARATOR = new GapTolerantComparator();
 
@@ -42,13 +42,13 @@ public class SparseBinarySearchTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testBinarySearchWithManyGapsAndManyRollCycles(int numberOfMessages, float percentageWithValues) throws ParseException {
+    void testBinarySearchWithManyGapsAndManyRollCycles(int numberOfMessages, float percentageWithValues) throws ParseException {
         runWithTimeParameters(TEST_SECONDLY, 300, numberOfMessages, percentageWithValues);
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testBinarySearchWithManyGaps(int numberOfMessages, float percentageWithValues) throws ParseException {
+    void testBinarySearchWithManyGaps(int numberOfMessages, float percentageWithValues) throws ParseException {
         runWithTimeParameters(DAILY, 1, numberOfMessages, percentageWithValues);
     }
 
@@ -145,7 +145,7 @@ public class SparseBinarySearchTest extends QueueTestCommon {
         return wire;
     }
 
-    public static class MyData extends SelfDescribingMarshallable {
+    static class MyData extends SelfDescribingMarshallable {
         private int key;
         private String value;
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SparseBinarySearchTest.java
@@ -12,35 +12,22 @@ import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.ParseException;
 import java.util.*;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.DAILY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RequiredForClient
-@RunWith(Parameterized.class)
 public class SparseBinarySearchTest extends QueueTestCommon {
 
     private static final GapTolerantComparator GAP_TOLERANT_COMPARATOR = new GapTolerantComparator();
 
-    private final int numberOfMessages;
-    private final float percentageWithValues;
-
-    public SparseBinarySearchTest(int numberOfMessages, float percentageWithValues) {
-        this.numberOfMessages = numberOfMessages;
-        this.percentageWithValues = percentageWithValues;
-    }
-
-    @Parameterized.Parameters(name = "items in queue: {0}, percentage with values: {1}")
-    public static Collection<Object[]> data() {
+    public static List<Object[]> data() {
         List<Object[]> parameters = new ArrayList<>();
         List<Integer> numbersOfMessages = Arrays.asList(0, 1, 2, 100);
         List<Float> percentagesWithValues = Arrays.asList(0.0f, 0.1f, 0.9f);
@@ -53,17 +40,19 @@ public class SparseBinarySearchTest extends QueueTestCommon {
         return parameters;
     }
 
-    @Test
-    public void testBinarySearchWithManyGapsAndManyRollCycles() throws ParseException {
-        runWithTimeParameters(TEST_SECONDLY, 300);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testBinarySearchWithManyGapsAndManyRollCycles(int numberOfMessages, float percentageWithValues) throws ParseException {
+        runWithTimeParameters(TEST_SECONDLY, 300, numberOfMessages, percentageWithValues);
     }
 
-    @Test
-    public void testBinarySearchWithManyGaps() throws ParseException {
-        runWithTimeParameters(DAILY, 1);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testBinarySearchWithManyGaps(int numberOfMessages, float percentageWithValues) throws ParseException {
+        runWithTimeParameters(DAILY, 1, numberOfMessages, percentageWithValues);
     }
 
-    private void runWithTimeParameters(RollCycle rollCycle, long incrementInMillis) throws ParseException {
+    private void runWithTimeParameters(RollCycle rollCycle, long incrementInMillis, int numberOfMessages, float percentageWithValues) throws ParseException {
         final SetTimeProvider stp = new SetTimeProvider();
         stp.currentTimeMillis(0);
 
@@ -97,7 +86,7 @@ public class SparseBinarySearchTest extends QueueTestCommon {
                         Wire key = toWire(j);
                         long index = BinarySearch.search(binarySearchTailer, key, GAP_TOLERANT_COMPARATOR);
                         if (entriesWithValues.contains(j)) {
-                            Assert.assertEquals(tailer.index(), index);
+                            assertEquals(tailer.index(), index);
                         } else {
                             assertTrue(index < 0);
                         }
@@ -106,7 +95,7 @@ public class SparseBinarySearchTest extends QueueTestCommon {
                 }
 
                 Wire key = toWire(numberOfMessages);
-                assertTrue("Should not find non-existent", BinarySearch.search(tailer, key, GAP_TOLERANT_COMPARATOR) < 0);
+                assertTrue(BinarySearch.search(tailer, key, GAP_TOLERANT_COMPARATOR) < 0, "Should not find non-existent");
             }
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
@@ -37,7 +37,7 @@ class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
     @BeforeEach
     void beforeEachStoreAppenderInternalWriteBytesTest() {
         check64bit();
-        public threadDump();
+        threadDump();
     }
 
     public void check64bit() {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
@@ -30,14 +30,14 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_SECOND
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
+class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
 
     private static final int MESSAGES_TO_WRITE = 200;
 
     @BeforeEach
-    public void beforeEachStoreAppenderInternalWriteBytesTest() {
+    void beforeEachStoreAppenderInternalWriteBytesTest() {
         check64bit();
-        threadDump();
+        public threadDump();
     }
 
     public void check64bit() {
@@ -50,12 +50,12 @@ public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void internalWriteBytesShouldBeIdempotentUnderConcurrentUpdates() throws InterruptedException {
+    void internalWriteBytesShouldBeIdempotentUnderConcurrentUpdates() throws InterruptedException {
         testInternalWriteBytes(5, true);
     }
 
     @Test
-    public void internalWriteBytesShouldBeIdempotent() throws InterruptedException {
+    void internalWriteBytesShouldBeIdempotent() throws InterruptedException {
         testInternalWriteBytes(5, false);
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
@@ -13,8 +13,8 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -27,22 +27,24 @@ import java.util.concurrent.TimeUnit;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_SECONDLY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeNotNull;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
 
     private static final int MESSAGES_TO_WRITE = 200;
 
-    @Before
+    @BeforeEach
+    public void beforeEachStoreAppenderInternalWriteBytesTest() {
+        check64bit();
+        threadDump();
+    }
+
     public void check64bit() {
         assumeTrue(Jvm.is64bit());
     }
 
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
@@ -122,8 +124,7 @@ public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
                     assert sourceTailer.readBytes(sourceBuffer) : "Source queue is shorter than expected";
                     assert destinationTailer.readBytes(destinationBuffer) : "Destination queue is shorter than expected";
                     final String s = destinationBuffer.toString();
-                    assertEquals(format("Mismatch at index %s/%s was %s", Long.toHexString(sourceIndex), Long.toHexString(destinationIndex), s),
-                            sourceBuffer.toString(), s.replaceAll(" - .*", ""));
+                    assertEquals(sourceBuffer.toString(), s.replaceAll(" - .*", ""), format("Mismatch at index %s/%s was %s", Long.toHexString(sourceIndex), Long.toHexString(destinationIndex), s));
                 }
             }
         }
@@ -176,8 +177,8 @@ public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
 //                        if (false && index %17 == 0) {
                         try (final ChronicleQueue dq = createQueue(destinationDir, null);
                              final ExcerptAppender da = dq.createAppender()) {
-                            assumeNotNull(dq);
-                            assumeNotNull(da);
+                            assumeTrue(dq != null);
+                            assumeTrue(da != null);
                         }
                         //                      }
                     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -11,36 +11,36 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.WriteAfterEOFException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StoreAppenderTest extends QueueTestCommon {
 
     private static final String TEST_TEXT = "Some text some text some text";
     private static final long ONE_DAY = TimeUnit.DAYS.toMillis(1);
 
-    @Rule
-    public final TemporaryFolder queueDirectory = new TemporaryFolder();
+    @TempDir
+    Path queueDirectory;
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
 
     @Test
     public void writingDocumentAcquisitionWorksAfterInterruptedAttempt() throws InterruptedException, IOException {
-        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder()).build()) {
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(Files.createTempDirectory(queueDirectory, "queue").toFile()).build()) {
             final BlockingWriter blockingWriter = new BlockingWriter(queue);
             final BlockedWriter blockedWriter = new BlockedWriter(queue);
 
@@ -67,7 +67,7 @@ public class StoreAppenderTest extends QueueTestCommon {
 
         clock.addAndGet(-clock.get() % ONE_DAY);
 
-        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder())
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(Files.createTempDirectory(queueDirectory, "queue").toFile())
                 .timeProvider(clock::get)
                 .build();
              final ExcerptAppender appender = queue.createAppender()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class StoreAppenderTest extends QueueTestCommon {
+class StoreAppenderTest extends QueueTestCommon {
 
     private static final String TEST_TEXT = "Some text some text some text";
     private static final long ONE_DAY = TimeUnit.DAYS.toMillis(1);
@@ -39,7 +39,7 @@ public class StoreAppenderTest extends QueueTestCommon {
     }
 
     @Test
-    public void writingDocumentAcquisitionWorksAfterInterruptedAttempt() throws InterruptedException, IOException {
+    void writingDocumentAcquisitionWorksAfterInterruptedAttempt() throws InterruptedException, IOException {
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(Files.createTempDirectory(queueDirectory, "queue").toFile()).build()) {
             final BlockingWriter blockingWriter = new BlockingWriter(queue);
             final BlockedWriter blockedWriter = new BlockedWriter(queue);
@@ -62,7 +62,7 @@ public class StoreAppenderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testCanWriteAfterWriteAfterEOFExceptionIsThrown() throws IOException {
+    void testCanWriteAfterWriteAfterEOFExceptionIsThrown() throws IOException {
         final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
 
         clock.addAndGet(-clock.get() % ONE_DAY);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
@@ -16,9 +16,8 @@ import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.WireType;
 import net.openhft.chronicle.wire.Wires;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -29,15 +28,16 @@ import java.util.function.Supplier;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 @SuppressWarnings("this-escape")
 public class StoreTailerTest extends QueueTestCommon {
     private final Path dataDirectory = getTmpDir().toPath();
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
@@ -59,7 +59,7 @@ public class StoreTailerTest extends QueueTestCommon {
 
     @Test
     public void shouldHandleCycleRollWhenInReadOnlyMode() {
-        assumeFalse("Read-only mode is not supported on Windows", OS.isWindows());
+        assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
         final MutableTimeProvider timeProvider = new MutableTimeProvider();
         try (ChronicleQueue queue = build(createQueue(dataDirectory, MINUTELY, 0, "cycleRoll", false).
@@ -113,7 +113,7 @@ public class StoreTailerTest extends QueueTestCommon {
 
             append.writeDocument(w -> w.write("test").text("text"));
 
-            if (!tailer.readDocument(w -> w.read("test").text("text", Assert::assertEquals))) {
+            if (!tailer.readDocument(w -> w.read("test").text("text", Assertions::assertEquals))) {
                 // System.out.println("dump chronicle:\n" + chronicle.dump());
                 // System.out.println("dump chronicle2:\n" + chronicle2.dump());
                 fail("readDocument false");
@@ -432,40 +432,44 @@ public class StoreTailerTest extends QueueTestCommon {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void cantMoveToStartDuringDocumentReading() {
-        File dir = getTmpDir();
-        try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
-                .testBlockSize().build();
-             ExcerptTailer tailer = queue.createTailer();
-             ExcerptAppender appender = queue.createAppender()) {
-            appender.writeText("Hello World");
-            try (DocumentContext dc = tailer.readingDocument(true)) {
-                assertTrue(dc.isPresent());
-                assertTrue(dc.isMetaData());
-                assertEquals("header", dc.wire().readEvent(String.class));
-                assertTrue(tailer.toString().contains("StoreTailer{"));
-                tailer.toStart(); // forbidden
+        assertThrows(IllegalStateException.class, () -> {
+            File dir = getTmpDir();
+            try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
+                    .testBlockSize().build();
+                 ExcerptTailer tailer = queue.createTailer();
+                 ExcerptAppender appender = queue.createAppender()) {
+                appender.writeText("Hello World");
+                try (DocumentContext dc = tailer.readingDocument(true)) {
+                    assertTrue(dc.isPresent());
+                    assertTrue(dc.isMetaData());
+                    assertEquals("header", dc.wire().readEvent(String.class));
+                    assertTrue(tailer.toString().contains("StoreTailer{"));
+                    tailer.toStart(); // forbidden
+                }
             }
-        }
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void cantMoveToEndDuringDocumentReading() {
-        File dir = getTmpDir();
-        try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
-                .testBlockSize().build();
-             ExcerptTailer tailer = queue.createTailer();
-             ExcerptAppender appender = queue.createAppender()) {
-            appender.writeText("Hello World");
-            try (DocumentContext dc = tailer.readingDocument(true)) {
-                assertTrue(dc.isPresent());
-                assertTrue(dc.isMetaData());
-                assertEquals("header", dc.wire().readEvent(String.class));
-                assertTrue(tailer.toString().contains("StoreTailer{"));
-                tailer.toEnd(); // forbidden
+        assertThrows(IllegalStateException.class, () -> {
+            File dir = getTmpDir();
+            try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
+                    .testBlockSize().build();
+                 ExcerptTailer tailer = queue.createTailer();
+                 ExcerptAppender appender = queue.createAppender()) {
+                appender.writeText("Hello World");
+                try (DocumentContext dc = tailer.readingDocument(true)) {
+                    assertTrue(dc.isPresent());
+                    assertTrue(dc.isMetaData());
+                    assertEquals("header", dc.wire().readEvent(String.class));
+                    assertTrue(tailer.toString().contains("StoreTailer{"));
+                    tailer.toEnd(); // forbidden
+                }
             }
-        }
+        });
     }
 
     @Test
@@ -550,15 +554,15 @@ public class StoreTailerTest extends QueueTestCommon {
 
             int cycle = queue.cycle();
 
-            assertEquals("No excerpts should be present initially", -1, tailer.excerptsInCycle(cycle));
+            assertEquals(-1, tailer.excerptsInCycle(cycle), "No excerpts should be present initially");
 
             appender.writeText("Message 1");
             appender.writeText("Message 2");
 
-            assertEquals("Should have 2 excerpts in cycle", 2, tailer.excerptsInCycle(cycle));
+            assertEquals(2, tailer.excerptsInCycle(cycle), "Should have 2 excerpts in cycle");
 
             int nonExistentCycle = cycle + 1;
-            assertEquals("Excerpts in non-existent cycle should be -1", -1, tailer.excerptsInCycle(nonExistentCycle));
+            assertEquals(-1, tailer.excerptsInCycle(nonExistentCycle), "Excerpts in non-existent cycle should be -1");
         }
     }
 
@@ -569,15 +573,15 @@ public class StoreTailerTest extends QueueTestCommon {
                 .testBlockSize().build();
              ExcerptTailer tailer = queue.createTailer()) {
             // Negative index
-            assertFalse("Should not move to a negative index", tailer.moveToIndex(-1));
+            assertFalse(tailer.moveToIndex(-1), "Should not move to a negative index");
 
             // Index beyond the last index
-            assertFalse("Should not move to an index beyond the last index", tailer.moveToIndex(100));
+            assertFalse(tailer.moveToIndex(100), "Should not move to an index beyond the last index");
 
             // Index in a non-existent cycle
             int nonExistentCycle = queue.rollCycle().toCycle(tailer.index()) + 10;
             long nonExistentIndex = queue.rollCycle().toIndex(nonExistentCycle, 0);
-            assertFalse("Should not move to an index in a non-existent cycle", tailer.moveToIndex(nonExistentIndex));
+            assertFalse(tailer.moveToIndex(nonExistentIndex), "Should not move to an index in a non-existent cycle");
         }
     }
 
@@ -598,10 +602,10 @@ public class StoreTailerTest extends QueueTestCommon {
             assertEquals("Message 3", tailer.readText());
             assertEquals("Message 2", tailer.readText());
             assertEquals("Message 1", tailer.readText());
-            assertNull("Should be null", tailer.readText());
+            assertNull(tailer.readText(), "Should be null");
 
             tailer.direction(TailerDirection.FORWARD);
-            assertNull("Should be null", tailer.readText());
+            assertNull(tailer.readText(), "Should be null");
             assertEquals("Message 1", tailer.readText());
             assertEquals("Message 2", tailer.readText());
             assertEquals("Message 3", tailer.readText());
@@ -615,12 +619,12 @@ public class StoreTailerTest extends QueueTestCommon {
                 .testBlockSize().build();
              ExcerptTailer tailer = queue.createTailer()) {
 
-            assertNull("Should return null when reading from an empty queue", tailer.readText());
+            assertNull(tailer.readText(), "Should return null when reading from an empty queue");
 
             tailer.toStart();
             tailer.toEnd();
 
-            assertNull("Should still return null after moving to end", tailer.readText());
+            assertNull(tailer.readText(), "Should still return null after moving to end");
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
@@ -28,12 +28,14 @@ import java.util.function.Supplier;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
+
 import org.junit.jupiter.api.Assertions;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 @SuppressWarnings("this-escape")
-public class StoreTailerTest extends QueueTestCommon {
+class StoreTailerTest extends QueueTestCommon {
     private final Path dataDirectory = getTmpDir().toPath();
 
     @Override
@@ -43,7 +45,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testEntryCount() {
+    void testEntryCount() {
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dataDirectory).build();
              final ExcerptAppender appender = queue.createAppender()) {
             assertEquals(0, queue.entryCount());
@@ -58,7 +60,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldHandleCycleRollWhenInReadOnlyMode() {
+    void shouldHandleCycleRollWhenInReadOnlyMode() {
         assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
         final MutableTimeProvider timeProvider = new MutableTimeProvider();
@@ -95,7 +97,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldHandleCycleRoll() {
+    void shouldHandleCycleRoll() {
         File dir = getTmpDir();
         MutableTimeProvider timeProvider = new MutableTimeProvider();
         timeProvider.setTime(System.currentTimeMillis());
@@ -122,7 +124,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldHaltAtPartiallyInitialisedRollCycle() throws ExecutionException, InterruptedException {
+    void shouldHaltAtPartiallyInitialisedRollCycle() throws ExecutionException, InterruptedException {
         // Windows doesn't support renaming a file that is open.
         assumeFalse(OS.isWindows());
         expectException("Renamed un-acquirable segment file to");
@@ -217,7 +219,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void disableThreadSafety() throws InterruptedException {
+    void disableThreadSafety() throws InterruptedException {
         new ThreadSafetyTestingTemplate() {
 
             @Override
@@ -240,7 +242,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void disableThreadSafetyWithMethodReader() throws InterruptedException {
+    void disableThreadSafetyWithMethodReader() throws InterruptedException {
         new ThreadSafetyTestingTemplate() {
 
             @Override
@@ -265,7 +267,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void clearUsedByThread() throws InterruptedException {
+    void clearUsedByThread() throws InterruptedException {
         new ThreadSafetyTestingTemplate() {
 
             @Override
@@ -288,7 +290,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void clearUsedByThreadWithMethodReader() throws InterruptedException {
+    void clearUsedByThreadWithMethodReader() throws InterruptedException {
         new ThreadSafetyTestingTemplate() {
 
             @Override
@@ -326,7 +328,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void readMetaData() {
+    void readMetaData() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir).build();
              ExcerptTailer tailer = queue.createTailer();
@@ -341,7 +343,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void toEndWorksWhenLastCycleIsEmpty() {
+    void toEndWorksWhenLastCycleIsEmpty() {
         File dir = getTmpDir();
         SetTimeProvider stp = new SetTimeProvider();
 
@@ -433,7 +435,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void cantMoveToStartDuringDocumentReading() {
+    void cantMoveToStartDuringDocumentReading() {
         assertThrows(IllegalStateException.class, () -> {
             File dir = getTmpDir();
             try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
@@ -453,7 +455,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void cantMoveToEndDuringDocumentReading() {
+    void cantMoveToEndDuringDocumentReading() {
         assertThrows(IllegalStateException.class, () -> {
             File dir = getTmpDir();
             try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
@@ -473,7 +475,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testStriding() {
+    void testStriding() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
                 .testBlockSize().build();
@@ -484,7 +486,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testStridingReadForward() {
+    void testStridingReadForward() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
                 .testBlockSize().build();
@@ -507,7 +509,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testStridingReadBackward() {
+    void testStridingReadBackward() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
                 .testBlockSize().build();
@@ -530,7 +532,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testMoveToIndex() {
+    void testMoveToIndex() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
                 .testBlockSize().build();
@@ -545,7 +547,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testExcerptsInCycle() {
+    void testExcerptsInCycle() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
                 .testBlockSize().build();
@@ -567,7 +569,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testMoveToInvalidIndex() {
+    void testMoveToInvalidIndex() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
                 .testBlockSize().build();
@@ -586,7 +588,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testDirectionChange() {
+    void testDirectionChange() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
                 .testBlockSize().build();
@@ -613,7 +615,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testBehaviorOnEmptyQueue() {
+    void testBehaviorOnEmptyQueue() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir)
                 .testBlockSize().build();
@@ -629,7 +631,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldHandleCycleRollBackward() {
+    void shouldHandleCycleRollBackward() {
         File dir = getTmpDir();
         MutableTimeProvider timeProvider = new MutableTimeProvider();
         timeProvider.setTime(System.currentTimeMillis());
@@ -668,7 +670,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testOriginalToEndBeforeInitialised() {
+    void testOriginalToEndBeforeInitialised() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir).testBlockSize().build();
              ExcerptTailer tailer = queue.createTailer()) {
@@ -678,7 +680,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void currentFileShouldReturnFileIfInitialised() {
+    void currentFileShouldReturnFileIfInitialised() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir).testBlockSize().build();
              ExcerptAppender appender = queue.createAppender();
@@ -691,7 +693,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void currentFileShouldReturnNullWhenNotInitialised() {
+    void currentFileShouldReturnNullWhenNotInitialised() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir).testBlockSize().build();
              ExcerptTailer tailer = queue.createTailer()) {
@@ -701,7 +703,7 @@ public class StoreTailerTest extends QueueTestCommon {
     }
 
     @Test
-    public void syncShouldReturnNullIfNotInitialised() {
+    void syncShouldReturnNullIfNotInitialised() {
         File dir = getTmpDir();
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(dir).testBlockSize().build();
              ExcerptTailer tailer = queue.createTailer()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreTailerTest.java
@@ -712,5 +712,4 @@ class StoreTailerTest extends QueueTestCommon {
             assertNull(tailer.currentFile());
         }
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StuckQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StuckQueueTest.java
@@ -11,8 +11,7 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.RollingChronicleQueue;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,8 +20,8 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class StuckQueueTest extends QueueTestCommon {
 
@@ -33,7 +32,7 @@ public class StuckQueueTest extends QueueTestCommon {
         assumeFalse(OS.isWindows());
 
         Path tmpDir = getTmpDir().toPath();
-        assumeFalse("This test uses a checked in queue file that has a size incompatible with hugetlbfs", PageUtil.isHugePage(tmpDir.toString()));
+        assumeFalse(PageUtil.isHugePage(tmpDir.toString()), "This test uses a checked in queue file that has a size incompatible with hugetlbfs");
 
         expectException("Failback to readonly tablestore");
         ignoreException("reading control code as text");
@@ -58,18 +57,18 @@ public class StuckQueueTest extends QueueTestCommon {
             try (SingleChronicleQueueStore wireStore = q.storeForCycle(cycle, q.epoch(), false, null)) {
                 String absolutePath = wireStore.file().getAbsolutePath();
                 // System.out.println(absolutePath);
-                Assert.assertTrue(absolutePath.endsWith("20180508-1249.cq4"));
+                assertTrue(absolutePath.endsWith("20180508-1249.cq4"));
             }
 
-            // Assert.assertTrue(tailer.moveToIndex(0x18406e100000000L));
+            // assertTrue(tailer.moveToIndex(0x18406e100000000L));
 
             try (DocumentContext dc = tailer.readingDocument()) {
-                assumeNotNull(dc);
-                // Assert.assertTrue(!dc.isPresent());
+                assumeTrue(dc != null);
+                // assertTrue(!dc.isPresent());
                 // System.out.println(Long.toHexString(dc.index()));
             }
 
-            // Assert.assertTrue(tailer.moveToIndex(0x183efe300000000L));
+            // assertTrue(tailer.moveToIndex(0x183efe300000000L));
             try (final SingleChronicleQueue q2 = ChronicleQueue.singleBuilder(tmpDir).rollCycle(MINUTELY).build();
                  final ExcerptAppender appender = q2.createAppender()) {
                 try (DocumentContext dc = appender.writingDocument()) {
@@ -78,9 +77,9 @@ public class StuckQueueTest extends QueueTestCommon {
             }
             ExcerptTailer tailer2 = q.createTailer();
             try (DocumentContext dc = tailer2.readingDocument()) {
-                Assert.assertTrue(dc.isPresent());
+                assertTrue(dc.isPresent());
                 String actual = dc.wire().read("hello").text();
-                Assert.assertEquals("world", actual);
+                assertEquals("world", actual);
                 // System.out.println(Long.toHexString(dc.index()));
             }
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StuckQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StuckQueueTest.java
@@ -23,10 +23,10 @@ import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class StuckQueueTest extends QueueTestCommon {
+class StuckQueueTest extends QueueTestCommon {
 
     @Test
-    public void test() throws IOException {
+    void test() throws IOException {
 
         // java.nio.file.InvalidPathException: Illegal char <:> at index 2: /D:/BuildAgent/work/1e5875c1db7235db/target/test-classes/stuck.queue.test/20180508-1249.cq4
         assumeFalse(OS.isWindows());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
@@ -11,13 +11,13 @@ import net.openhft.chronicle.queue.impl.table.Metadata;
 import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
 import net.openhft.chronicle.queue.impl.table.SingleTableStore;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TableDirectoryListingTest extends QueueTestCommon {
     private DirectoryListing listing;
@@ -32,7 +32,7 @@ public class TableDirectoryListingTest extends QueueTestCommon {
         return getTmpDir();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         testDirectory = testDirectory();
         testDirectory.mkdirs();
@@ -58,10 +58,10 @@ public class TableDirectoryListingTest extends QueueTestCommon {
         Closeable.closeQuietly(tablestore, tablestoreReadOnly, listing, listingReadOnly);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldBlowUpIfClosed() {
         listing.close();
-        listing.getMaxCreatedCycle();
+        assertThrows(IllegalStateException.class, () -> listing.getMaxCreatedCycle());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TableDirectoryListingTest extends QueueTestCommon {
+class TableDirectoryListingTest extends QueueTestCommon {
     private DirectoryListing listing;
     private DirectoryListing listingReadOnly;
     private TableStore<Metadata.NoMeta> tablestore;
@@ -33,7 +33,7 @@ public class TableDirectoryListingTest extends QueueTestCommon {
     }
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         testDirectory = testDirectory();
         testDirectory.mkdirs();
         File tableFile = new File(testDirectory, "dir-list" + SingleTableStore.SUFFIX);
@@ -59,13 +59,13 @@ public class TableDirectoryListingTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldBlowUpIfClosed() {
+    void shouldBlowUpIfClosed() {
         listing.close();
         assertThrows(IllegalStateException.class, () -> listing.getMaxCreatedCycle());
     }
 
     @Test
-    public void shouldTrackMaxValue() {
+    void shouldTrackMaxValue() {
         listing.refresh(true);
 
         listing.onFileCreated(tempFile, 7);
@@ -84,7 +84,7 @@ public class TableDirectoryListingTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldInitialiseFromFilesystem() throws IOException {
+    void shouldInitialiseFromFilesystem() throws IOException {
         new File(testDirectory, 1 + SingleChronicleQueue.SUFFIX).createNewFile();
         new File(testDirectory, 2 + SingleChronicleQueue.SUFFIX).createNewFile();
         new File(testDirectory, 3 + SingleChronicleQueue.SUFFIX).createNewFile();
@@ -98,7 +98,7 @@ public class TableDirectoryListingTest extends QueueTestCommon {
     }
 
     @Test
-    public void lockShouldTimeOut() {
+    void lockShouldTimeOut() {
         listing.onFileCreated(tempFile, 8);
 
         listing.onFileCreated(tempFile, 9);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
@@ -31,7 +31,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TableStoreWriteLockTest extends QueueTestCommon {
+class TableStoreWriteLockTest extends QueueTestCommon {
 
     private static final String TEST_LOCK_NAME = "testLock";
     private static final long TIMEOUT_MS = 100;
@@ -39,9 +39,9 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
     private Path tempDir;
 
     @BeforeEach
-    public void beforeEachTableStoreWriteLockTest() {
+    void beforeEachTableStoreWriteLockTest() {
         setUp();
-        threadDump();
+        public threadDump();
     }
 
     public void setUp() {
@@ -57,14 +57,14 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @AfterEach
-    public void tearDown() {
+    protected void tearDown() {
         Closeable.closeQuietly(tableStore);
         IOTools.deleteDirWithFiles(tempDir.toFile());
     }
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void lockWillThrowIllegalStateExceptionIfInterruptedWhileWaitingForLock() throws InterruptedException {
+    void lockWillThrowIllegalStateExceptionIfInterruptedWhileWaitingForLock() throws InterruptedException {
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 5_000)) {
             testLock.lock();
             AtomicBoolean threwException = new AtomicBoolean(false);
@@ -85,7 +85,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testIsLockedByCurrentProcess() {
+    void testIsLockedByCurrentProcess() {
         AtomicLong actualPid = new AtomicLong(-1);
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.lock();
@@ -99,7 +99,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void lockWillBeAcquiredAfterTimeoutWithAWarning() throws InterruptedException {
+    void lockWillBeAcquiredAfterTimeoutWithAWarning() throws InterruptedException {
         System.setProperty("queue.force.unlock.mode", "ALWAYS");
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
             Thread t = new Thread(testLock::lock);
@@ -115,7 +115,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void lockWillThrowExceptionAfterTimeoutWhenDontRecoverLockTimeoutIsTrue() throws InterruptedException {
+    void lockWillThrowExceptionAfterTimeoutWhenDontRecoverLockTimeoutIsTrue() throws InterruptedException {
         assertThrows(UnrecoverableTimeoutException.class, () -> {
             System.setProperty("queue.force.unlock.mode", "NEVER");
             try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
@@ -132,7 +132,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void lockWillThrowExceptionAfterTimeoutWhenOnlyUnlockIfProcessDeadIsTrue() throws InterruptedException {
+    void lockWillThrowExceptionAfterTimeoutWhenOnlyUnlockIfProcessDeadIsTrue() throws InterruptedException {
         assertThrows(UnrecoverableTimeoutException.class, () -> {
             System.setProperty("queue.force.unlock.mode", "LOCKING_PROCESS_DEAD");
             try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
@@ -149,7 +149,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void unlockWillWarnIfNotLocked() {
+    void unlockWillWarnIfNotLocked() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.unlock();
             expectException("Write lock was already unlocked.");
@@ -158,7 +158,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void unlockWillNotUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
+    void unlockWillNotUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             final Process process = runLockingProcess(true);
             waitForLockToBecomeLocked(testLock);
@@ -172,7 +172,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void forceUnlockWillUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
+    void forceUnlockWillUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             final Process process = runLockingProcess(true);
             waitForLockToBecomeLocked(testLock);
@@ -186,7 +186,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void forceUnlockWillNotWarnIfLockIsNotLocked() {
+    void forceUnlockWillNotWarnIfLockIsNotLocked() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.forceUnlock();
             assertFalse(testLock.locked());
@@ -195,7 +195,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void forceUnlockWillWarnIfLockIsLockedByCurrentProcess() {
+    void forceUnlockWillWarnIfLockIsLockedByCurrentProcess() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.lock();
             testLock.forceUnlock();
@@ -206,7 +206,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void lockPreventsConcurrentAcquisition() {
+    void lockPreventsConcurrentAcquisition() {
         AtomicBoolean lockIsAcquired = new AtomicBoolean(false);
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 10_000)) {
             int numThreads = Math.min(6, Runtime.getRuntime().availableProcessors());
@@ -229,7 +229,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void forceUnlockIfProcessIsDeadWillFailWhenLockingProcessIsAlive() throws IOException, TimeoutException, InterruptedException {
+    void forceUnlockIfProcessIsDeadWillFailWhenLockingProcessIsAlive() throws IOException, TimeoutException, InterruptedException {
         Process lockingProcess = runLockingProcess(true);
         try (TableStoreWriteLock lock = createTestLock()) {
             waitForLockToBecomeLocked(lock);
@@ -242,7 +242,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void forceUnlockIfProcessIsDeadWillSucceedWhenLockingProcessIsDead() throws IOException, TimeoutException, InterruptedException {
+    void forceUnlockIfProcessIsDeadWillSucceedWhenLockingProcessIsDead() throws IOException, TimeoutException, InterruptedException {
         ignoreException("Forced unlock");
         Process lockingProcess = runLockingProcess(false);
         try (TableStoreWriteLock lock = createTestLock()) {
@@ -256,7 +256,7 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void forceUnlockIfProcessIsDeadWillSucceedWhenLockIsNotLocked() {
+    void forceUnlockIfProcessIsDeadWillSucceedWhenLockIsNotLocked() {
         try (TableStoreWriteLock lock = createTestLock()) {
             assertTrue(lock.forceUnlockIfProcessIsDead());
             assertFalse(lock.locked());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
@@ -17,12 +17,14 @@ import net.openhft.chronicle.threads.Threads;
 import net.openhft.chronicle.wire.UnrecoverableTimeoutException;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -41,7 +43,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     @BeforeEach
     void beforeEachTableStoreWriteLockTest() {
         setUp();
-        public threadDump();
+        threadDump();
     }
 
     public void setUp() {
@@ -63,7 +65,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
     void lockWillThrowIllegalStateExceptionIfInterruptedWhileWaitingForLock() throws InterruptedException {
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 5_000)) {
             testLock.lock();
@@ -84,7 +86,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
     void testIsLockedByCurrentProcess() {
         AtomicLong actualPid = new AtomicLong(-1);
         try (final TableStoreWriteLock testLock = createTestLock()) {
@@ -98,7 +100,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
     void lockWillBeAcquiredAfterTimeoutWithAWarning() throws InterruptedException {
         System.setProperty("queue.force.unlock.mode", "ALWAYS");
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
@@ -114,7 +116,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
     void lockWillThrowExceptionAfterTimeoutWhenDontRecoverLockTimeoutIsTrue() throws InterruptedException {
         assertThrows(UnrecoverableTimeoutException.class, () -> {
             System.setProperty("queue.force.unlock.mode", "NEVER");
@@ -131,7 +133,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
     void lockWillThrowExceptionAfterTimeoutWhenOnlyUnlockIfProcessDeadIsTrue() throws InterruptedException {
         assertThrows(UnrecoverableTimeoutException.class, () -> {
             System.setProperty("queue.force.unlock.mode", "LOCKING_PROCESS_DEAD");
@@ -148,7 +150,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
     void unlockWillWarnIfNotLocked() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.unlock();
@@ -157,7 +159,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
     void unlockWillNotUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             final Process process = runLockingProcess(true);
@@ -171,7 +173,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
     void forceUnlockWillUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             final Process process = runLockingProcess(true);
@@ -185,7 +187,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
     void forceUnlockWillNotWarnIfLockIsNotLocked() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.forceUnlock();
@@ -194,7 +196,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
     void forceUnlockWillWarnIfLockIsLockedByCurrentProcess() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.lock();
@@ -205,7 +207,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
     void lockPreventsConcurrentAcquisition() {
         AtomicBoolean lockIsAcquired = new AtomicBoolean(false);
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 10_000)) {
@@ -228,7 +230,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
     void forceUnlockIfProcessIsDeadWillFailWhenLockingProcessIsAlive() throws IOException, TimeoutException, InterruptedException {
         Process lockingProcess = runLockingProcess(true);
         try (TableStoreWriteLock lock = createTestLock()) {
@@ -241,7 +243,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
     void forceUnlockIfProcessIsDeadWillSucceedWhenLockingProcessIsDead() throws IOException, TimeoutException, InterruptedException {
         ignoreException("Forced unlock");
         Process lockingProcess = runLockingProcess(false);
@@ -255,7 +257,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
     void forceUnlockIfProcessIsDeadWillSucceedWhenLockIsNotLocked() {
         try (TableStoreWriteLock lock = createTestLock()) {
             assertTrue(lock.forceUnlockIfProcessIsDead());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -65,7 +64,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void lockWillThrowIllegalStateExceptionIfInterruptedWhileWaitingForLock() throws InterruptedException {
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 5_000)) {
             testLock.lock();
@@ -86,7 +85,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void testIsLockedByCurrentProcess() {
         AtomicLong actualPid = new AtomicLong(-1);
         try (final TableStoreWriteLock testLock = createTestLock()) {
@@ -100,7 +99,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void lockWillBeAcquiredAfterTimeoutWithAWarning() throws InterruptedException {
         System.setProperty("queue.force.unlock.mode", "ALWAYS");
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
@@ -116,7 +115,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void lockWillThrowExceptionAfterTimeoutWhenDontRecoverLockTimeoutIsTrue() throws InterruptedException {
         assertThrows(UnrecoverableTimeoutException.class, () -> {
             System.setProperty("queue.force.unlock.mode", "NEVER");
@@ -133,7 +132,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void lockWillThrowExceptionAfterTimeoutWhenOnlyUnlockIfProcessDeadIsTrue() throws InterruptedException {
         assertThrows(UnrecoverableTimeoutException.class, () -> {
             System.setProperty("queue.force.unlock.mode", "LOCKING_PROCESS_DEAD");
@@ -150,7 +149,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void unlockWillWarnIfNotLocked() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.unlock();
@@ -159,7 +158,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(15)
     void unlockWillNotUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             final Process process = runLockingProcess(true);
@@ -173,7 +172,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(15)
     void forceUnlockWillUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             final Process process = runLockingProcess(true);
@@ -187,7 +186,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void forceUnlockWillNotWarnIfLockIsNotLocked() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.forceUnlock();
@@ -196,7 +195,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void forceUnlockWillWarnIfLockIsLockedByCurrentProcess() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.lock();
@@ -207,7 +206,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(15)
     void lockPreventsConcurrentAcquisition() {
         AtomicBoolean lockIsAcquired = new AtomicBoolean(false);
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 10_000)) {
@@ -230,7 +229,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(15)
     void forceUnlockIfProcessIsDeadWillFailWhenLockingProcessIsAlive() throws IOException, TimeoutException, InterruptedException {
         Process lockingProcess = runLockingProcess(true);
         try (TableStoreWriteLock lock = createTestLock()) {
@@ -243,7 +242,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 15_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(15)
     void forceUnlockIfProcessIsDeadWillSucceedWhenLockingProcessIsDead() throws IOException, TimeoutException, InterruptedException {
         ignoreException("Forced unlock");
         Process lockingProcess = runLockingProcess(false);
@@ -257,7 +256,7 @@ class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void forceUnlockIfProcessIsDeadWillSucceedWhenLockIsNotLocked() {
         try (TableStoreWriteLock lock = createTestLock()) {
             assertTrue(lock.forceUnlockIfProcessIsDead());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableStoreWriteLockTest.java
@@ -16,9 +16,9 @@ import net.openhft.chronicle.threads.Pauser;
 import net.openhft.chronicle.threads.Threads;
 import net.openhft.chronicle.wire.UnrecoverableTimeoutException;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TableStoreWriteLockTest extends QueueTestCommon {
 
@@ -38,7 +38,12 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
     private TableStore<Metadata.NoMeta> tableStore;
     private Path tempDir;
 
-    @Before
+    @BeforeEach
+    public void beforeEachTableStoreWriteLockTest() {
+        setUp();
+        threadDump();
+    }
+
     public void setUp() {
         tempDir = IOTools.createTempDirectory("namedTableStoreLockTest");
         tempDir.toFile().mkdirs();
@@ -47,18 +52,18 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
     }
 
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         Closeable.closeQuietly(tableStore);
         IOTools.deleteDirWithFiles(tempDir.toFile());
     }
 
-    @Test(timeout = 5_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void lockWillThrowIllegalStateExceptionIfInterruptedWhileWaitingForLock() throws InterruptedException {
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 5_000)) {
             testLock.lock();
@@ -78,7 +83,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testIsLockedByCurrentProcess() {
         AtomicLong actualPid = new AtomicLong(-1);
         try (final TableStoreWriteLock testLock = createTestLock()) {
@@ -91,7 +97,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void lockWillBeAcquiredAfterTimeoutWithAWarning() throws InterruptedException {
         System.setProperty("queue.force.unlock.mode", "ALWAYS");
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
@@ -106,35 +113,42 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5_000, expected = UnrecoverableTimeoutException.class)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void lockWillThrowExceptionAfterTimeoutWhenDontRecoverLockTimeoutIsTrue() throws InterruptedException {
-        System.setProperty("queue.force.unlock.mode", "NEVER");
-        try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
-            Thread t = new Thread(testLock::lock);
-            t.start();
-            t.join();
-            testLock.lock();
-            fail("Should have thrown trying to lock()");
-        } finally {
-            System.clearProperty("queue.force.unlock.mode");
-        }
+        assertThrows(UnrecoverableTimeoutException.class, () -> {
+            System.setProperty("queue.force.unlock.mode", "NEVER");
+            try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
+                Thread t = new Thread(testLock::lock);
+                t.start();
+                t.join();
+                testLock.lock();
+                fail("Should have thrown trying to lock()");
+            } finally {
+                System.clearProperty("queue.force.unlock.mode");
+            }
+        });
     }
 
-    @Test(timeout = 5_000, expected = UnrecoverableTimeoutException.class)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void lockWillThrowExceptionAfterTimeoutWhenOnlyUnlockIfProcessDeadIsTrue() throws InterruptedException {
-        System.setProperty("queue.force.unlock.mode", "LOCKING_PROCESS_DEAD");
-        try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
-            Thread t = new Thread(testLock::lock);
-            t.start();
-            t.join();
-            testLock.lock();
-            fail("Should have thrown trying to lock()");
-        } finally {
-            System.clearProperty("queue.force.unlock.mode");
-        }
+        assertThrows(UnrecoverableTimeoutException.class, () -> {
+            System.setProperty("queue.force.unlock.mode", "LOCKING_PROCESS_DEAD");
+            try (final TableStoreWriteLock testLock = createTestLock(tableStore, 50)) {
+                Thread t = new Thread(testLock::lock);
+                t.start();
+                t.join();
+                testLock.lock();
+                fail("Should have thrown trying to lock()");
+            } finally {
+                System.clearProperty("queue.force.unlock.mode");
+            }
+        });
     }
 
-    @Test(timeout = 5_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void unlockWillWarnIfNotLocked() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.unlock();
@@ -142,7 +156,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 15_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void unlockWillNotUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             final Process process = runLockingProcess(true);
@@ -155,7 +170,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 15_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void forceUnlockWillUnlockAndWarnIfLockedByAnotherProcess() throws IOException, InterruptedException, TimeoutException {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             final Process process = runLockingProcess(true);
@@ -168,7 +184,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void forceUnlockWillNotWarnIfLockIsNotLocked() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.forceUnlock();
@@ -176,7 +193,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void forceUnlockWillWarnIfLockIsLockedByCurrentProcess() {
         try (final TableStoreWriteLock testLock = createTestLock()) {
             testLock.lock();
@@ -186,7 +204,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 15_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void lockPreventsConcurrentAcquisition() {
         AtomicBoolean lockIsAcquired = new AtomicBoolean(false);
         try (final TableStoreWriteLock testLock = createTestLock(tableStore, 10_000)) {
@@ -208,7 +227,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         assertTrue(true); // if we got here without an exception, the test passes
     }
 
-    @Test(timeout = 15_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void forceUnlockIfProcessIsDeadWillFailWhenLockingProcessIsAlive() throws IOException, TimeoutException, InterruptedException {
         Process lockingProcess = runLockingProcess(true);
         try (TableStoreWriteLock lock = createTestLock()) {
@@ -220,7 +240,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         lockingProcess.waitFor(3_000, TimeUnit.SECONDS);
     }
 
-    @Test(timeout = 15_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 15_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void forceUnlockIfProcessIsDeadWillSucceedWhenLockingProcessIsDead() throws IOException, TimeoutException, InterruptedException {
         ignoreException("Forced unlock");
         Process lockingProcess = runLockingProcess(false);
@@ -233,7 +254,8 @@ public class TableStoreWriteLockTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void forceUnlockIfProcessIsDeadWillSucceedWhenLockIsNotLocked() {
         try (TableStoreWriteLock lock = createTestLock()) {
             assertTrue(lock.forceUnlockIfProcessIsDead());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerIndexingQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerIndexingQueueTest.java
@@ -25,7 +25,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public final class TailerIndexingQueueTest extends QueueTestCommon {
+final class TailerIndexingQueueTest extends QueueTestCommon {
     private final File path = getTmpDir();
     private final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
 
@@ -48,7 +48,7 @@ public final class TailerIndexingQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void tailerShouldBeAbleToMoveBackwardFromEndOfCycle() throws IOException {
+    void tailerShouldBeAbleToMoveBackwardFromEndOfCycle() throws IOException {
         assumeFalse(OS.isWindows());
         try (final ChronicleQueue queue = createQueue(path, clock::get);
              final ExcerptAppender appender = queue.createAppender()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerIndexingQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerIndexingQueueTest.java
@@ -9,7 +9,7 @@ import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,8 +22,8 @@ import java.util.stream.Stream;
 
 import static java.util.stream.IntStream.range;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public final class TailerIndexingQueueTest extends QueueTestCommon {
     private final File path = getTmpDir();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerPollingEmptyQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerPollingEmptyQueueTest.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public final class TailerPollingEmptyQueueTest extends QueueTestCommon {
+final class TailerPollingEmptyQueueTest extends QueueTestCommon {
 
     @Test
-    public void shouldNotGenerateExcessGarbage() {
+    void shouldNotGenerateExcessGarbage() {
         // Perform a GC prior to the test to ensure an unrelated GC does not occur which would devalue this test
         GcControls.waitForGcCycle();
 
@@ -40,7 +40,7 @@ public final class TailerPollingEmptyQueueTest extends QueueTestCommon {
 
     private SingleChronicleQueue createQueue() {
         return ChronicleQueue.singleBuilder(
-                getTmpDir()).
+                        getTmpDir()).
                 testBlockSize().
                 build();
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerPollingEmptyQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerPollingEmptyQueueTest.java
@@ -7,10 +7,9 @@ import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.testframework.GcControls;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class TailerPollingEmptyQueueTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerSequenceRaceConditionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerSequenceRaceConditionTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public final class TailerSequenceRaceConditionTest extends QueueTestCommon {
+final class TailerSequenceRaceConditionTest extends QueueTestCommon {
     private final AtomicBoolean failedToMoveToEnd = new AtomicBoolean(false);
     private final ExecutorService threadPool = Executors.newFixedThreadPool(8,
             new NamedThreadFactory("test"));
@@ -32,7 +32,7 @@ public final class TailerSequenceRaceConditionTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldAlwaysBeAbleToTail() throws InterruptedException {
+    void shouldAlwaysBeAbleToTail() throws InterruptedException {
         ChronicleQueue[] queues = new ChronicleQueue[10];
         for (int i = 0; i < 10; i++) {
             final ChronicleQueue queue = createNewQueue();
@@ -55,7 +55,7 @@ public final class TailerSequenceRaceConditionTest extends QueueTestCommon {
     }
 
     @Override
-    public void tearDown() {
+    protected public void tearDown() {
         super.tearDown();
         threadPool.shutdownNow();
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerSequenceRaceConditionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerSequenceRaceConditionTest.java
@@ -9,8 +9,8 @@ import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -18,8 +18,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class TailerSequenceRaceConditionTest extends QueueTestCommon {
     private final AtomicBoolean failedToMoveToEnd = new AtomicBoolean(false);
@@ -27,7 +26,7 @@ public final class TailerSequenceRaceConditionTest extends QueueTestCommon {
             new NamedThreadFactory("test"));
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TailerSequenceRaceConditionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TailerSequenceRaceConditionTest.java
@@ -55,7 +55,7 @@ final class TailerSequenceRaceConditionTest extends QueueTestCommon {
     }
 
     @Override
-    protected public void tearDown() {
+    protected void tearDown() {
         super.tearDown();
         threadPool.shutdownNow();
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
@@ -23,7 +23,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestBinarySearch extends QueueTestCommon {
+class TestBinarySearch extends QueueTestCommon {
 
     private final Map<Integer, Long> keyToIndex = new HashMap<>();
 
@@ -47,7 +47,7 @@ public class TestBinarySearch extends QueueTestCommon {
             for (int j = 0; j < noStrategies; j++) {
                 Object[] newParameter = Arrays.copyOf(parameter, parameter.length + 1);
                 newParameter[parameter.length] = emptyCyclesStrategies[j];
-                result[i*noStrategies + j] = newParameter;
+                result[i * noStrategies + j] = newParameter;
             }
         }
         return result;
@@ -55,7 +55,7 @@ public class TestBinarySearch extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testBinarySearch(int numberOfMessages, int numberOfMessagesToVerify, EmptyCyclesStrategy emptyCyclesStrategy) {
+    void testBinarySearch(int numberOfMessages, int numberOfMessagesToVerify, EmptyCyclesStrategy emptyCyclesStrategy) {
         RetrievalStrategy retrievalStrategy = numberOfMessages == numberOfMessagesToVerify ? RetrievalStrategy.LINEAR : RetrievalStrategy.RANDOM;
         final SetTimeProvider stp = new SetTimeProvider();
         stp.currentTimeMillis(0);
@@ -138,7 +138,7 @@ public class TestBinarySearch extends QueueTestCommon {
                 // easiest way to write an empty cycle is to start writing a document and then rollback
                 dc.rollbackOnClose();
             }
-            ((SetTimeProvider)appender.queue().time()).advanceMillis(appender.queue().rollCycle().lengthInMillis() + 1);
+            ((SetTimeProvider) appender.queue().time()).advanceMillis(appender.queue().rollCycle().lengthInMillis() + 1);
         }
     }
 
@@ -154,7 +154,7 @@ public class TestBinarySearch extends QueueTestCommon {
         return wire;
     }
 
-    public static class MyData extends SelfDescribingMarshallable {
+    static class MyData extends SelfDescribingMarshallable {
         private int key;
         private String value;
 
@@ -177,6 +177,7 @@ public class TestBinarySearch extends QueueTestCommon {
         },
         RANDOM {
             final Random random = new Random(234563434L);
+
             @Override
             public long retrieveIndex(long currentIndex, long totalNumberOfMessages) {
                 return random.nextInt((int) totalNumberOfMessages);
@@ -194,8 +195,7 @@ public class TestBinarySearch extends QueueTestCommon {
         MULTIPLE_EMPTY_AT_START,
         MULTIPLE_EMPTY_AT_END,
         SINGLE_EMPTY_IN_MIDDLE,
-        MULTIPLE_CONCURRENTLY_EMPTY_IN_MIDDLE
-        ;
+        MULTIPLE_CONCURRENTLY_EMPTY_IN_MIDDLE;
 
         public boolean atStart() {
             return this == SINGLE_EMPTY_AT_START || this == MULTIPLE_EMPTY_AT_START;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestBinarySearch.java
@@ -16,32 +16,17 @@ import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class TestBinarySearch extends QueueTestCommon {
 
     private final Map<Integer, Long> keyToIndex = new HashMap<>();
-    private final int numberOfMessages;
-    private final int numberOfMessagesToVerify;
-    private final RetrievalStrategy retrievalStrategy;
-    private final EmptyCyclesStrategy emptyCyclesStrategy;
 
-    public TestBinarySearch(int numberOfMessages, int numberOfMessagesToVerify, EmptyCyclesStrategy emptyCyclesStrategy) {
-        this.numberOfMessages = numberOfMessages;
-        this.numberOfMessagesToVerify = numberOfMessagesToVerify;
-        this.retrievalStrategy = numberOfMessages == numberOfMessagesToVerify ? RetrievalStrategy.LINEAR : RetrievalStrategy.RANDOM;
-        this.emptyCyclesStrategy = emptyCyclesStrategy;
-    }
-
-    @Parameterized.Parameters(name = "items: {0} verify: {1} emptyCycles: {2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(runForEveryEmptyCycleStrategy(new Object[][]{
                 {0, 0},
@@ -68,8 +53,10 @@ public class TestBinarySearch extends QueueTestCommon {
         return result;
     }
 
-    @Test
-    public void testBinarySearch() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testBinarySearch(int numberOfMessages, int numberOfMessagesToVerify, EmptyCyclesStrategy emptyCyclesStrategy) {
+        RetrievalStrategy retrievalStrategy = numberOfMessages == numberOfMessagesToVerify ? RetrievalStrategy.LINEAR : RetrievalStrategy.RANDOM;
         final SetTimeProvider stp = new SetTimeProvider();
         stp.currentTimeMillis(0);
 
@@ -128,7 +115,7 @@ public class TestBinarySearch extends QueueTestCommon {
                     Wire key = toWire(indexToVerify);
                     long index = BinarySearch.search(binarySearchTailer, key, comparator);
                     long expectedIndex = keyToIndex.get(indexToVerify);
-                    assertEquals("Failed looking for item at index: " + expectedIndex, expectedIndex, index);
+                    assertEquals(expectedIndex, index, "Failed looking for item at index: " + expectedIndex);
                     key.bytes().releaseLast();
 
                     if (j > 0 && numberOfMessagesToVerify > 10 && j % (numberOfMessagesToVerify / 10) == 0) {
@@ -139,13 +126,13 @@ public class TestBinarySearch extends QueueTestCommon {
 
                 Wire key = toWire(numberOfMessages);
                 long result = BinarySearch.search(binarySearchTailer, key, comparator);
-                Assert.assertTrue("Should not find non-existent", result < 0);
+                assertTrue(result < 0, "Should not find non-existent");
             }
         }
     }
 
     private void writeEmptyCycles(ExcerptAppender appender) {
-        int numberOfEmptyCycles = emptyCyclesStrategy.single() ? 1 : 2;
+        int numberOfEmptyCycles = 2;
         for (int i = 0; i < numberOfEmptyCycles; i++) {
             try (final DocumentContext dc = appender.writingDocument()) {
                 // easiest way to write an empty cycle is to start writing a document and then rollback

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
@@ -21,25 +21,25 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class TestEmptyFile {
+class TestEmptyFile {
     private Path tmpDir = DirectoryUtils.tempDir(TestEmptyFile.class.getSimpleName()).toPath();
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @BeforeEach
-    public void setup() throws IOException {
+    void setup() throws IOException {
         tmpDir.toFile().mkdirs();
         File file = tmpDir.resolve("20170320.cq4").toFile();
         new FileOutputStream(file).close();
     }
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         IOTools.deleteDirWithFiles(tmpDir.toFile());
     }
 
     @Test
     @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
-    public void shouldHandleEmptyFile() {
+    void shouldHandleEmptyFile() {
         assumeFalse(OS.isWindows());
         try (final ChronicleQueue queue =
                      ChronicleQueue.singleBuilder(tmpDir)

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
@@ -8,37 +8,39 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.DirectoryUtils;
 import net.openhft.chronicle.queue.ExcerptTailer;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class TestEmptyFile {
     private Path tmpDir = DirectoryUtils.tempDir(TestEmptyFile.class.getSimpleName()).toPath();
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         tmpDir.toFile().mkdirs();
         File file = tmpDir.resolve("20170320.cq4").toFile();
         new FileOutputStream(file).close();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         IOTools.deleteDirWithFiles(tmpDir.toFile());
     }
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
     public void shouldHandleEmptyFile() {
-        Assume.assumeFalse(OS.isWindows());
+        assumeFalse(OS.isWindows());
         try (final ChronicleQueue queue =
                      ChronicleQueue.singleBuilder(tmpDir)
                              .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestEmptyFile.java
@@ -9,14 +9,11 @@ import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.DirectoryUtils;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
@@ -38,7 +35,7 @@ class TestEmptyFile {
     }
 
     @Test
-    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     void shouldHandleEmptyFile() {
         assumeFalse(OS.isWindows());
         try (final ChronicleQueue queue =

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
@@ -7,19 +7,15 @@ import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.queue.ChronicleQueue;
-import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.main.DumpMain;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -28,50 +24,46 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 
-import static junit.framework.TestCase.fail;
 import static net.openhft.chronicle.queue.impl.single.ThreadLocalAppender.acquireThreadLocalAppender;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.HOURLY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 /**
  * check that method writes are thread safe when used with queue.methodWriter
  */
-@RunWith(Parameterized.class)
 public class TestMethodWriterWithThreads extends QueueTestCommon {
 
     private static final int AMEND = 1;
     private static final int CREATE = 2;
-    @Rule
-    public final TestName testName = new TestName();
     private ThreadLocal<Amend> amendTL = ThreadLocal.withInitial(Amend::new);
     private ThreadLocal<Create> createTL = ThreadLocal.withInitial(Create::new);
     private I methodWriter;
     private AtomicBoolean fail = new AtomicBoolean();
-    private boolean doubleBuffer;
 
-    public TestMethodWriterWithThreads(boolean doubleBuffer) {
-        this.doubleBuffer = doubleBuffer;
-    }
-
-    @Parameterized.Parameters(name = "doubleBuffer={0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[]{true}, new Object[]{false});
     }
 
-    @Before
+    @BeforeEach
+    public void beforeEachTestMethodWriterWithThreads() {
+        check64bit();
+        threadDump();
+    }
+
     public void check64bit() {
         assumeTrue(Jvm.is64bit());
     }
 
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
 
-    @Test(timeout = 30_000)
-    public void test() throws FileNotFoundException {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(boolean doubleBuffer) throws FileNotFoundException {
 
         File tmpDir = getTmpDir();
         try (final ChronicleQueue q = builder(tmpDir, WireType.BINARY).rollCycle(HOURLY).doubleBuffer(doubleBuffer).build()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
@@ -49,7 +49,7 @@ class TestMethodWriterWithThreads extends QueueTestCommon {
     @BeforeEach
     void beforeEachTestMethodWriterWithThreads() {
         check64bit();
-        public threadDump();
+        threadDump();
     }
 
     public void check64bit() {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TestMethodWriterWithThreads.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assumptions.*;
 /**
  * check that method writes are thread safe when used with queue.methodWriter
  */
-public class TestMethodWriterWithThreads extends QueueTestCommon {
+class TestMethodWriterWithThreads extends QueueTestCommon {
 
     private static final int AMEND = 1;
     private static final int CREATE = 2;
@@ -47,9 +47,9 @@ public class TestMethodWriterWithThreads extends QueueTestCommon {
     }
 
     @BeforeEach
-    public void beforeEachTestMethodWriterWithThreads() {
+    void beforeEachTestMethodWriterWithThreads() {
         check64bit();
-        threadDump();
+        public threadDump();
     }
 
     public void check64bit() {
@@ -63,7 +63,7 @@ public class TestMethodWriterWithThreads extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void test(boolean doubleBuffer) throws FileNotFoundException {
+    void test(boolean doubleBuffer) throws FileNotFoundException {
 
         File tmpDir = getTmpDir();
         try (final ChronicleQueue q = builder(tmpDir, WireType.BINARY).rollCycle(HOURLY).doubleBuffer(doubleBuffer).build()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndInvalidIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndInvalidIndexTest.java
@@ -17,26 +17,26 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ToEndInvalidIndexTest extends QueueTestCommon {
+class ToEndInvalidIndexTest extends QueueTestCommon {
 
     private static final long LAST_INDEX = RollCycles.FAST_DAILY.toIndex(2, 2);
     private Path queuePath;
     private SetTimeProvider setTimeProvider;
 
     @BeforeEach
-    public void setUp() throws StreamCorruptedException {
+    void setUp() throws StreamCorruptedException {
         queuePath = IOTools.createTempDirectory("partialIndex");
         setTimeProvider = new SetTimeProvider();
         createQueueWithZeroFirstSubIndexValue(setTimeProvider, queuePath);
     }
 
     @AfterEach
-    public void tearDown() {
+    protected void tearDown() {
         IOTools.deleteDirWithFiles(queuePath.toFile());
     }
 
     @Test
-    public void testBackwardsToEndReportsCorrectIndex() {
+    void testBackwardsToEndReportsCorrectIndex() {
         try (SingleChronicleQueue queue = createQueue(setTimeProvider, queuePath);
              ExcerptTailer tailer = queue.createTailer()) {
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndInvalidIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndInvalidIndexTest.java
@@ -8,14 +8,14 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.*;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.StreamCorruptedException;
 import java.nio.file.Path;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ToEndInvalidIndexTest extends QueueTestCommon {
 
@@ -23,14 +23,14 @@ public class ToEndInvalidIndexTest extends QueueTestCommon {
     private Path queuePath;
     private SetTimeProvider setTimeProvider;
 
-    @Before
+    @BeforeEach
     public void setUp() throws StreamCorruptedException {
         queuePath = IOTools.createTempDirectory("partialIndex");
         setTimeProvider = new SetTimeProvider();
         createQueueWithZeroFirstSubIndexValue(setTimeProvider, queuePath);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         IOTools.deleteDirWithFiles(queuePath.toFile());
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
@@ -26,14 +26,14 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class ToEndTest extends QueueTestCommon {
+class ToEndTest extends QueueTestCommon {
     private static final long FIVE_SECONDS = SECONDS.toMicros(5);
     private static final String ZERO_AS_HEX_STRING = Long.toHexString(0);
     private static final String LONG_MIN_VALUE_AS_HEX_STRING = Long.toHexString(Long.MIN_VALUE);
     private long lastCycle;
 
     @Test
-    public void missingCyclesToEndTest() {
+    void missingCyclesToEndTest() {
         String path = OS.getTarget() + "/missingCyclesToEndTest-" + Time.uniqueId();
         try {
             IOTools.shallowDeleteDirWithFiles(path);
@@ -111,7 +111,7 @@ public class ToEndTest extends QueueTestCommon {
     }
 
     @Test
-    public void tailerToEndIncreasesRefCount() throws NoSuchFieldException, IllegalAccessException {
+    void tailerToEndIncreasesRefCount() throws NoSuchFieldException, IllegalAccessException {
         String path = OS.getTarget() + "/toEndIncRefCount-" + Time.uniqueId();
         IOTools.shallowDeleteDirWithFiles(path);
 
@@ -150,7 +150,7 @@ public class ToEndTest extends QueueTestCommon {
     }
 
     @Test
-    public void toEndTest() {
+    void toEndTest() {
         File baseDir = getTmpDir();
 
         try {
@@ -194,7 +194,7 @@ public class ToEndTest extends QueueTestCommon {
     }
 
     @Test
-    public void toEndBeforeWriteTest() {
+    void toEndBeforeWriteTest() {
         File baseDir = getTmpDir();
         IOTools.shallowDeleteDirWithFiles(baseDir);
 
@@ -232,7 +232,7 @@ public class ToEndTest extends QueueTestCommon {
     }
 
     @Test
-    public void toEndAfterWriteTest() {
+    void toEndAfterWriteTest() {
         File file = getTmpDir();
         IOTools.shallowDeleteDirWithFiles(file);
         final SetTimeProvider stp = new SetTimeProvider();
@@ -280,7 +280,7 @@ public class ToEndTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldReturnExpectedValuesForEmptyQueue() {
+    void shouldReturnExpectedValuesForEmptyQueue() {
         SetTimeProvider timeProvider = new SetTimeProvider();
         try (final SingleChronicleQueue queue = createQueue(timeProvider)) {
             assertEquals(ZERO_AS_HEX_STRING, tailerToEndIndex(queue));
@@ -289,7 +289,7 @@ public class ToEndTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldReturnExpectedValuesForQueueWithOnlyMetadata() {
+    void shouldReturnExpectedValuesForQueueWithOnlyMetadata() {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.advanceMicros(FIVE_SECONDS);
         try (final SingleChronicleQueue queue = createQueue(timeProvider)) {
@@ -371,7 +371,7 @@ public class ToEndTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldReturnExpectedValuesForNonEmptyQueueRolledByMetadata() {
+    void shouldReturnExpectedValuesForNonEmptyQueueRolledByMetadata() {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.advanceMicros(FIVE_SECONDS);
         try (final SingleChronicleQueue queue = createQueue(timeProvider)) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ToEndTest.java
@@ -3,7 +3,6 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
-import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.PageUtil;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
@@ -13,9 +12,7 @@ import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -26,7 +23,8 @@ import java.util.List;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_SECONDLY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class ToEndTest extends QueueTestCommon {
     private static final long FIVE_SECONDS = SECONDS.toMicros(5);
@@ -71,9 +69,9 @@ public class ToEndTest extends QueueTestCommon {
                 appender.writeDocument(wire -> wire.write("msg").int32(4));
 
                 try (DocumentContext dc = tailer.readingDocument()) {
-                    assertTrue("Should be able to read entry in this cycle. Got NoDocumentContext.", dc.isPresent());
+                    assertTrue(dc.isPresent(), "Should be able to read entry in this cycle. Got NoDocumentContext.");
                     int i = dc.wire().read("msg").int32();
-                    assertEquals("Should've read 4, instead we read: " + i, 4, i);
+                    assertEquals(4, i, "Should've read 4, instead we read: " + i);
                 }
 
                 // read from the beginning
@@ -295,7 +293,7 @@ public class ToEndTest extends QueueTestCommon {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.advanceMicros(FIVE_SECONDS);
         try (final SingleChronicleQueue queue = createQueue(timeProvider)) {
-            Assume.assumeFalse("Ignored on hugetlbfs as byte offsets will be different due to page size", PageUtil.isHugePage(queue.file().getAbsolutePath()));
+            assumeFalse(PageUtil.isHugePage(queue.file().getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
             writeMetadataToQueue(queue);
             assertEquals("" +
                     "--- !!meta-data #binary\n" +
@@ -432,7 +430,7 @@ public class ToEndTest extends QueueTestCommon {
             return;
 
         if (files.length == 1)
-            assertTrue(files[0], files[0].startsWith("2"));
+            assertTrue(files[0].startsWith("2"), files[0]);
         else
             fail("Too many files " + Arrays.toString(files));
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
@@ -9,12 +9,12 @@ import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_SECONDLY;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WriteBytesIndexTest extends QueueTestCommon {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
@@ -16,9 +16,9 @@ import java.io.File;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_SECONDLY;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class WriteBytesIndexTest extends QueueTestCommon {
+class WriteBytesIndexTest extends QueueTestCommon {
     @Test
-    public void writeMultipleAppenders() {
+    void writeMultipleAppenders() {
         File path = IOTools.createTempFile("writeMultipleAppenders");
         try (ChronicleQueue q0 = createQueue(path);
              ExcerptAppender a0 = q0.createAppender();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue28Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue28Test.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class Queue28Test extends QueueTestCommon {
+class Queue28Test extends QueueTestCommon {
 
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
@@ -33,7 +33,7 @@ public class Queue28Test extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void test(WireType wireType) {
+    void test(WireType wireType) {
         File dir = getTmpDir();
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.builder(dir, wireType)
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue28Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue28Test.java
@@ -7,27 +7,17 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class Queue28Test extends QueueTestCommon {
 
-    private final WireType wireType;
-
-    public Queue28Test(WireType wireType) {
-        this.wireType = wireType;
-    }
-
-    @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 // {WireType.TEXT},
@@ -41,8 +31,9 @@ public class Queue28Test extends QueueTestCommon {
      * See https://higherfrequencytrading.atlassian.net/browse/QUEUE-28
      */
 
-    @Test
-    public void test() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(WireType wireType) {
         File dir = getTmpDir();
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.builder(dir, wireType)
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue36Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue36Test.java
@@ -8,12 +8,11 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * See https://higherfrequencytrading.atlassian.net/browse/QUEUE-36

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue36Test.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/jira/Queue36Test.java
@@ -17,9 +17,9 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * See https://higherfrequencytrading.atlassian.net/browse/QUEUE-36
  */
-public class Queue36Test extends QueueTestCommon {
+class Queue36Test extends QueueTestCommon {
     @Test
-    public void testTail() {
+    void testTail() {
         File basePath = getTmpDir();
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(basePath)
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressDoubleBufferTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressDoubleBufferTest.java
@@ -16,7 +16,7 @@ import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Disabled("double buffering is turned off currently")
-public class RollCycleMultiThreadStressDoubleBufferTest extends RollCycleMultiThreadStressTest {
+class RollCycleMultiThreadStressDoubleBufferTest extends RollCycleMultiThreadStressTest {
 
     private AtomicBoolean queueDumped = new AtomicBoolean(false);
 
@@ -26,7 +26,7 @@ public class RollCycleMultiThreadStressDoubleBufferTest extends RollCycleMultiTh
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         queueDumped = new AtomicBoolean(false);
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressDoubleBufferTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressDoubleBufferTest.java
@@ -9,23 +9,23 @@ import net.openhft.chronicle.queue.impl.RollingChronicleQueue;
 import net.openhft.chronicle.queue.internal.main.InternalDumpMain;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.ValueIn;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@Ignore("double buffering is turned off currently")
+@Disabled("double buffering is turned off currently")
 public class RollCycleMultiThreadStressDoubleBufferTest extends RollCycleMultiThreadStressTest {
 
     private AtomicBoolean queueDumped = new AtomicBoolean(false);
 
-    public RollCycleMultiThreadStressDoubleBufferTest() {
-        super(StressTestType.DOUBLEBUFFER);
+    @Override
+    protected StressTestType stressTestType() {
+        return StressTestType.DOUBLEBUFFER;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         queueDumped = new AtomicBoolean(false);
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchEATest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchEATest.java
@@ -4,20 +4,21 @@
 package net.openhft.chronicle.queue.impl.single.stress;
 
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class RollCycleMultiThreadStressPretouchEATest extends RollCycleMultiThreadStressTest {
 
-    public RollCycleMultiThreadStressPretouchEATest() {
-        super(StressTestType.PRETOUCH_EA);
+    @Override
+    protected StressTestType stressTestType() {
+        return StressTestType.PRETOUCH_EA;
     }
 
     @Test
     public void stress() throws Exception {
-        Assume.assumeTrue(SingleChronicleQueueBuilder.areEnterpriseFeaturesAvailable());
+        assumeTrue(SingleChronicleQueueBuilder.areEnterpriseFeaturesAvailable());
         super.stress();
         assertTrue(true); // parent has asserts
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchEATest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchEATest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class RollCycleMultiThreadStressPretouchEATest extends RollCycleMultiThreadStressTest {
+class RollCycleMultiThreadStressPretouchEATest extends RollCycleMultiThreadStressTest {
 
     @Override
     protected StressTestType stressTestType() {
@@ -17,7 +17,7 @@ public class RollCycleMultiThreadStressPretouchEATest extends RollCycleMultiThre
     }
 
     @Test
-    public void stress() throws Exception {
+    void stress() throws Exception {
         assumeTrue(SingleChronicleQueueBuilder.areEnterpriseFeaturesAvailable());
         super.stress();
         assertTrue(true); // parent has asserts

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchTest.java
@@ -4,20 +4,21 @@
 package net.openhft.chronicle.queue.impl.single.stress;
 
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class RollCycleMultiThreadStressPretouchTest extends RollCycleMultiThreadStressTest {
 
-    public RollCycleMultiThreadStressPretouchTest() {
-        super(StressTestType.PRETOUCH);
+    @Override
+    protected StressTestType stressTestType() {
+        return StressTestType.PRETOUCH;
     }
 
     @Test
     public void stress() throws Exception {
-        Assume.assumeTrue(SingleChronicleQueueBuilder.areEnterpriseFeaturesAvailable());
+        assumeTrue(SingleChronicleQueueBuilder.areEnterpriseFeaturesAvailable());
         super.stress();
         assertTrue(true); // parent has asserts
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressPretouchTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class RollCycleMultiThreadStressPretouchTest extends RollCycleMultiThreadStressTest {
+class RollCycleMultiThreadStressPretouchTest extends RollCycleMultiThreadStressTest {
 
     @Override
     protected StressTestType stressTestType() {
@@ -17,7 +17,7 @@ public class RollCycleMultiThreadStressPretouchTest extends RollCycleMultiThread
     }
 
     @Test
-    public void stress() throws Exception {
+    void stress() throws Exception {
         assumeTrue(SingleChronicleQueueBuilder.areEnterpriseFeaturesAvailable());
         super.stress();
         assertTrue(true); // parent has asserts

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressReadOnlyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressReadOnlyTest.java
@@ -4,20 +4,21 @@
 package net.openhft.chronicle.queue.impl.single.stress;
 
 import net.openhft.chronicle.core.OS;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class RollCycleMultiThreadStressReadOnlyTest extends RollCycleMultiThreadStressTest {
 
-    public RollCycleMultiThreadStressReadOnlyTest() {
-        super(StressTestType.READONLY);
+    @Override
+    protected StressTestType stressTestType() {
+        return StressTestType.READONLY;
     }
 
     @Test
     public void stress() throws Exception {
-        Assume.assumeFalse("Windows does not support read only", OS.isWindows());
+        assumeFalse(OS.isWindows(), "Windows does not support read only");
         super.stress();
         assertTrue(true); // parent has asserts
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressReadOnlyTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressReadOnlyTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class RollCycleMultiThreadStressReadOnlyTest extends RollCycleMultiThreadStressTest {
+class RollCycleMultiThreadStressReadOnlyTest extends RollCycleMultiThreadStressTest {
 
     @Override
     protected StressTestType stressTestType() {
@@ -17,7 +17,7 @@ public class RollCycleMultiThreadStressReadOnlyTest extends RollCycleMultiThread
     }
 
     @Test
-    public void stress() throws Exception {
+    void stress() throws Exception {
         assumeFalse(OS.isWindows(), "Windows does not support read only");
         super.stress();
         assertTrue(true); // parent has asserts

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressSharedWriterQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressSharedWriterQueueTest.java
@@ -3,12 +3,11 @@
  */
 package net.openhft.chronicle.queue.impl.single.stress;
 
-import org.junit.Test;
-
 public class RollCycleMultiThreadStressSharedWriterQueueTest extends RollCycleMultiThreadStressTest {
 
-    public RollCycleMultiThreadStressSharedWriterQueueTest() {
-        super(StressTestType.SHAREDWRITEQ);
+    @Override
+    protected StressTestType stressTestType() {
+        return StressTestType.SHAREDWRITEQ;
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
@@ -20,9 +20,8 @@ import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.ValueIn;
 import net.openhft.chronicle.wire.ValueOut;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -36,9 +35,10 @@ import java.util.stream.Collectors;
 import static java.lang.Thread.currentThread;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
+@SuppressWarnings("this-escape")
 public class RollCycleMultiThreadStressTest extends QueueTestCommon {
 
     private final long SLEEP_PER_WRITE_NANOS;
@@ -61,10 +61,7 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
     private ChronicleQueue sharedWriterQueue;
 
     public RollCycleMultiThreadStressTest() {
-        this(StressTestType.VANILLA);
-    }
-
-    RollCycleMultiThreadStressTest(StressTestType type) {
+        StressTestType type = stressTestType();
         SLEEP_PER_WRITE_NANOS = Jvm.getLong("writeLatency", 30_000L);
         TEST_TIME = Jvm.getInteger("testTime", 15);
         ROLL_EVERY_MS = Jvm.getInteger("rollEvery", 300);
@@ -88,6 +85,10 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
                 throw new IllegalStateException("This test will run out of memory - change your system properties");
             }
         }
+    }
+
+    protected StressTestType stressTestType() {
+        return StressTestType.VANILLA;
     }
 
     private static boolean areAllReadersComplete(final int expectedNumberOfMessages, final List<Reader> readers) {
@@ -116,8 +117,13 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
         }
     }
 
+    @BeforeEach
+    public void beforeEachRollCycleMultiThreadStressTest() {
+        threadDump();
+        multiCPU();
+    }
+
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
@@ -231,8 +237,7 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
             writerExceptions.append("Writer failed due to: ").append(w.exception.getMessage()).append("\n");
         });
 
-        assertTrue("Wrote " + wrote.get() + " which is less than " + expectedNumberOfMessages + " within timeout. " + writerExceptions,
-                wrote.get() >= expectedNumberOfMessages);
+        assertTrue(wrote.get() >= expectedNumberOfMessages, "Wrote " + wrote.get() + " which is less than " + expectedNumberOfMessages + " within timeout. " + writerExceptions);
 
         readers.stream().filter(r -> r.exception != null).findAny().ifPresent(reader -> {
             throw new AssertionError("Reader encountered exception, so stopped reading messages",
@@ -271,8 +276,7 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
                 // System.out.printf("Not all readers are complete. Waiting...%n");
                 Jvm.pause(2000);
             }
-            assertTrue("Readers did not catch up",
-                    areAllReadersComplete(expectedNumberOfMessages, readers));
+            assertTrue(areAllReadersComplete(expectedNumberOfMessages, readers), "Readers did not catch up");
 
         } finally {
 
@@ -333,9 +337,8 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
         return sharedWriterQueue != null ? sharedWriterQueue : createQueue(path);
     }
 
-    @Before
     public void multiCPU() {
-        Assume.assumeTrue(Runtime.getRuntime().availableProcessors() > 1);
+        assumeTrue(Runtime.getRuntime().availableProcessors() > 1);
     }
 
     enum StressTestType {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
@@ -119,7 +119,7 @@ class RollCycleMultiThreadStressTest extends QueueTestCommon {
 
     @BeforeEach
     void beforeEachRollCycleMultiThreadStressTest() {
-        public threadDump();
+        threadDump();
         multiCPU();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadStressTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 @SuppressWarnings("this-escape")
-public class RollCycleMultiThreadStressTest extends QueueTestCommon {
+class RollCycleMultiThreadStressTest extends QueueTestCommon {
 
     private final long SLEEP_PER_WRITE_NANOS;
     private final int TEST_TIME;
@@ -118,8 +118,8 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
     }
 
     @BeforeEach
-    public void beforeEachRollCycleMultiThreadStressTest() {
-        threadDump();
+    void beforeEachRollCycleMultiThreadStressTest() {
+        public threadDump();
         multiCPU();
     }
 
@@ -129,7 +129,7 @@ public class RollCycleMultiThreadStressTest extends QueueTestCommon {
     }
 
     @Test
-    public void stress() throws Exception {
+    void stress() throws Exception {
         ignoreException(" us to grow file");
         ignoreException("ms to check the disk space of");
         ignoreException("seconds to ASYNC");

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
@@ -11,15 +11,14 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.concurrent.*;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class RollCycleMultiThreadTest extends QueueTestCommon {
 
@@ -50,14 +49,14 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
                     .build();
                  ExcerptAppender appender = queue.createAppender()) {
 
-                Assert.assertEquals(-2, (int) scheduledExecutorService.submit(observer::call).get());
+                assertEquals(-2, (int) scheduledExecutorService.submit(observer::call).get());
                 // two days pass
                 timeProvider.advanceMillis(TimeUnit.DAYS.toMillis(2));
 
                 try (final DocumentContext dc = appender.writingDocument()) {
                     dc.wire().write("say").text("Day 3 data");
                 }
-                Assert.assertEquals(1, (int) scheduledExecutorService.submit(observer::call).get());
+                assertEquals(1, (int) scheduledExecutorService.submit(observer::call).get());
                 assertEquals(1, observer.documentsRead);
 
             }
@@ -72,7 +71,7 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
     public void testRead2() throws ExecutionException, InterruptedException {
         finishedNormally = false;
         File path = getTmpDir();
-        Assume.assumeFalse("Ignored on hugetlbfs as byte offsets will be different due to page size", PageUtil.isHugePage(path.getAbsolutePath()));
+        assumeFalse(PageUtil.isHugePage(path.getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
         SetTimeProvider timeProvider = new SetTimeProvider();
 
         final ExecutorService es = Executors.newSingleThreadExecutor(
@@ -98,7 +97,7 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
                     dc.wire().write("say").text("Day 1 data");
                 }
 
-                Assert.assertEquals(1, (int) es.submit(observer).get());
+                assertEquals(1, (int) es.submit(observer).get());
 
                 assertEquals("" +
                                 "--- !!meta-data #binary\n" +
@@ -167,8 +166,7 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
                                 "--- !!data #binary\n" +
                                 "say: Day 1 data\n" +
                                 "...\n" +
-                                "# 130648 bytes remaining\n",
-                        queue.dump());
+                                "# 130648 bytes remaining\n", queue.dump());
 
                 // two days pass
                 timeProvider.advanceMillis(TimeUnit.DAYS.toMillis(2));
@@ -279,9 +277,8 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
                                 "--- !!data #binary\n" +
                                 "say: Day 3 data\n" +
                                 "...\n" +
-                                "# 130648 bytes remaining\n",
-                        queue.dump());
-                Assert.assertEquals(2, (int) es.submit(observer).get());
+                                "# 130648 bytes remaining\n", queue.dump());
+                assertEquals(2, (int) es.submit(observer).get());
 
                 // System.out.println(queue.dump());
                 assertEquals(2, observer.documentsRead);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
@@ -20,12 +20,12 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class RollCycleMultiThreadTest extends QueueTestCommon {
+class RollCycleMultiThreadTest extends QueueTestCommon {
 
     private static final RollCycle ROLL_CYCLE = TEST_DAILY;
 
     @Test
-    public void testRead1() throws ExecutionException, InterruptedException {
+    void testRead1() throws ExecutionException, InterruptedException {
         finishedNormally = false;
         File path = getTmpDir();
         SetTimeProvider timeProvider = new SetTimeProvider();
@@ -68,7 +68,7 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
     }
 
     @Test
-    public void testRead2() throws ExecutionException, InterruptedException {
+    void testRead2() throws ExecutionException, InterruptedException {
         finishedNormally = false;
         File path = getTmpDir();
         assumeFalse(PageUtil.isHugePage(path.getAbsolutePath()), "Ignored on hugetlbfs as byte offsets will be different due to page size");
@@ -100,73 +100,73 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
                 assertEquals(1, (int) es.submit(observer).get());
 
                 assertEquals("" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !STStore {\n" +
-                                "  wireType: !WireType BINARY_LIGHT,\n" +
-                                "  metadata: !SCQMeta {\n" +
-                                "    roll: !SCQSRoll { length: 86400000, format: yyyyMMdd'T1', epoch: 0 },\n" +
-                                "    sourceId: 0\n" +
-                                "  }\n" +
-                                "}\n" +
-                                "# position: 152, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "listing.highestCycle: 0\n" +
-                                "# position: 192, header: 1\n" +
-                                "--- !!data #binary\n" +
-                                "listing.lowestCycle: 0\n" +
-                                "# position: 232, header: 2\n" +
-                                "--- !!data #binary\n" +
-                                "listing.modCount: 5\n" +
-                                "# position: 264, header: 3\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.write.lock: -9223372036854775808\n" +
-                                "# position: 304, header: 4\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.append.lock: -9223372036854775808\n" +
-                                "# position: 344, header: 5\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.lastIndexReplicated: -1\n" +
-                                "# position: 392, header: 6\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.lastAcknowledgedIndexReplicated: -1\n" +
-                                "# position: 448, header: 7\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.lastIndexMSynced: -1\n" +
-                                "...\n" +
-                                "# 130572 bytes remaining\n" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !SCQStore {\n" +
-                                "  writePosition: [\n" +
-                                "    400,\n" +
-                                "    1717986918400\n" +
-                                "  ],\n" +
-                                "  indexing: !SCQSIndexing {\n" +
-                                "    indexCount: 8,\n" +
-                                "    indexSpacing: 1,\n" +
-                                "    index2Index: 200,\n" +
-                                "    lastIndex: 1\n" +
-                                "  },\n" +
-                                "  dataFormat: 1\n" +
-                                "}\n" +
-                                "# position: 200, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index2index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  304,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 304, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  400,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 400, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "say: Day 1 data\n" +
-                                "...\n" +
-                                "# 130648 bytes remaining\n", queue.dump());
+                        "--- !!meta-data #binary\n" +
+                        "header: !STStore {\n" +
+                        "  wireType: !WireType BINARY_LIGHT,\n" +
+                        "  metadata: !SCQMeta {\n" +
+                        "    roll: !SCQSRoll { length: 86400000, format: yyyyMMdd'T1', epoch: 0 },\n" +
+                        "    sourceId: 0\n" +
+                        "  }\n" +
+                        "}\n" +
+                        "# position: 152, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "listing.highestCycle: 0\n" +
+                        "# position: 192, header: 1\n" +
+                        "--- !!data #binary\n" +
+                        "listing.lowestCycle: 0\n" +
+                        "# position: 232, header: 2\n" +
+                        "--- !!data #binary\n" +
+                        "listing.modCount: 5\n" +
+                        "# position: 264, header: 3\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.write.lock: -9223372036854775808\n" +
+                        "# position: 304, header: 4\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.append.lock: -9223372036854775808\n" +
+                        "# position: 344, header: 5\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.lastIndexReplicated: -1\n" +
+                        "# position: 392, header: 6\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.lastAcknowledgedIndexReplicated: -1\n" +
+                        "# position: 448, header: 7\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.lastIndexMSynced: -1\n" +
+                        "...\n" +
+                        "# 130572 bytes remaining\n" +
+                        "--- !!meta-data #binary\n" +
+                        "header: !SCQStore {\n" +
+                        "  writePosition: [\n" +
+                        "    400,\n" +
+                        "    1717986918400\n" +
+                        "  ],\n" +
+                        "  indexing: !SCQSIndexing {\n" +
+                        "    indexCount: 8,\n" +
+                        "    indexSpacing: 1,\n" +
+                        "    index2Index: 200,\n" +
+                        "    lastIndex: 1\n" +
+                        "  },\n" +
+                        "  dataFormat: 1\n" +
+                        "}\n" +
+                        "# position: 200, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index2index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  304,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 304, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  400,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 400, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "say: Day 1 data\n" +
+                        "...\n" +
+                        "# 130648 bytes remaining\n", queue.dump());
 
                 // two days pass
                 timeProvider.advanceMillis(TimeUnit.DAYS.toMillis(2));
@@ -176,108 +176,108 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
                 }
 
                 assertEquals("" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !STStore {\n" +
-                                "  wireType: !WireType BINARY_LIGHT,\n" +
-                                "  metadata: !SCQMeta {\n" +
-                                "    roll: !SCQSRoll { length: 86400000, format: yyyyMMdd'T1', epoch: 0 },\n" +
-                                "    sourceId: 0\n" +
-                                "  }\n" +
-                                "}\n" +
-                                "# position: 152, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "listing.highestCycle: 2\n" +
-                                "# position: 192, header: 1\n" +
-                                "--- !!data #binary\n" +
-                                "listing.lowestCycle: 0\n" +
-                                "# position: 232, header: 2\n" +
-                                "--- !!data #binary\n" +
-                                "listing.modCount: 8\n" +
-                                "# position: 264, header: 3\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.write.lock: -9223372036854775808\n" +
-                                "# position: 304, header: 4\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.append.lock: -9223372036854775808\n" +
-                                "# position: 344, header: 5\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.lastIndexReplicated: -1\n" +
-                                "# position: 392, header: 6\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.lastAcknowledgedIndexReplicated: -1\n" +
-                                "# position: 448, header: 7\n" +
-                                "--- !!data #binary\n" +
-                                "chronicle.lastIndexMSynced: -1\n" +
-                                "...\n" +
-                                "# 130572 bytes remaining\n" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !SCQStore {\n" +
-                                "  writePosition: [\n" +
-                                "    400,\n" +
-                                "    1717986918400\n" +
-                                "  ],\n" +
-                                "  indexing: !SCQSIndexing {\n" +
-                                "    indexCount: 8,\n" +
-                                "    indexSpacing: 1,\n" +
-                                "    index2Index: 200,\n" +
-                                "    lastIndex: 1\n" +
-                                "  },\n" +
-                                "  dataFormat: 1\n" +
-                                "}\n" +
-                                "# position: 200, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index2index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  304,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 304, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  400,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 400, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "say: Day 1 data\n" +
-                                "# position: 420, header: 0 EOF\n" +
-                                "--- !!not-ready-meta-data #binary\n" +
-                                "...\n" +
-                                "# 130648 bytes remaining\n" +
-                                "--- !!meta-data #binary\n" +
-                                "header: !SCQStore {\n" +
-                                "  writePosition: [\n" +
-                                "    400,\n" +
-                                "    1717986918400\n" +
-                                "  ],\n" +
-                                "  indexing: !SCQSIndexing {\n" +
-                                "    indexCount: 8,\n" +
-                                "    indexSpacing: 1,\n" +
-                                "    index2Index: 200,\n" +
-                                "    lastIndex: 1\n" +
-                                "  },\n" +
-                                "  dataFormat: 1\n" +
-                                "}\n" +
-                                "# position: 200, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index2index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  304,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 304, header: -1\n" +
-                                "--- !!meta-data #binary\n" +
-                                "index: [\n" +
-                                "  # length: 8, used: 1\n" +
-                                "  400,\n" +
-                                "  0, 0, 0, 0, 0, 0, 0\n" +
-                                "]\n" +
-                                "# position: 400, header: 0\n" +
-                                "--- !!data #binary\n" +
-                                "say: Day 3 data\n" +
-                                "...\n" +
-                                "# 130648 bytes remaining\n", queue.dump());
+                        "--- !!meta-data #binary\n" +
+                        "header: !STStore {\n" +
+                        "  wireType: !WireType BINARY_LIGHT,\n" +
+                        "  metadata: !SCQMeta {\n" +
+                        "    roll: !SCQSRoll { length: 86400000, format: yyyyMMdd'T1', epoch: 0 },\n" +
+                        "    sourceId: 0\n" +
+                        "  }\n" +
+                        "}\n" +
+                        "# position: 152, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "listing.highestCycle: 2\n" +
+                        "# position: 192, header: 1\n" +
+                        "--- !!data #binary\n" +
+                        "listing.lowestCycle: 0\n" +
+                        "# position: 232, header: 2\n" +
+                        "--- !!data #binary\n" +
+                        "listing.modCount: 8\n" +
+                        "# position: 264, header: 3\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.write.lock: -9223372036854775808\n" +
+                        "# position: 304, header: 4\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.append.lock: -9223372036854775808\n" +
+                        "# position: 344, header: 5\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.lastIndexReplicated: -1\n" +
+                        "# position: 392, header: 6\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.lastAcknowledgedIndexReplicated: -1\n" +
+                        "# position: 448, header: 7\n" +
+                        "--- !!data #binary\n" +
+                        "chronicle.lastIndexMSynced: -1\n" +
+                        "...\n" +
+                        "# 130572 bytes remaining\n" +
+                        "--- !!meta-data #binary\n" +
+                        "header: !SCQStore {\n" +
+                        "  writePosition: [\n" +
+                        "    400,\n" +
+                        "    1717986918400\n" +
+                        "  ],\n" +
+                        "  indexing: !SCQSIndexing {\n" +
+                        "    indexCount: 8,\n" +
+                        "    indexSpacing: 1,\n" +
+                        "    index2Index: 200,\n" +
+                        "    lastIndex: 1\n" +
+                        "  },\n" +
+                        "  dataFormat: 1\n" +
+                        "}\n" +
+                        "# position: 200, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index2index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  304,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 304, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  400,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 400, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "say: Day 1 data\n" +
+                        "# position: 420, header: 0 EOF\n" +
+                        "--- !!not-ready-meta-data #binary\n" +
+                        "...\n" +
+                        "# 130648 bytes remaining\n" +
+                        "--- !!meta-data #binary\n" +
+                        "header: !SCQStore {\n" +
+                        "  writePosition: [\n" +
+                        "    400,\n" +
+                        "    1717986918400\n" +
+                        "  ],\n" +
+                        "  indexing: !SCQSIndexing {\n" +
+                        "    indexCount: 8,\n" +
+                        "    indexSpacing: 1,\n" +
+                        "    index2Index: 200,\n" +
+                        "    lastIndex: 1\n" +
+                        "  },\n" +
+                        "  dataFormat: 1\n" +
+                        "}\n" +
+                        "# position: 200, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index2index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  304,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 304, header: -1\n" +
+                        "--- !!meta-data #binary\n" +
+                        "index: [\n" +
+                        "  # length: 8, used: 1\n" +
+                        "  400,\n" +
+                        "  0, 0, 0, 0, 0, 0, 0\n" +
+                        "]\n" +
+                        "# position: 400, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "say: Day 3 data\n" +
+                        "...\n" +
+                        "# 130648 bytes remaining\n", queue.dump());
                 assertEquals(2, (int) es.submit(observer).get());
 
                 // System.out.println(queue.dump());

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerBoundaryTest.java
@@ -10,10 +10,8 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,47 +20,34 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class BackwardsTailerBoundaryTest extends QueueTestCommon {
 
     private static final Logger log = LoggerFactory.getLogger(BackwardsTailerBoundaryTest.class);
 
-    private SetTimeProvider timeProvider;
-
-    private final RollCycle rollCycle;
-
-    public BackwardsTailerBoundaryTest(RollCycle rollCycle) {
-        this.rollCycle = rollCycle;
-    }
-
-    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         final List<Object[]> data = new ArrayList<>();
         data.add(new Object[]{TestRollCycles.TEST4_DAILY});
         return data;
     }
 
-    @Before
-    public void before() {
-        timeProvider = new SetTimeProvider();
-    }
-
-    @Test
-    public void verifyConsistency() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void verifyConsistency(RollCycle rollCycle) {
+        SetTimeProvider timeProvider = new SetTimeProvider();
         @NotNull File path = getTmpDir();
         IOTools.deleteDirWithFiles(path);
-        try (SingleChronicleQueue queue = createQueue(path, rollCycle);
+        try (SingleChronicleQueue queue = createQueue(path, rollCycle, timeProvider);
              ExcerptAppender appender = queue.createAppender();
              ExcerptTailer tailer = queue.createTailer().direction(TailerDirection.BACKWARD)) {
 
-            assertEquals("Backwards tailer should start at index 0 when no queue data", 0, tailer.index());
+            assertEquals(0, tailer.index(), "Backwards tailer should start at index 0 when no queue data");
 
             long messagesPerCycle = (long) rollCycle.defaultIndexSpacing() * rollCycle.defaultIndexCount() * 5;
 
             for (int i = 0; i < messagesPerCycle * 5; i++) {
-                advanceTimeBeforeRollCycleFills(i, messagesPerCycle, queue);
+                advanceTimeBeforeRollCycleFills(i, messagesPerCycle, queue, rollCycle, timeProvider);
                 long lastIndexAppended = writeDataToQueue(appender, i, queue);
 
                 // Move to end
@@ -87,7 +72,7 @@ public class BackwardsTailerBoundaryTest extends QueueTestCommon {
         return lastIndexAppended;
     }
 
-    private void advanceTimeBeforeRollCycleFills(int i, long messagesPerCycle, SingleChronicleQueue queue) {
+    private void advanceTimeBeforeRollCycleFills(int i, long messagesPerCycle, SingleChronicleQueue queue, RollCycle rollCycle, SetTimeProvider timeProvider) {
         if (i > 0 && i % messagesPerCycle == 0) {
             log.info("Advancing time to move to next cycle. Current cycle={}", queue.cycle());
             timeProvider.advanceMillis(rollCycle.lengthInMillis());
@@ -95,8 +80,7 @@ public class BackwardsTailerBoundaryTest extends QueueTestCommon {
     }
 
     @NotNull
-    private SingleChronicleQueue createQueue(File path,
-                                             RollCycle rollCycle) {
+    private SingleChronicleQueue createQueue(File path, RollCycle rollCycle, SetTimeProvider timeProvider) {
         return SingleChronicleQueueBuilder
                 .builder()
                 .timeProvider(timeProvider)

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerBoundaryTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class BackwardsTailerBoundaryTest extends QueueTestCommon {
+class BackwardsTailerBoundaryTest extends QueueTestCommon {
 
     private static final Logger log = LoggerFactory.getLogger(BackwardsTailerBoundaryTest.class);
 
@@ -34,7 +34,7 @@ public class BackwardsTailerBoundaryTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void verifyConsistency(RollCycle rollCycle) {
+    void verifyConsistency(RollCycle rollCycle) {
         SetTimeProvider timeProvider = new SetTimeProvider();
         @NotNull File path = getTmpDir();
         IOTools.deleteDirWithFiles(path);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndPerfAcceptanceTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndPerfAcceptanceTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class BackwardsTailerToEndPerfAcceptanceTest extends QueueTestCommon {
+class BackwardsTailerToEndPerfAcceptanceTest extends QueueTestCommon {
 
     private static final Logger log = LoggerFactory.getLogger(BackwardsTailerToEndPerfAcceptanceTest.class);
 
@@ -52,7 +52,7 @@ public class BackwardsTailerToEndPerfAcceptanceTest extends QueueTestCommon {
     @Disabled("Disabled as too flaky when run as part of the full test suite")
     @ParameterizedTest
     @MethodSource("data")
-    public void fromBeginning(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
+    void fromBeginning(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
         long baseline = captureBaseline(rollCycle, tailerIndexStartPosition);
         long duration = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing() + 1, TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
         assertReasonablePerformance(duration, baseline);
@@ -61,7 +61,7 @@ public class BackwardsTailerToEndPerfAcceptanceTest extends QueueTestCommon {
     @Disabled("Disabled as too flaky when run as part of the full test suite")
     @ParameterizedTest
     @MethodSource("data")
-    public void lessThanBoundary(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
+    void lessThanBoundary(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
         long baseline = captureBaseline(rollCycle, tailerIndexStartPosition);
         long duration = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing() + 1, TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
         assertReasonablePerformance(duration, baseline);
@@ -70,7 +70,7 @@ public class BackwardsTailerToEndPerfAcceptanceTest extends QueueTestCommon {
     @Disabled("Disabled as too flaky when run as part of the full test suite")
     @ParameterizedTest
     @MethodSource("data")
-    public void onBoundary(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
+    void onBoundary(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
         long baseline = captureBaseline(rollCycle, tailerIndexStartPosition);
         long duration = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing(), TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
         assertReasonablePerformance(duration, baseline);
@@ -79,7 +79,7 @@ public class BackwardsTailerToEndPerfAcceptanceTest extends QueueTestCommon {
     @Disabled("Disabled as too flaky when run as part of the full test suite")
     @ParameterizedTest
     @MethodSource("data")
-    public void greaterThanBoundary(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
+    void greaterThanBoundary(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
         long baseline = captureBaseline(rollCycle, tailerIndexStartPosition);
         long duration = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing() - 1, TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
         assertReasonablePerformance(duration, baseline);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndPerfAcceptanceTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/backwardstailer/BackwardsTailerToEndPerfAcceptanceTest.java
@@ -12,11 +12,9 @@ import net.openhft.chronicle.queue.rollcycles.LargeRollCycles;
 import net.openhft.chronicle.queue.rollcycles.LegacyRollCycles;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,25 +23,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class BackwardsTailerToEndPerfAcceptanceTest extends QueueTestCommon {
 
     private static final Logger log = LoggerFactory.getLogger(BackwardsTailerToEndPerfAcceptanceTest.class);
 
-    private final RollCycle rollCycle;
-
-    private final TailerIndexStartPosition tailerIndexStartPosition;
-
-    private long baseline;
-
-    public BackwardsTailerToEndPerfAcceptanceTest(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
-        this.rollCycle = rollCycle;
-        this.tailerIndexStartPosition = tailerIndexStartPosition;
-    }
-
-    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         final List<Object[]> data = new ArrayList<>();
         data.add(new Object[]{TestRollCycles.TEST_HOURLY, TailerIndexStartPosition.BEGINNING});
@@ -56,57 +41,64 @@ public class BackwardsTailerToEndPerfAcceptanceTest extends QueueTestCommon {
         return data;
     }
 
-    @Before
-    public void before() {
-        // Capture baseline performance of toEnd
+    private long captureBaseline(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
         log.info("rollCycle={}, tailerIndexStartPosition={}", rollCycle, tailerIndexStartPosition);
         log.info("Capturing baseline performance. rollCycle={}", rollCycle);
-        baseline = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing() - 1, TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
+        long baseline = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing() - 1, TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
         log.info("Baseline performance captured. rollCycle={}", rollCycle);
+        return baseline;
     }
 
-    @Ignore("Disabled as too flaky when run as part of the full test suite")
-    @Test
-    public void fromBeginning() {
+    @Disabled("Disabled as too flaky when run as part of the full test suite")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void fromBeginning(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
+        long baseline = captureBaseline(rollCycle, tailerIndexStartPosition);
         long duration = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing() + 1, TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
-        assertReasonablePerformance(duration);
+        assertReasonablePerformance(duration, baseline);
     }
 
-    @Ignore("Disabled as too flaky when run as part of the full test suite")
-    @Test
-    public void lessThanBoundary() {
+    @Disabled("Disabled as too flaky when run as part of the full test suite")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void lessThanBoundary(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
+        long baseline = captureBaseline(rollCycle, tailerIndexStartPosition);
         long duration = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing() + 1, TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
-        assertReasonablePerformance(duration);
+        assertReasonablePerformance(duration, baseline);
     }
 
-    @Ignore("Disabled as too flaky when run as part of the full test suite")
-    @Test
-    public void onBoundary() {
+    @Disabled("Disabled as too flaky when run as part of the full test suite")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void onBoundary(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
+        long baseline = captureBaseline(rollCycle, tailerIndexStartPosition);
         long duration = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing(), TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
-        assertReasonablePerformance(duration);
+        assertReasonablePerformance(duration, baseline);
     }
 
-    @Ignore("Disabled as too flaky when run as part of the full test suite")
-    @Test
-    public void greaterThanBoundary() {
+    @Disabled("Disabled as too flaky when run as part of the full test suite")
+    @ParameterizedTest
+    @MethodSource("data")
+    public void greaterThanBoundary(RollCycle rollCycle, TailerIndexStartPosition tailerIndexStartPosition) {
+        long baseline = captureBaseline(rollCycle, tailerIndexStartPosition);
         long duration = runTest(rollCycle.defaultIndexCount() * rollCycle.defaultIndexSpacing() - 1, TailerDirection.BACKWARD, tailerIndexStartPosition, rollCycle);
-        assertReasonablePerformance(duration);
+        assertReasonablePerformance(duration, baseline);
     }
 
-    private void assertReasonablePerformance(long duration) {
+    private void assertReasonablePerformance(long duration, long baseline) {
         double factor = (double) duration / baseline;
         long baselineUs = baseline / 1000;
         long durationUs = duration / 1000;
         String message = "Performance of this test was " + factor + "x baseline. baseline=" + baselineUs + "us, duration=" + durationUs + "us.";
         log.info(message);
-        assertTrue(message, factor < 10);
+        assertTrue(factor < 10, message);
     }
 
     private void populateQueue(int entriesToWrite, ExcerptAppender appender) {
         for (int i = 0; i < entriesToWrite; i++) {
             appender.writeText("message_" + i);
 
-            if (rollCycle.equals(TestRollCycles.TEST2_DAILY)) {
+            if (appender.queue().rollCycle().equals(TestRollCycles.TEST2_DAILY)) {
                 log.info("lastIndexAppended={}", appender.lastIndexAppended());
             }
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
@@ -20,33 +20,33 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SingleTableStoreIntegrationTests extends QueueTestCommon {
+class SingleTableStoreIntegrationTests extends QueueTestCommon {
 
     private TestContext context;
 
     @BeforeEach
-    public void beforeEach() {
+    void beforeEach() {
         context = new TestContext();
     }
 
     @AfterEach
-    public void after() throws IOException {
+    void after() throws IOException {
         context.close();
     }
 
     @Test
-    public void baseCasePutAndGet() {
+    void baseCasePutAndGet() {
         context.newQueueInstance().tableStorePut("a", 1);
         assertEquals(1, context.newQueueInstance().tableStoreGet("a"));
     }
 
     @Test
-    public void getMissingKeyWithoutDefault() {
+    void getMissingKeyWithoutDefault() {
         assertEquals(Long.MIN_VALUE, context.newQueueInstance().tableStoreGet("test"));
     }
 
     @Test
-    public void growNumberOfKeys() {
+    void growNumberOfKeys() {
         SingleChronicleQueue queue1 = context.newQueueInstance();
         queue1.tableStorePut("a", 1);
         queue1.tableStorePut("b", 2);
@@ -61,7 +61,7 @@ public class SingleTableStoreIntegrationTests extends QueueTestCommon {
     }
 
     @Test
-    public void largeNumberOfKeyValuePairs() {
+    void largeNumberOfKeyValuePairs() {
         finishedNormally = false;
         SingleChronicleQueue queue1 = context.newQueueInstance();
         int count = 4_000;
@@ -75,7 +75,7 @@ public class SingleTableStoreIntegrationTests extends QueueTestCommon {
     }
 
     @Test
-    public void longKeyPutAndGet() {
+    void longKeyPutAndGet() {
         SingleChronicleQueue queue1 = context.newQueueInstance();
         StringBuilder keyBuffer = new StringBuilder("AAAA");
         Random random = new Random();

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreIntegrationTests.java
@@ -7,9 +7,9 @@ import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.Closeable;
 import java.io.File;
@@ -18,18 +18,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SingleTableStoreIntegrationTests extends QueueTestCommon {
 
     private TestContext context;
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         context = new TestContext();
     }
 
-    @After
+    @AfterEach
     public void after() throws IOException {
         context.close();
     }

--- a/src/test/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpecTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpecTest.java
@@ -78,9 +78,7 @@ class QueueOffsetSpecTest {
 
     @Test
     void parseRollTimeWithInvalidZoneFailsValidation() {
-        assertThrows(java.time.DateTimeException.class, () -> {
-            QueueOffsetSpec spec = QueueOffsetSpec.parse("ROLL_TIME;12:00;Invalid/Zone");
-            spec.validate();
-        });
+        QueueOffsetSpec spec = QueueOffsetSpec.parse("ROLL_TIME;12:00;Invalid/Zone");
+        assertThrows(java.time.DateTimeException.class, spec::validate);
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpecTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpecTest.java
@@ -4,12 +4,12 @@
 package net.openhft.chronicle.queue.internal.domestic;
 
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalTime;
 import java.time.ZoneId;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class QueueOffsetSpecTest {
 
@@ -42,9 +42,11 @@ public class QueueOffsetSpecTest {
         assertEquals("NONE", QueueOffsetSpec.formatNone());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void parseWithTooFewTokensThrows() {
-        QueueOffsetSpec.parse("ROLL_TIME;12:00");
+        assertThrows(IllegalArgumentException.class, () -> {
+            QueueOffsetSpec.parse("ROLL_TIME;12:00");
+        });
     }
 
     @Test
@@ -67,14 +69,18 @@ public class QueueOffsetSpecTest {
         assertEquals("NONE;", builder.queueOffsetSpec().format());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void parseUnknownTypeThrows() {
-        QueueOffsetSpec.parse("INVALID;foo");
+        assertThrows(IllegalArgumentException.class, () -> {
+            QueueOffsetSpec.parse("INVALID;foo");
+        });
     }
 
-    @Test(expected = java.time.DateTimeException.class)
+    @Test
     public void parseRollTimeWithInvalidZoneFailsValidation() {
-        QueueOffsetSpec spec = QueueOffsetSpec.parse("ROLL_TIME;12:00;Invalid/Zone");
-        spec.validate();
+        assertThrows(java.time.DateTimeException.class, () -> {
+            QueueOffsetSpec spec = QueueOffsetSpec.parse("ROLL_TIME;12:00;Invalid/Zone");
+            spec.validate();
+        });
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpecTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpecTest.java
@@ -11,10 +11,10 @@ import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class QueueOffsetSpecTest {
+class QueueOffsetSpecTest {
 
     @Test
-    public void parseEpochAndApplySetsBuilderEpoch() {
+    void parseEpochAndApplySetsBuilderEpoch() {
         QueueOffsetSpec spec = QueueOffsetSpec.parse("EPOCH;12345");
         SingleChronicleQueueBuilder b = SingleChronicleQueueBuilder.single();
         spec.apply(b);
@@ -24,7 +24,7 @@ public class QueueOffsetSpecTest {
     }
 
     @Test
-    public void parseRollTimeAndApplySetsRollTimeAndZone() {
+    void parseRollTimeAndApplySetsRollTimeAndZone() {
         String def = "ROLL_TIME;12:34;Europe/London";
         QueueOffsetSpec spec = QueueOffsetSpec.parse(def);
         SingleChronicleQueueBuilder b = SingleChronicleQueueBuilder.single();
@@ -38,19 +38,19 @@ public class QueueOffsetSpecTest {
     }
 
     @Test
-    public void formatNoneReturnsBareType() {
+    void formatNoneReturnsBareType() {
         assertEquals("NONE", QueueOffsetSpec.formatNone());
     }
 
     @Test
-    public void parseWithTooFewTokensThrows() {
+    void parseWithTooFewTokensThrows() {
         assertThrows(IllegalArgumentException.class, () -> {
             QueueOffsetSpec.parse("ROLL_TIME;12:00");
         });
     }
 
     @Test
-    public void formatAndParseEpochRoundTrip() {
+    void formatAndParseEpochRoundTrip() {
         long epoch = 42_000L;
         String formatted = QueueOffsetSpec.formatEpochOffset(epoch);
         QueueOffsetSpec parsed = QueueOffsetSpec.parse(formatted);
@@ -60,7 +60,7 @@ public class QueueOffsetSpecTest {
     }
 
     @Test
-    public void applyNoneDoesNotChangeBuilder() {
+    void applyNoneDoesNotChangeBuilder() {
         QueueOffsetSpec spec = QueueOffsetSpec.ofNone();
         SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.single().queueOffsetSpec(spec);
         long originalEpoch = builder.epoch();
@@ -70,14 +70,14 @@ public class QueueOffsetSpecTest {
     }
 
     @Test
-    public void parseUnknownTypeThrows() {
+    void parseUnknownTypeThrows() {
         assertThrows(IllegalArgumentException.class, () -> {
             QueueOffsetSpec.parse("INVALID;foo");
         });
     }
 
     @Test
-    public void parseRollTimeWithInvalidZoneFailsValidation() {
+    void parseRollTimeWithInvalidZoneFailsValidation() {
         assertThrows(java.time.DateTimeException.class, () -> {
             QueueOffsetSpec spec = QueueOffsetSpec.parse("ROLL_TIME;12:00;Invalid/Zone");
             spec.validate();

--- a/src/test/java/net/openhft/chronicle/queue/internal/main/InternalDumpMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/main/InternalDumpMainTest.java
@@ -18,10 +18,10 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class InternalDumpMainTest extends QueueTestCommon {
+class InternalDumpMainTest extends QueueTestCommon {
 
     @Test
-    public void shouldDumpDirectoryAndIncludeMetadataAndQueueFiles() throws Exception {
+    void shouldDumpDirectoryAndIncludeMetadataAndQueueFiles() throws Exception {
         final File dir = getTmpDir();
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(dir).build();
              ExcerptAppender appender = queue.createAppender()) {

--- a/src/test/java/net/openhft/chronicle/queue/internal/main/InternalDumpMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/main/InternalDumpMainTest.java
@@ -8,17 +8,15 @@ import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Stream;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class InternalDumpMainTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/internal/main/InternalRemovableRollFileCandidatesMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/main/InternalRemovableRollFileCandidatesMainTest.java
@@ -10,7 +10,7 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import net.openhft.chronicle.queue.main.RemovableRollFileCandidatesMain;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -18,8 +18,8 @@ import java.io.PrintStream;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class InternalRemovableRollFileCandidatesMainTest extends QueueTestCommon {
 
@@ -31,7 +31,7 @@ public class InternalRemovableRollFileCandidatesMainTest extends QueueTestCommon
 
         final String output = invokeMain(InternalRemovableRollFileCandidatesMain::main, dir.getAbsolutePath());
 
-        assertFalse("Expected removable candidates to be printed", output.trim().isEmpty());
+        assertFalse(output.trim().isEmpty(), "Expected removable candidates to be printed");
         assertTrue(output.contains(dir.getAbsolutePath()));
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/internal/main/InternalRemovableRollFileCandidatesMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/main/InternalRemovableRollFileCandidatesMainTest.java
@@ -21,10 +21,10 @@ import java.util.function.Consumer;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class InternalRemovableRollFileCandidatesMainTest extends QueueTestCommon {
+class InternalRemovableRollFileCandidatesMainTest extends QueueTestCommon {
 
     @Test
-    public void internalMainPrintsRemovableFiles() {
+    void internalMainPrintsRemovableFiles() {
         assumeTrue(OS.isLinux());
 
         final File dir = prepareQueueWithMultipleCycles();
@@ -36,7 +36,7 @@ public class InternalRemovableRollFileCandidatesMainTest extends QueueTestCommon
     }
 
     @Test
-    public void publicMainDelegatesToInternal() {
+    void publicMainDelegatesToInternal() {
         assumeTrue(OS.isLinux());
 
         final File dir = prepareQueueWithMultipleCycles();

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
@@ -14,15 +14,14 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.reader.ChronicleHistoryReader;
 import net.openhft.chronicle.wire.*;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ChronicleHistoryReaderTest extends QueueTestCommon {
 
@@ -51,9 +50,9 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
         MessageHistory.set(mh);
 
         int extraTiming = 1;
-        File queuePath1 = IOTools.createTempFile(testName.getMethodName() + "1-");
-        File queuePath2 = IOTools.createTempFile(testName.getMethodName() + "2-");
-        File queuePath3 = IOTools.createTempFile(testName.getMethodName() + "3-");
+        File queuePath1 = IOTools.createTempFile(testMethodName + "1-");
+        File queuePath2 = IOTools.createTempFile(testMethodName + "2-");
+        File queuePath3 = IOTools.createTempFile(testMethodName + "3-");
         try {
             try (ChronicleQueue out = queue(queuePath1, 1)) {
                 DummyListener writer = out
@@ -71,15 +70,15 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
                 DummyListenerId dummy = msg -> {
                     numberRead.incrementAndGet();
                     MessageHistory history = MessageHistory.get();
-                    Assert.assertEquals(1, history.sources());
+                    assertEquals(1, history.sources());
                     // written 1st then received by me
-                    Assert.assertEquals(1 + extraTiming, history.timings());
+                    assertEquals(1 + extraTiming, history.timings());
                     // this writes 2 more timestamps
                     writer.say(msg);
                 };
                 MethodReader reader = in.createTailer().methodReader(dummy);
                 assertTrue(reader.readOne());
-                assertEquals("check routed to correct dest", 1, numberRead.get());
+                assertEquals(1, numberRead.get(), "check routed to correct dest");
                 assertFalse(reader.readOne());
             }
 
@@ -91,14 +90,14 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
                 DummyListenerId dummy = msg -> {
                     numberRead.incrementAndGet();
                     MessageHistory history = MessageHistory.get();
-                    Assert.assertEquals(2, history.sources());
-                    Assert.assertEquals(3 + extraTiming, history.timings());
+                    assertEquals(2, history.sources());
+                    assertEquals(3 + extraTiming, history.timings());
                     // this writes 2 more timestamps
                     writer.say(msg);
                 };
                 MethodReader reader = in.createTailer().methodReader(dummy);
                 assertTrue(reader.readOne());
-                assertEquals("check routed to correct dest", 1, numberRead.get());
+                assertEquals(1, numberRead.get(), "check routed to correct dest");
                 assertFalse(reader.readOne());
             }
 
@@ -109,8 +108,8 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
                 Map<String, Histogram> histos = chronicleHistoryReader.readChronicle();
                 chronicleHistoryReader.outputData();
 
-                Assert.assertEquals(5, histos.size());
-                Assert.assertEquals("[1, startTo1, 2, 1to2, endToEnd]", histos.keySet().toString());
+                assertEquals(5, histos.size());
+                assertEquals("[1, startTo1, 2, 1to2, endToEnd]", histos.keySet().toString());
             }
         } finally {
             IOTools.deleteDirWithFiles(queuePath1.toString(), queuePath2.toString(), queuePath3.toString());
@@ -203,9 +202,9 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
         mh.addSourceDetails(true);
         MessageHistory.set(mh);
 
-        File queuePath1 = IOTools.createTempFile(testName.getMethodName() + "1-");
-        File queuePath2 = IOTools.createTempFile(testName.getMethodName() + "2-");
-        File queuePath3 = IOTools.createTempFile(testName.getMethodName() + "3-");
+        File queuePath1 = IOTools.createTempFile(testMethodName + "1-");
+        File queuePath2 = IOTools.createTempFile(testMethodName + "2-");
+        File queuePath3 = IOTools.createTempFile(testMethodName + "3-");
         try {
             StringBuilder sb = new StringBuilder();
             try (ChronicleQueue q1 = queue(queuePath1, 1);
@@ -235,7 +234,7 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
                     chronicleHistoryReader.withStartIndex(startIndexOffset + q3.firstIndex());
                 chronicleHistoryReader.readChronicle();
                 chronicleHistoryReader.outputData();
-                Assert.assertEquals(output, sb.toString());
+                assertEquals(output, sb.toString());
 
                 writer1.say("again");
                 assertTrue(reader1.readOne());
@@ -246,19 +245,17 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
                 sb.setLength(0);
                 chronicleHistoryReader.readChronicle();
                 chronicleHistoryReader.outputData();
-                Assert.assertEquals("re-reading should only show new data",
-                        "Timings below in MICROSECONDS\n" +
-                                "sourceId                   1     startTo1            2         1to2     endToEnd \n" +
-                                "count:                     1            1            1            1            1 \n" +
-                                "50:                        9           19            9           19           60 \n" +
-                                "90:                        9           19            9           19           60 \n" +
-                                "99:                        9           19            9           19           60 \n" +
-                                "99.9:                                                                            \n" +
-                                "99.99:                                                                           \n" +
-                                "99.999:                                                                          \n" +
-                                "99.9999:                                                                         \n" +
-                                "worst:                     9           19            9           19           60 \n",
-                        sb.toString());
+                assertEquals("Timings below in MICROSECONDS\n" +
+                        "sourceId                   1     startTo1            2         1to2     endToEnd \n" +
+                        "count:                     1            1            1            1            1 \n" +
+                        "50:                        9           19            9           19           60 \n" +
+                        "90:                        9           19            9           19           60 \n" +
+                        "99:                        9           19            9           19           60 \n" +
+                        "99.9:                                                                            \n" +
+                        "99.99:                                                                           \n" +
+                        "99.999:                                                                          \n" +
+                        "99.9999:                                                                         \n" +
+                        "worst:                     9           19            9           19           60 \n", sb.toString(), "re-reading should only show new data");
             }
         } finally {
             IOTools.deleteDirWithFiles(queuePath1.toString(), queuePath2.toString(), queuePath3.toString());

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleHistoryReaderTest.java
@@ -23,10 +23,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ChronicleHistoryReaderTest extends QueueTestCommon {
+class ChronicleHistoryReaderTest extends QueueTestCommon {
 
     @Test
-    public void testWithQueueHistoryRecordHistoryInitial() {
+    void testWithQueueHistoryRecordHistoryInitial() {
         if (OS.isWindows())
             expectException("Read-only mode is not supported on Windows");
 
@@ -34,7 +34,7 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testWithQueueHistoryRecordHistoryInitialMethodIds() {
+    void testWithQueueHistoryRecordHistoryInitialMethodIds() {
         if (OS.isWindows())
             expectException("Read-only mode is not supported on Windows");
 
@@ -117,7 +117,7 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testPredictable() {
+    void testPredictable() {
         runPredictable(0, null, "Timings below in MICROSECONDS\n" +
                 "sourceId                   1     startTo1            2         1to2     endToEnd \n" +
                 "count:                   100          100          100          100          100 \n" +
@@ -132,7 +132,7 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testPredictableStartIndex() {
+    void testPredictableStartIndex() {
         runPredictable(0, 33L, "Timings below in MICROSECONDS\n" +
                 "sourceId                   1     startTo1            2         1to2     endToEnd \n" +
                 "count:                    67           67           67           67           67 \n" +
@@ -147,7 +147,7 @@ public class ChronicleHistoryReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testPredictableMeasurementWindow() {
+    void testPredictableMeasurementWindow() {
         runPredictable(2_800, null, "Timings below in MICROSECONDS\n" +
                 "sourceId                   1     startTo1            2         1to2     endToEnd \n" +
                 "count:                     1            1            1            1            1 \n" +

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
@@ -198,8 +198,8 @@ class ChronicleMethodReaderTest extends QueueTestCommon {
         capturedOutput.forEach(msg -> assertFalse(msg.contains("goodbye")));
     }
 
-    @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1150")
     @Test
+    @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1150")
     void shouldFilterByMultipleExclusionRegex() {
         basicReaderMethodReader().withExclusionRegex(".*bye$").withExclusionRegex(".*ell.*").execute();
 

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
@@ -30,13 +30,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class ChronicleMethodReaderTest extends QueueTestCommon {
+class ChronicleMethodReaderTest extends QueueTestCommon {
 
     private final Queue<String> capturedOutput = new ConcurrentLinkedQueue<>();
     private Path dataDir;
 
     @BeforeEach
-    public void before() {
+    void before() {
         dataDir = getTmpDir().toPath();
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.binary(dataDir)
                 .sourceId(1)
@@ -64,7 +64,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldNotFailOnEmptyQueue() {
+    void shouldNotFailOnEmptyQueue() {
         if (!OS.isWindows())
             expectException("Failback to readonly tablestore");
         Path path = getTmpDir().toPath();
@@ -88,7 +88,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldNotFailWhenNoMetadata() throws IOException {
+    void shouldNotFailWhenNoMetadata() throws IOException {
         if (!OS.isWindows())
             expectException("Failback to readonly tablestore");
         Files.list(dataDir).filter(f -> f.getFileName().toString().endsWith(SingleTableStore.SUFFIX)).findFirst().ifPresent(path -> path.toFile().delete());
@@ -97,14 +97,14 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldIncludeMessageHistoryByDefault() {
+    void shouldIncludeMessageHistoryByDefault() {
         basicReader().execute();
 
         assertTrue(capturedOutput.stream().anyMatch(msg -> msg.contains("history:")));
     }
 
     @Test
-    public void shouldApplyIncludeRegexToHistoryMessagesAndBusinessMessages() {
+    void shouldApplyIncludeRegexToHistoryMessagesAndBusinessMessages() {
         basicReader()
                 .withInclusionRegex("goodbye") // matches goodbye, but not hello or history
                 .asMethodReader("")
@@ -114,7 +114,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldBeAbleToReadFromReadOnlyFile() throws IOException {
+    void shouldBeAbleToReadFromReadOnlyFile() throws IOException {
         assumeFalse(OS.isWindows(), "#460 read-only not supported on Windows");
         final Path queueFile = Files.list(dataDir).
                 filter(f -> f.getFileName().toString().endsWith(SingleChronicleQueue.SUFFIX)).findFirst().
@@ -127,7 +127,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldConvertEntriesToTextMethodReader() {
+    void shouldConvertEntriesToTextMethodReader() {
         basicReaderMethodReader().execute();
         long msgCount =
                 capturedOutput.stream()
@@ -141,7 +141,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldNotConvertEntriesToText() {
+    void shouldNotConvertEntriesToText() {
         basicReader().execute();
         long msgCount =
                 capturedOutput.stream()
@@ -160,7 +160,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldFilterByInclusionRegex() {
+    void shouldFilterByInclusionRegex() {
         basicReader().withInclusionRegex(".*good.*").execute();
 
         assertEquals(24, capturedOutput.size());
@@ -170,7 +170,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldFilterByMultipleInclusionRegex() {
+    void shouldFilterByMultipleInclusionRegex() {
         basicReader()
                 .withInclusionRegex(".*bye.*")
                 .withInclusionRegex(".*o.*")
@@ -184,12 +184,12 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldThrowExceptionIfInputDirectoryDoesNotExist() {
+    void shouldThrowExceptionIfInputDirectoryDoesNotExist() {
         assertThrows(IllegalArgumentException.class, () -> basicReader().withBasePath(Paths.get("/does/not/exist")).execute());
     }
 
     @Test
-    public void shouldFilterByExclusionRegex() {
+    void shouldFilterByExclusionRegex() {
         basicReader().withExclusionRegex(".*good.*").execute();
 
         long msgCount =
@@ -203,14 +203,14 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
 
     @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1150")
     @Test
-    public void shouldFilterByMultipleExclusionRegex() {
+    void shouldFilterByMultipleExclusionRegex() {
         basicReaderMethodReader().withExclusionRegex(".*bye$").withExclusionRegex(".*ell.*").execute();
 
         assertEquals(0L, capturedOutput.stream().filter(msg -> !msg.startsWith("0x")).count());
     }
 
     @Test
-    public void shouldReturnNoMoreThanTheSpecifiedNumberOfMaxRecords() {
+    void shouldReturnNoMoreThanTheSpecifiedNumberOfMaxRecords() {
         basicReaderMethodReader().historyRecords(5).execute();
 
         assertEquals(5, capturedOutput.stream()
@@ -218,12 +218,12 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldFailIfSpecifiedIndexIsBeforeFirstIndex() {
+    void shouldFailIfSpecifiedIndexIsBeforeFirstIndex() {
         assertThrows(IllegalArgumentException.class, () -> basicReader().withStartIndex(1L).execute());
     }
 
     @Test
-    public void shouldNotRewindPastStartOfQueueWhenDisplayingHistory() {
+    void shouldNotRewindPastStartOfQueueWhenDisplayingHistory() {
         basicReader().historyRecords(Long.MAX_VALUE).execute();
 
         assertEquals(24, capturedOutput.stream()
@@ -240,7 +240,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     }
 
     @AfterEach
-    public void clearInterrupt() {
+    void clearInterrupt() {
         Thread.interrupted();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
@@ -24,9 +24,6 @@ import java.nio.file.Paths;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
@@ -166,7 +163,7 @@ class ChronicleMethodReaderTest extends QueueTestCommon {
         assertEquals(24, capturedOutput.size());
         capturedOutput.stream()
                 .filter(msg -> !msg.startsWith("0x"))
-                .forEach(msg -> assertThat(msg, containsString("goodbye")));
+                .forEach(msg -> assertTrue(msg.contains("goodbye")));
     }
 
     @Test
@@ -178,9 +175,9 @@ class ChronicleMethodReaderTest extends QueueTestCommon {
 
         assertEquals(24, capturedOutput.size());
         capturedOutput.stream().filter(msg -> !msg.startsWith("0x")).
-                forEach(msg -> assertThat(msg, containsString("goodbye")));
+                forEach(msg -> assertTrue(msg.contains("goodbye")));
         capturedOutput.stream().filter(msg -> !msg.startsWith("0x")).
-                forEach(msg -> assertThat(msg, not(containsString("hello"))));
+                forEach(msg -> assertFalse(msg.contains("hello")));
     }
 
     @Test
@@ -198,7 +195,7 @@ class ChronicleMethodReaderTest extends QueueTestCommon {
 //                        .peek(System.out::println)
                         .count();
         assertEquals(12, msgCount);
-        capturedOutput.forEach(msg -> assertThat(msg, not(containsString("goodbye"))));
+        capturedOutput.forEach(msg -> assertFalse(msg.contains("goodbye")));
     }
 
     @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1150")

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleMethodReaderTest.java
@@ -15,10 +15,7 @@ import net.openhft.chronicle.wire.BytesInBinaryMarshallable;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.VanillaMethodWriterBuilder;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -30,15 +27,15 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class ChronicleMethodReaderTest extends QueueTestCommon {
 
     private final Queue<String> capturedOutput = new ConcurrentLinkedQueue<>();
     private Path dataDir;
 
-    @Before
+    @BeforeEach
     public void before() {
         dataDir = getTmpDir().toPath();
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.binary(dataDir)
@@ -79,7 +76,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     @NotNull
     private ChronicleReader basicReader(Path path) {
         if (OS.isWindows())
-            if (!testName.getMethodName().startsWith("shouldThrowExceptionIfInputDirectoryDoesNotExist"))
+            if (!testMethodName.startsWith("shouldThrowExceptionIfInputDirectoryDoesNotExist"))
                 expectException("Read-only mode is not supported on Windows");
 
         return new ChronicleReader().withBasePath(path).withMessageSink(capturedOutput::add);
@@ -118,7 +115,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
 
     @Test
     public void shouldBeAbleToReadFromReadOnlyFile() throws IOException {
-        assumeFalse("#460 read-only not supported on Windows", OS.isWindows());
+        assumeFalse(OS.isWindows(), "#460 read-only not supported on Windows");
         final Path queueFile = Files.list(dataDir).
                 filter(f -> f.getFileName().toString().endsWith(SingleChronicleQueue.SUFFIX)).findFirst().
                 orElseThrow(() ->
@@ -186,9 +183,9 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
                 forEach(msg -> assertThat(msg, not(containsString("hello"))));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfInputDirectoryDoesNotExist() {
-        basicReader().withBasePath(Paths.get("/does/not/exist")).execute();
+        assertThrows(IllegalArgumentException.class, () -> basicReader().withBasePath(Paths.get("/does/not/exist")).execute());
     }
 
     @Test
@@ -204,7 +201,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
         capturedOutput.forEach(msg -> assertThat(msg, not(containsString("goodbye"))));
     }
 
-    @Ignore("https://github.com/OpenHFT/Chronicle-Queue/issues/1150")
+    @Disabled("https://github.com/OpenHFT/Chronicle-Queue/issues/1150")
     @Test
     public void shouldFilterByMultipleExclusionRegex() {
         basicReaderMethodReader().withExclusionRegex(".*bye$").withExclusionRegex(".*ell.*").execute();
@@ -216,24 +213,22 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
     public void shouldReturnNoMoreThanTheSpecifiedNumberOfMaxRecords() {
         basicReaderMethodReader().historyRecords(5).execute();
 
-        assertEquals(5,
-                capturedOutput.stream()
-                        .filter(msg -> !msg.startsWith("0x")).count());
+        assertEquals(5, capturedOutput.stream()
+                .filter(msg -> !msg.startsWith("0x")).count());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailIfSpecifiedIndexIsBeforeFirstIndex() {
-        basicReader().withStartIndex(1L).execute();
+        assertThrows(IllegalArgumentException.class, () -> basicReader().withStartIndex(1L).execute());
     }
 
     @Test
     public void shouldNotRewindPastStartOfQueueWhenDisplayingHistory() {
         basicReader().historyRecords(Long.MAX_VALUE).execute();
 
-        assertEquals(24,
-                capturedOutput.stream()
-                        .filter(msg -> !msg.startsWith("0x"))
-                        .count());
+        assertEquals(24, capturedOutput.stream()
+                .filter(msg -> !msg.startsWith("0x"))
+                .count());
     }
 
     private ChronicleReader basicReader() {
@@ -244,7 +239,7 @@ public class ChronicleMethodReaderTest extends QueueTestCommon {
         return basicReaderMethodReader(dataDir);
     }
 
-    @After
+    @AfterEach
     public void clearInterrupt() {
         Thread.interrupted();
     }

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
@@ -36,7 +36,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
@@ -116,7 +115,7 @@ class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
+    @Timeout(10)
     void shouldReadQueueInReverse() {
         addCountToEndOfQueue();
 
@@ -193,7 +192,7 @@ class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
+    @Timeout(10)
     void shouldReadQueueWithNonDefaultRollCycle() {
         expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");
@@ -214,7 +213,7 @@ class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
+    @Timeout(10)
     void shouldReadQueueWithNonDefaultRollCycleWhenMetadataDeleted() throws IOException {
         if (!OS.isWindows())
             expectException("Failback to readonly tablestore");
@@ -376,7 +375,7 @@ class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void readOnlyQueueTailerShouldObserveChangesAfterInitiallyObservedReadLimit() throws IOException, InterruptedException, TimeoutException, ExecutionException {
         IOTools.deleteDirWithFiles(dataDir.toFile());
         dataDir.toFile().mkdirs();
@@ -526,9 +525,9 @@ class ChronicleReaderTest extends QueueTestCommon {
         assertEquals(expectedPollCountWhenDocumentIsEmpty, pollMethod.invocationCount);
     }
 
-    @RequiredForClient
     @Test
-    @Timeout(value = 20_000, unit = TimeUnit.MILLISECONDS)
+    @RequiredForClient
+    @Timeout(20)
     void shouldPrintTimestampsToLocalTime() throws IOException {
         finishedNormally = false;
         final File queueDir = getTmpDir();

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
@@ -24,6 +24,7 @@ import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.*;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
@@ -48,8 +50,6 @@ import java.util.stream.Collectors;
 import static net.openhft.chronicle.queue.rollcycles.LegacyRollCycles.MINUTELY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 import static net.openhft.chronicle.testframework.GcControls.waitForGcCycle;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
@@ -77,7 +77,7 @@ class ChronicleReaderTest extends QueueTestCommon {
     @BeforeEach
     void beforeEachChronicleReaderTest() {
         before();
-        public threadDump();
+        threadDump();
     }
 
     public void before() {
@@ -116,7 +116,7 @@ class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 10_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
     void shouldReadQueueInReverse() {
         addCountToEndOfQueue();
 
@@ -193,7 +193,7 @@ class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 10_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
     void shouldReadQueueWithNonDefaultRollCycle() {
         expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");
@@ -214,7 +214,7 @@ class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 10_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
     void shouldReadQueueWithNonDefaultRollCycleWhenMetadataDeleted() throws IOException {
         if (!OS.isWindows())
             expectException("Failback to readonly tablestore");
@@ -338,15 +338,15 @@ class ChronicleReaderTest extends QueueTestCommon {
 
         methodReaderForQueue.execute();
 
-        assertThat(capturedOutput.size(), is(8));
+        assertEquals(8, capturedOutput.size());
         capturedOutput.poll();
-        assertThat(capturedOutput.poll(), containsString("goodbye"));
+        assertTrue(capturedOutput.poll().contains("goodbye"));
         capturedOutput.poll();
-        assertThat(capturedOutput.poll(), containsString("hello"));
+        assertTrue(capturedOutput.poll().contains("hello"));
         capturedOutput.poll();
-        assertThat(capturedOutput.poll(), containsString("goodbye"));
+        assertTrue(capturedOutput.poll().contains("goodbye"));
         capturedOutput.poll();
-        assertThat(capturedOutput.poll(), containsString("hello"));
+        assertTrue(capturedOutput.poll().contains("hello"));
         capturedOutput.poll();
     }
 
@@ -376,7 +376,7 @@ class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     void readOnlyQueueTailerShouldObserveChangesAfterInitiallyObservedReadLimit() throws IOException, InterruptedException, TimeoutException, ExecutionException {
         IOTools.deleteDirWithFiles(dataDir.toFile());
         dataDir.toFile().mkdirs();
@@ -439,7 +439,7 @@ class ChronicleReaderTest extends QueueTestCommon {
 
         assertEquals(TOTAL_EXCERPTS_IN_QUEUE, capturedOutput.size());
         capturedOutput.stream().filter(msg -> !msg.startsWith("0x")).
-                forEach(msg -> assertThat(msg, containsString("goodbye")));
+                forEach(msg -> assertTrue(msg.contains("goodbye")));
     }
 
     @Test
@@ -448,9 +448,9 @@ class ChronicleReaderTest extends QueueTestCommon {
 
         assertEquals(TOTAL_EXCERPTS_IN_QUEUE, capturedOutput.size());
         capturedOutput.stream().filter(msg -> !msg.startsWith("0x")).
-                forEach(msg -> assertThat(msg, containsString("goodbye")));
+                forEach(msg -> assertTrue(msg.contains("goodbye")));
         capturedOutput.stream().filter(msg -> !msg.startsWith("0x")).
-                forEach(msg -> assertThat(msg, not(containsString("hello"))));
+                forEach(msg -> assertFalse(msg.contains("hello")));
     }
 
     @Test
@@ -463,7 +463,7 @@ class ChronicleReaderTest extends QueueTestCommon {
         basicReader().withExclusionRegex(".*good.*").execute();
 
         assertEquals(TOTAL_EXCERPTS_IN_QUEUE, capturedOutput.size());
-        capturedOutput.forEach(msg -> assertThat(msg, not(containsString("goodbye"))));
+        capturedOutput.forEach(msg -> assertFalse(msg.contains("goodbye")));
     }
 
     @Test
@@ -509,8 +509,8 @@ class ChronicleReaderTest extends QueueTestCommon {
     void shouldNotRewindPastStartOfQueueWhenDisplayingHistory() {
         basicReader().historyRecords(Long.MAX_VALUE).execute();
 
-        assertThat(capturedOutput.stream().
-                filter(msg -> !msg.startsWith("0x")).count(), is(TOTAL_EXCERPTS_IN_QUEUE));
+        assertEquals(TOTAL_EXCERPTS_IN_QUEUE, capturedOutput.stream().
+                filter(msg -> !msg.startsWith("0x")).count());
     }
 
     @Test
@@ -528,7 +528,7 @@ class ChronicleReaderTest extends QueueTestCommon {
 
     @RequiredForClient
     @Test
-    @org.junit.jupiter.api.Timeout(value = 20_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 20_000, unit = TimeUnit.MILLISECONDS)
     void shouldPrintTimestampsToLocalTime() throws IOException {
         finishedNormally = false;
         final File queueDir = getTmpDir();

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
@@ -53,7 +53,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class ChronicleReaderTest extends QueueTestCommon {
+class ChronicleReaderTest extends QueueTestCommon {
     private static final byte[] ONE_KILOBYTE = new byte[1024];
     private static final long TOTAL_EXCERPTS_IN_QUEUE = 24;
 
@@ -75,9 +75,9 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @BeforeEach
-    public void beforeEachChronicleReaderTest() {
+    void beforeEachChronicleReaderTest() {
         before();
-        threadDump();
+        public threadDump();
     }
 
     public void before() {
@@ -117,7 +117,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 10_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void shouldReadQueueInReverse() {
+    void shouldReadQueueInReverse() {
         addCountToEndOfQueue();
 
         new ChronicleReader().withBasePath(dataDir)
@@ -130,7 +130,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void reverseOrderShouldIgnoreOptionsThatDontMakeSense() {
+    void reverseOrderShouldIgnoreOptionsThatDontMakeSense() {
         addCountToEndOfQueue();
 
         new ChronicleReader().withBasePath(dataDir)
@@ -145,7 +145,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void reverseOrderWorksWithStartPosition() {
+    void reverseOrderWorksWithStartPosition() {
         List<Long> indices = addCountToEndOfQueue();
 
         new ChronicleReader().withBasePath(dataDir)
@@ -159,7 +159,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void reverseOrderThrowsWhenStartPositionIsAfterEndOfQueue() {
+    void reverseOrderThrowsWhenStartPositionIsAfterEndOfQueue() {
         assertThrows(IllegalArgumentException.class, () -> new ChronicleReader().withBasePath(dataDir)
                 .withMessageSink(capturedOutput::add)
                 .inReverseOrder()
@@ -169,7 +169,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void reverseOrderThrowsWhenStartPositionIsBeforeStartOfQueue() {
+    void reverseOrderThrowsWhenStartPositionIsBeforeStartOfQueue() {
         assertThrows(IllegalArgumentException.class, () -> new ChronicleReader().withBasePath(dataDir)
                 .withMessageSink(capturedOutput::add)
                 .inReverseOrder()
@@ -194,7 +194,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 10_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void shouldReadQueueWithNonDefaultRollCycle() {
+    void shouldReadQueueWithNonDefaultRollCycle() {
         expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");
         Path path = getTmpDir().toPath();
@@ -215,7 +215,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 10_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void shouldReadQueueWithNonDefaultRollCycleWhenMetadataDeleted() throws IOException {
+    void shouldReadQueueWithNonDefaultRollCycleWhenMetadataDeleted() throws IOException {
         if (!OS.isWindows())
             expectException("Failback to readonly tablestore");
         Path path = getTmpDir().toPath();
@@ -237,7 +237,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldNotFailOnEmptyQueue() {
+    void shouldNotFailOnEmptyQueue() {
         Path path = getTmpDir().toPath();
         path.toFile().mkdirs();
         if (!OS.isWindows())
@@ -247,7 +247,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldNotFailWhenNoMetadata() throws IOException {
+    void shouldNotFailWhenNoMetadata() throws IOException {
         if (!OS.isWindows())
             expectException("Failback to readonly tablestore");
         Files.list(dataDir).filter(f -> f.getFileName().toString().endsWith(SingleTableStore.SUFFIX)).findFirst().ifPresent(path -> path.toFile().delete());
@@ -256,14 +256,14 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldIncludeMessageHistoryByDefault() {
+    void shouldIncludeMessageHistoryByDefault() {
         basicReader().execute();
 
         assertTrue(capturedOutput.stream().anyMatch(msg -> msg.contains("history:")));
     }
 
     @Test
-    public void shouldApplyIncludeRegexToHistoryMessagesAndBusinessMessagesMethodReaderDummy() {
+    void shouldApplyIncludeRegexToHistoryMessagesAndBusinessMessagesMethodReaderDummy() {
         basicReader()
                 // matches goodbye, but not hello or history
                 .withInclusionRegex("goodbye")
@@ -273,7 +273,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldNotShowIndexForFilteredMessages() {
+    void shouldNotShowIndexForFilteredMessages() {
         basicReader()
                 .asMethodReader(SayWhen.class.getName())
                 .execute();
@@ -282,7 +282,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldNotShowIndexForHistoryMessages() {
+    void shouldNotShowIndexForHistoryMessages() {
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.binary(dataDir).testBlockSize().build();
              final ExcerptAppender appender = queue.createAppender()) {
             try (DocumentContext dc = appender.writingDocument()) {
@@ -299,7 +299,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
 //    }
 
     @Test
-    public void canReadPastEmptyMessageInReverseOrder() {
+    void canReadPastEmptyMessageInReverseOrder() {
         dataDir = getTmpDir().toPath();
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.binary(dataDir)
                 .sourceId(1)
@@ -351,7 +351,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldNotIncludeMessageHistoryByDefaultMethodReader() {
+    void shouldNotIncludeMessageHistoryByDefaultMethodReader() {
         basicReader().
                 asMethodReader(Say.class.getName()).
                 execute();
@@ -360,7 +360,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldIncludeMessageHistoryMethodReaderShowHistory() {
+    void shouldIncludeMessageHistoryMethodReaderShowHistory() {
         basicReader().
                 asMethodReader(Say.class.getName()).
                 showMessageHistory(true).
@@ -377,7 +377,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
 
     @Test
     @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void readOnlyQueueTailerShouldObserveChangesAfterInitiallyObservedReadLimit() throws IOException, InterruptedException, TimeoutException, ExecutionException {
+    void readOnlyQueueTailerShouldObserveChangesAfterInitiallyObservedReadLimit() throws IOException, InterruptedException, TimeoutException, ExecutionException {
         IOTools.deleteDirWithFiles(dataDir.toFile());
         dataDir.toFile().mkdirs();
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.binary(dataDir).testBlockSize().build()) {
@@ -412,7 +412,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldBeAbleToReadFromReadOnlyFile() throws IOException {
+    void shouldBeAbleToReadFromReadOnlyFile() throws IOException {
         assumeFalse(OS.isWindows(), "#460 read-only not supported on Windows");
 
         final Path queueFile = Files.list(dataDir).
@@ -426,7 +426,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldConvertEntriesToText() {
+    void shouldConvertEntriesToText() {
         basicReader().execute();
 
         assertEquals(48, capturedOutput.size());
@@ -434,7 +434,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldFilterByInclusionRegex() {
+    void shouldFilterByInclusionRegex() {
         basicReader().withInclusionRegex(".*good.*").execute();
 
         assertEquals(TOTAL_EXCERPTS_IN_QUEUE, capturedOutput.size());
@@ -443,7 +443,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldFilterByMultipleInclusionRegex() {
+    void shouldFilterByMultipleInclusionRegex() {
         basicReader().withInclusionRegex(".*bye$").withInclusionRegex(".*o.*").execute();
 
         assertEquals(TOTAL_EXCERPTS_IN_QUEUE, capturedOutput.size());
@@ -454,12 +454,12 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldThrowExceptionIfInputDirectoryDoesNotExist() {
+    void shouldThrowExceptionIfInputDirectoryDoesNotExist() {
         assertThrows(IllegalArgumentException.class, () -> basicReader().withBasePath(Paths.get("/does/not/exist")).execute());
     }
 
     @Test
-    public void shouldFilterByExclusionRegex() {
+    void shouldFilterByExclusionRegex() {
         basicReader().withExclusionRegex(".*good.*").execute();
 
         assertEquals(TOTAL_EXCERPTS_IN_QUEUE, capturedOutput.size());
@@ -467,14 +467,14 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldFilterByMultipleExclusionRegex() {
+    void shouldFilterByMultipleExclusionRegex() {
         basicReader().withExclusionRegex(".*bye$").withExclusionRegex(".*ell.*").execute();
 
         assertEquals(0L, capturedOutput.stream().filter(msg -> !msg.startsWith("0x")).count());
     }
 
     @Test
-    public void shouldReturnNoMoreThanTheSpecifiedNumberOfMaxRecords() {
+    void shouldReturnNoMoreThanTheSpecifiedNumberOfMaxRecords() {
         basicReader().historyRecords(5).execute();
 
         assertEquals(5L, capturedOutput.stream().
@@ -482,7 +482,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldCombineIncludeFilterAndMaxRecords() {
+    void shouldCombineIncludeFilterAndMaxRecords() {
         basicReader().historyRecords(5).withInclusionRegex("hello").execute();
 
         assertEquals(2L, capturedOutput.stream().
@@ -490,7 +490,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldForwardToSpecifiedIndex() {
+    void shouldForwardToSpecifiedIndex() {
         final long knownIndex = Long.decode(findAnExistingIndex());
         basicReader().withStartIndex(knownIndex).execute();
 
@@ -499,14 +499,14 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldFailIfSpecifiedIndexIsBeforeFirstIndex() {
+    void shouldFailIfSpecifiedIndexIsBeforeFirstIndex() {
         assertThrows(IllegalArgumentException.class, () -> {
             basicReader().withStartIndex(1L).execute();
         });
     }
 
     @Test
-    public void shouldNotRewindPastStartOfQueueWhenDisplayingHistory() {
+    void shouldNotRewindPastStartOfQueueWhenDisplayingHistory() {
         basicReader().historyRecords(Long.MAX_VALUE).execute();
 
         assertThat(capturedOutput.stream().
@@ -514,7 +514,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldContinueToPollQueueWhenTailModeIsEnabled() {
+    void shouldContinueToPollQueueWhenTailModeIsEnabled() {
         final int expectedPollCountWhenDocumentIsEmpty = 3;
         final FiniteDocumentPollMethod pollMethod = new FiniteDocumentPollMethod(expectedPollCountWhenDocumentIsEmpty);
         try {
@@ -529,7 +529,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     @RequiredForClient
     @Test
     @org.junit.jupiter.api.Timeout(value = 20_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void shouldPrintTimestampsToLocalTime() throws IOException {
+    void shouldPrintTimestampsToLocalTime() throws IOException {
         finishedNormally = false;
         final File queueDir = getTmpDir();
         try (final ChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
@@ -556,7 +556,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldOnlyOutputUpToMatchLimitAfterFiltering() {
+    void shouldOnlyOutputUpToMatchLimitAfterFiltering() {
         basicReader().withInclusionRegex("goodbye").withMatchLimit(3).execute();
 
         final List<String> matchedMessages = capturedOutput.stream()
@@ -567,7 +567,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void matchLimitThenNamedTailer() {
+    void matchLimitThenNamedTailer() {
         final long maxRecords = 5;
         final String tailerId = "myTailer";
         basicReader().withMatchLimit(maxRecords).withReadOnly(false).withTailerId(tailerId).execute();
@@ -582,13 +582,13 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void namedTailerRequiresReadWrite() {
+    void namedTailerRequiresReadWrite() {
         assumeFalse(OS.isWindows());
         assertThrows(IllegalArgumentException.class, () -> basicReader().withTailerId("tailerId").withReadOnly(true).execute());
     }
 
     @Test
-    public void shouldStopReadingWhenContentBasedLimitHasBeenReached() {
+    void shouldStopReadingWhenContentBasedLimitHasBeenReached() {
         AtomicInteger helloCount = new AtomicInteger();
         AtomicInteger goodbyeCount = new AtomicInteger();
         final Say say = msg -> {
@@ -639,7 +639,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearch() {
+    void findByBinarySearch() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -662,7 +662,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchReverse() {
+    void findByBinarySearchReverse() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -686,7 +686,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchSparseRepeated() {
+    void findByBinarySearchSparseRepeated() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -714,7 +714,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchSparseRepeatedReverse() {
+    void findByBinarySearchSparseRepeatedReverse() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -743,7 +743,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchSparseApprox() {
+    void findByBinarySearchSparseApprox() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -770,7 +770,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchSparseApproxReverse() {
+    void findByBinarySearchSparseApproxReverse() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -798,7 +798,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchApprox() {
+    void findByBinarySearchApprox() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
             final int reps = 5;
@@ -821,7 +821,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchApproxReverse() {
+    void findByBinarySearchApproxReverse() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
             final int reps = 5;
@@ -845,7 +845,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchAfterEnd() {
+    void findByBinarySearchAfterEnd() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -865,7 +865,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchAfterEndReverse() {
+    void findByBinarySearchAfterEndReverse() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -886,7 +886,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchBeforeStart() {
+    void findByBinarySearchBeforeStart() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -906,7 +906,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchBeforeStartReverse() {
+    void findByBinarySearchBeforeStartReverse() {
         final File queueDir = getTmpDir();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
 
@@ -927,7 +927,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void findByBinarySearchWithDeletedRollCyles() {
+    void findByBinarySearchWithDeletedRollCyles() {
         final File queueDir = getTmpDir();
         final SetTimeProvider timeProvider = new SetTimeProvider();
         try (final SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir)
@@ -960,7 +960,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldRespectWireType() {
+    void shouldRespectWireType() {
         basicReader().
                 asMethodReader(Say.class.getName()).
                 withWireType(WireType.JSON).
@@ -971,7 +971,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Test
-    public void shouldRespectWireType2() {
+    void shouldRespectWireType2() {
         basicReader()
                 .asMethodReader(Say.class.getName())
                 .withWireType(WireType.JSON_ONLY)
@@ -1029,7 +1029,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @AfterEach
-    public void clearInterrupt() {
+    void clearInterrupt() {
         Thread.interrupted();
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/ChronicleReaderTest.java
@@ -23,9 +23,9 @@ import net.openhft.chronicle.queue.reader.Reader;
 import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
 import net.openhft.chronicle.threads.NamedThreadFactory;
 import net.openhft.chronicle.wire.*;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,8 +50,8 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static net.openhft.chronicle.testframework.GcControls.waitForGcCycle;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class ChronicleReaderTest extends QueueTestCommon {
     private static final byte[] ONE_KILOBYTE = new byte[1024];
@@ -74,18 +74,23 @@ public class ChronicleReaderTest extends QueueTestCommon {
         }
     }
 
-    @Before
+    @BeforeEach
+    public void beforeEachChronicleReaderTest() {
+        before();
+        threadDump();
+    }
+
     public void before() {
         assumeFalse(Jvm.isArm());
 
         // Reader opens queues in read-only mode
         if (OS.isWindows())
-            if (!(testName.getMethodName().equals("shouldThrowExceptionIfInputDirectoryDoesNotExist") ||
-                    testName.getMethodName().equals("shouldNotShowIndexForHistoryMessages") ||
-                    testName.getMethodName().equals("shouldBeAbleToReadFromReadOnlyFile") ||
-                    testName.getMethodName().equals("shouldPrintTimestampsToLocalTime") ||
-                    testName.getMethodName().equals("namedTailerRequiresReadWrite") ||
-                    testName.getMethodName().equals("matchLimitThenNamedTailer")))
+            if (!(testMethodName.equals("shouldThrowExceptionIfInputDirectoryDoesNotExist") ||
+                    testMethodName.equals("shouldNotShowIndexForHistoryMessages") ||
+                    testMethodName.equals("shouldBeAbleToReadFromReadOnlyFile") ||
+                    testMethodName.equals("shouldPrintTimestampsToLocalTime") ||
+                    testMethodName.equals("namedTailerRequiresReadWrite") ||
+                    testMethodName.equals("matchLimitThenNamedTailer")))
                 expectException("Read-only mode is not supported on Windows");
 
         dataDir = getTmpDir().toPath();
@@ -106,12 +111,12 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @Override
-    @Before
     public void threadDump() {
         super.threadDump();
     }
 
-    @Test(timeout = 10_000L)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 10_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void shouldReadQueueInReverse() {
         addCountToEndOfQueue();
 
@@ -153,24 +158,24 @@ public class ChronicleReaderTest extends QueueTestCommon {
         assertEquals(Arrays.asList("\"2\"\n", "\"1\"\n"), firstFourElements);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void reverseOrderThrowsWhenStartPositionIsAfterEndOfQueue() {
-        new ChronicleReader().withBasePath(dataDir)
+        assertThrows(IllegalArgumentException.class, () -> new ChronicleReader().withBasePath(dataDir)
                 .withMessageSink(capturedOutput::add)
                 .inReverseOrder()
                 .suppressDisplayIndex()
                 .withStartIndex(lastIndex + 1)
-                .execute();
+                .execute());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void reverseOrderThrowsWhenStartPositionIsBeforeStartOfQueue() {
-        new ChronicleReader().withBasePath(dataDir)
+        assertThrows(IllegalArgumentException.class, () -> new ChronicleReader().withBasePath(dataDir)
                 .withMessageSink(capturedOutput::add)
                 .inReverseOrder()
                 .suppressDisplayIndex()
                 .withStartIndex(firstIndex - 1)
-                .execute();
+                .execute());
     }
 
     private List<Long> addCountToEndOfQueue() {
@@ -187,7 +192,8 @@ public class ChronicleReaderTest extends QueueTestCommon {
         return indices;
     }
 
-    @Test(timeout = 10_000L)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 10_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void shouldReadQueueWithNonDefaultRollCycle() {
         expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");
@@ -207,7 +213,8 @@ public class ChronicleReaderTest extends QueueTestCommon {
         assertFalse(capturedOutput.isEmpty());
     }
 
-    @Test(timeout = 10_000L)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 10_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void shouldReadQueueWithNonDefaultRollCycleWhenMetadataDeleted() throws IOException {
         if (!OS.isWindows())
             expectException("Failback to readonly tablestore");
@@ -362,13 +369,14 @@ public class ChronicleReaderTest extends QueueTestCommon {
         String first = capturedOutput.poll();
         assertTrue(first.startsWith("0x"));
         String second = capturedOutput.poll();
-        assertTrue(second, second.matches("VanillaMessageHistory *. *sources: ..,? timings: .[0-9]+.,? addSourceDetails=false ?}" +
+        assertTrue(second.matches("VanillaMessageHistory *. *sources: ..,? timings: .[0-9]+.,? addSourceDetails=false ?}" +
                 System.lineSeparator() +
                 "say: hello\n" +
-                "...\n"));
+                "...\n"), second);
     }
 
-    @Test(timeout = 5000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void readOnlyQueueTailerShouldObserveChangesAfterInitiallyObservedReadLimit() throws IOException, InterruptedException, TimeoutException, ExecutionException {
         IOTools.deleteDirWithFiles(dataDir.toFile());
         dataDir.toFile().mkdirs();
@@ -405,7 +413,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
 
     @Test
     public void shouldBeAbleToReadFromReadOnlyFile() throws IOException {
-        assumeFalse("#460 read-only not supported on Windows", OS.isWindows());
+        assumeFalse(OS.isWindows(), "#460 read-only not supported on Windows");
 
         final Path queueFile = Files.list(dataDir).
                 filter(f -> f.getFileName().toString().endsWith(SingleChronicleQueue.SUFFIX)).findFirst().
@@ -445,9 +453,9 @@ public class ChronicleReaderTest extends QueueTestCommon {
                 forEach(msg -> assertThat(msg, not(containsString("hello"))));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfInputDirectoryDoesNotExist() {
-        basicReader().withBasePath(Paths.get("/does/not/exist")).execute();
+        assertThrows(IllegalArgumentException.class, () -> basicReader().withBasePath(Paths.get("/does/not/exist")).execute());
     }
 
     @Test
@@ -490,9 +498,11 @@ public class ChronicleReaderTest extends QueueTestCommon {
         assertTrue(capturedOutput.poll().contains(Long.toHexString(knownIndex)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailIfSpecifiedIndexIsBeforeFirstIndex() {
-        basicReader().withStartIndex(1L).execute();
+        assertThrows(IllegalArgumentException.class, () -> {
+            basicReader().withStartIndex(1L).execute();
+        });
     }
 
     @Test
@@ -517,7 +527,8 @@ public class ChronicleReaderTest extends QueueTestCommon {
     }
 
     @RequiredForClient
-    @Test(timeout = 20_000)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 20_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void shouldPrintTimestampsToLocalTime() throws IOException {
         finishedNormally = false;
         final File queueDir = getTmpDir();
@@ -570,10 +581,10 @@ public class ChronicleReaderTest extends QueueTestCommon {
                 filter(msg -> !msg.startsWith("0x")).count());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void namedTailerRequiresReadWrite() {
         assumeFalse(OS.isWindows());
-        basicReader().withTailerId("tailerId").withReadOnly(true).execute();
+        assertThrows(IllegalArgumentException.class, () -> basicReader().withTailerId("tailerId").withReadOnly(true).execute());
     }
 
     @Test
@@ -622,7 +633,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
         for (Long timestamp : timestamps) {
             final String expectedTimestamp = mtlc.asString(timestamp);
             int timestampIndex = output.indexOf(expectedTimestamp);
-            assertTrue(String.format("%s contains %s", output, expectedTimestamp), timestampIndex > 0);
+            assertTrue(timestampIndex > 0, String.format("%s contains %s", output, expectedTimestamp));
             output = output.substring(timestampIndex + expectedTimestamp.length());
         }
     }
@@ -934,7 +945,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
         BackgroundResourceReleaser.releasePendingResources();
 
         // delete the 4th roll cycle
-        assertTrue("Couldn't delete cycle, test is broken", queueDir.toPath().resolve("19700101-000009T.cq4").toFile().delete());
+        assertTrue(queueDir.toPath().resolve("19700101-000009T.cq4").toFile().delete(), "Couldn't delete cycle, test is broken");
 
         // this should be before the start
         long tsToLookFor = getTimestampAtIndex(22); // third index in 3rd roll cycle, should be ({reps=5} * 8) + ({remaining_cycles=1} * ({reps=5} * {entries=10})) = 90 in output
@@ -956,8 +967,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
                 execute();
 
         capturedOutput.poll();
-        assertEquals("{\"say\":\"hello\"}",
-                capturedOutput.poll().trim());
+        assertEquals("{\"say\":\"hello\"}", capturedOutput.poll().trim());
     }
 
     @Test
@@ -968,8 +978,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
                 .execute();
 
         capturedOutput.poll();
-        assertEquals("{\"say\":\"hello\"}",
-                capturedOutput.poll().trim());
+        assertEquals("{\"say\":\"hello\"}", capturedOutput.poll().trim());
     }
 
     private void populateQueueWithTimestamps(SingleChronicleQueue queue, int entries, int repeatsPerEntry) {
@@ -1019,7 +1028,7 @@ public class ChronicleReaderTest extends QueueTestCommon {
                 .withMessageSink(capturedOutput::add);
     }
 
-    @After
+    @AfterEach
     public void clearInterrupt() {
         Thread.interrupted();
     }

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/FieldlessMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/FieldlessMethodReaderTest.java
@@ -24,11 +24,11 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class FieldlessMethodReaderTest extends QueueTestCommon {
+class FieldlessMethodReaderTest extends QueueTestCommon {
 
     @ParameterizedTest
     @MethodSource("enums")
-    public void test(CustomEnumType enumType) throws InterruptedException {
+    void test(CustomEnumType enumType) throws InterruptedException {
         final AtomicInteger msgCounter = new AtomicInteger();
         File path = new File(getTmpDir(), "enum_test_" + enumType);
 

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/FieldlessMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/FieldlessMethodReaderTest.java
@@ -11,10 +11,8 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.util.Arrays;
@@ -24,18 +22,14 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
+import static org.junit.jupiter.api.Assertions.*;
+
 public class FieldlessMethodReaderTest extends QueueTestCommon {
 
-    private final CustomEnumType enumType;
-    private final AtomicInteger msgCounter = new AtomicInteger();
-
-    public FieldlessMethodReaderTest(CustomEnumType enumType) {
-        this.enumType = enumType;
-    }
-
-    @Test
-    public void test() throws InterruptedException {
+    @ParameterizedTest
+    @MethodSource("enums")
+    public void test(CustomEnumType enumType) throws InterruptedException {
+        final AtomicInteger msgCounter = new AtomicInteger();
         File path = new File(getTmpDir(), "enum_test_" + enumType);
 
         try (SingleChronicleQueue chronicle = SingleChronicleQueueBuilder.builder().path(path)
@@ -49,13 +43,12 @@ public class FieldlessMethodReaderTest extends QueueTestCommon {
             //noinspection StatementWithEmptyBody
             while (methodReader.readOne()) {
             }
-            Assert.assertEquals(2, msgCounter.get());
+            assertEquals(2, msgCounter.get());
         } finally {
             IOTools.deleteDirWithFilesOrWait(1000, path);
         }
     }
 
-    @Parameterized.Parameters
     public static Collection<CustomEnumType> enums() {
         return Stream.concat(Stream.of((CustomEnumType) null), Arrays.stream(CustomEnumType.values()))
                 .collect(Collectors.toList());

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Calendar;
-import java.util.concurrent.TimeUnit;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -67,7 +66,7 @@ class RollEOFTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void testRollWritesEOF() throws IOException {
         assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
@@ -100,7 +99,7 @@ class RollEOFTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void testRollWithoutEOFDoesntBlowup() throws IOException {
         assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
@@ -141,7 +140,7 @@ class RollEOFTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void testRollWithoutEOF() throws IOException {
 //        expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
@@ -43,7 +43,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class RollEOFTest extends QueueTestCommon {
+class RollEOFTest extends QueueTestCommon {
 
     private static final ReferenceOwner test = ReferenceOwner.temporary("test");
 
@@ -66,7 +66,7 @@ public class RollEOFTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 5000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testRollWritesEOF() throws IOException {
+    void testRollWritesEOF() throws IOException {
         assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
 //        expectException("Overriding roll length from existing metadata");
@@ -99,7 +99,7 @@ public class RollEOFTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 5000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testRollWithoutEOFDoesntBlowup() throws IOException {
+    void testRollWithoutEOFDoesntBlowup() throws IOException {
         assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
 //        expectException("Overriding roll length from existing metadata");
@@ -140,7 +140,7 @@ public class RollEOFTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 5000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testRollWithoutEOF() throws IOException {
+    void testRollWithoutEOF() throws IOException {
 //        expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");
 

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
@@ -26,7 +26,7 @@ import net.openhft.chronicle.wire.WireType;
 import net.openhft.chronicle.wire.Wires;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,8 +40,8 @@ import java.util.stream.Stream;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueue.SUFFIX;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class RollEOFTest extends QueueTestCommon {
 
@@ -63,9 +63,11 @@ public class RollEOFTest extends QueueTestCommon {
         return null;
     }
 
-    @Test(timeout = 5000L)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 5000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testRollWritesEOF() throws IOException {
-        assumeFalse("Read-only mode is not supported on Windows", OS.isWindows());
+        assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
 //        expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");
@@ -94,9 +96,11 @@ public class RollEOFTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5000L)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 5000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testRollWithoutEOFDoesntBlowup() throws IOException {
-        assumeFalse("Read-only mode is not supported on Windows", OS.isWindows());
+        assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
 //        expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");
@@ -133,7 +137,9 @@ public class RollEOFTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5000L)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 5000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testRollWithoutEOF() throws IOException {
 //        expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");

--- a/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/reader/RollEOFTest.java
@@ -27,12 +27,14 @@ import net.openhft.chronicle.wire.Wires;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -65,7 +67,7 @@ class RollEOFTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 5000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
     void testRollWritesEOF() throws IOException {
         assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
@@ -98,7 +100,7 @@ class RollEOFTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 5000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
     void testRollWithoutEOFDoesntBlowup() throws IOException {
         assumeFalse(OS.isWindows(), "Read-only mode is not supported on Windows");
 
@@ -139,7 +141,7 @@ class RollEOFTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 5000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
     void testRollWithoutEOF() throws IOException {
 //        expectException("Overriding roll length from existing metadata");
 //        expectException("Overriding roll cycle from");

--- a/src/test/java/net/openhft/chronicle/queue/internal/util/InternalFileUtilLinuxStateTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/util/InternalFileUtilLinuxStateTest.java
@@ -15,10 +15,10 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class InternalFileUtilLinuxStateTest extends QueueTestCommon {
+class InternalFileUtilLinuxStateTest extends QueueTestCommon {
 
     @Test
-    public void stateOpenAndClosedOnLinux() throws Exception {
+    void stateOpenAndClosedOnLinux() throws Exception {
         assumeTrue(OS.isLinux(), "Linux-only test");
         assumeTrue(InternalFileUtil.getAllOpenFilesIsSupportedOnOS(), "/proc required");
 

--- a/src/test/java/net/openhft/chronicle/queue/internal/util/InternalFileUtilLinuxStateTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/util/InternalFileUtilLinuxStateTest.java
@@ -6,22 +6,21 @@ package net.openhft.chronicle.queue.internal.util;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.util.FileState;
-import org.junit.Test;
-import org.junit.Assume;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class InternalFileUtilLinuxStateTest extends QueueTestCommon {
 
     @Test
     public void stateOpenAndClosedOnLinux() throws Exception {
-        Assume.assumeTrue("Linux-only test", OS.isLinux());
-        Assume.assumeTrue("/proc required", InternalFileUtil.getAllOpenFilesIsSupportedOnOS());
+        assumeTrue(OS.isLinux(), "Linux-only test");
+        assumeTrue(InternalFileUtil.getAllOpenFilesIsSupportedOnOS(), "/proc required");
 
         final File dir = getTmpDir();
         // Ensure parent directory exists

--- a/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
@@ -11,15 +11,17 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class ChronicleWriterTest extends QueueTestCommon {
+public class ChronicleWriterTest extends QueueTestCommon {
     private static final String METHOD_NAME = "doit";
     private final String cw1;
     private final String cw2;
@@ -35,7 +37,7 @@ class ChronicleWriterTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     void testWireMarshallingMapAndDTO() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(null, cw1, cw2);
         chronicleWriter.execute();
@@ -62,7 +64,7 @@ class ChronicleWriterTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     void testWireMarshallingWithInterface() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(MyInterface.class.getTypeName(), cw2);
         chronicleWriter.execute();
@@ -84,7 +86,7 @@ class ChronicleWriterTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     void testBytesMarshallingWithInterface() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(MyInterface2.class.getTypeName(), cw3);
         chronicleWriter.execute();
@@ -122,12 +124,12 @@ class ChronicleWriterTest extends QueueTestCommon {
         void doit(DTO2 dto);
     }
 
-    static class DTO extends SelfDescribingMarshallable {
+    public static class DTO extends SelfDescribingMarshallable {
         private int age;
         private String name;
     }
 
-    static class DTO2 extends DTO {
+    public static class DTO2 extends DTO {
         @Override
         public boolean usesSelfDescribingMessage() {
             return false;

--- a/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -37,7 +36,7 @@ public class ChronicleWriterTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void testWireMarshallingMapAndDTO() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(null, cw1, cw2);
         chronicleWriter.execute();
@@ -64,7 +63,7 @@ public class ChronicleWriterTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void testWireMarshallingWithInterface() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(MyInterface.class.getTypeName(), cw2);
         chronicleWriter.execute();
@@ -86,7 +85,7 @@ public class ChronicleWriterTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(5)
     void testBytesMarshallingWithInterface() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(MyInterface2.class.getTypeName(), cw3);
         chronicleWriter.execute();

--- a/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
@@ -10,13 +10,13 @@ import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ChronicleWriterTest extends QueueTestCommon {
     private static final String METHOD_NAME = "doit";
@@ -32,7 +32,9 @@ public class ChronicleWriterTest extends QueueTestCommon {
         dir = IOTools.createTempFile(this.getClass().getSimpleName());
     }
 
-    @Test(timeout = 5000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testWireMarshallingMapAndDTO() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(null, cw1, cw2);
         chronicleWriter.execute();
@@ -40,10 +42,10 @@ public class ChronicleWriterTest extends QueueTestCommon {
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(dir).build()) {
             StringBuilder sb = new StringBuilder();
             @NotNull MethodReader mr = queue.createTailer().methodReader(Mocker.intercepting(MyInterface.class, "*", sb::append));
-            Assert.assertTrue(mr.readOne());
-            Assert.assertTrue(mr.readOne());
-            Assert.assertFalse(mr.readOne());
-            Assert.assertEquals("*doit[!net.openhft.chronicle.queue.internal.writer.ChronicleWriterTest$DTO {\n" +
+            assertTrue(mr.readOne());
+            assertTrue(mr.readOne());
+            assertFalse(mr.readOne());
+            assertEquals("*doit[!net.openhft.chronicle.queue.internal.writer.ChronicleWriterTest$DTO {\n" +
                     "  age: 19,\n" +
                     "  name: Henry\n" +
                     "}\n" +
@@ -57,7 +59,9 @@ public class ChronicleWriterTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testWireMarshallingWithInterface() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(MyInterface.class.getTypeName(), cw2);
         chronicleWriter.execute();
@@ -65,9 +69,9 @@ public class ChronicleWriterTest extends QueueTestCommon {
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(dir).build()) {
             StringBuilder sb = new StringBuilder();
             @NotNull MethodReader mr = queue.createTailer().methodReader(Mocker.intercepting(MyInterface.class, "*", sb::append));
-            Assert.assertTrue(mr.readOne());
-            Assert.assertFalse(mr.readOne());
-            Assert.assertEquals("*doit[!net.openhft.chronicle.queue.internal.writer.ChronicleWriterTest$DTO {\n" +
+            assertTrue(mr.readOne());
+            assertFalse(mr.readOne());
+            assertEquals("*doit[!net.openhft.chronicle.queue.internal.writer.ChronicleWriterTest$DTO {\n" +
                     "  age: 42,\n" +
                     "  name: Percy\n" +
                     "}\n" +
@@ -77,7 +81,9 @@ public class ChronicleWriterTest extends QueueTestCommon {
         }
     }
 
-    @Test(timeout = 5000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void testBytesMarshallingWithInterface() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(MyInterface2.class.getTypeName(), cw3);
         chronicleWriter.execute();
@@ -85,9 +91,9 @@ public class ChronicleWriterTest extends QueueTestCommon {
         try (ChronicleQueue queue = ChronicleQueue.singleBuilder(dir).build()) {
             StringBuilder sb = new StringBuilder();
             @NotNull MethodReader mr = queue.createTailer().methodReader(Mocker.intercepting(MyInterface2.class, "*", sb::append));
-            Assert.assertTrue(mr.readOne());
-            Assert.assertFalse(mr.readOne());
-            Assert.assertEquals("*doit[!net.openhft.chronicle.queue.internal.writer.ChronicleWriterTest$DTO2 {\n" +
+            assertTrue(mr.readOne());
+            assertFalse(mr.readOne());
+            assertEquals("*doit[!net.openhft.chronicle.queue.internal.writer.ChronicleWriterTest$DTO2 {\n" +
                     "  age: 42,\n" +
                     "  name: Percy\n" +
                     "}\n" +

--- a/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/writer/ChronicleWriterTest.java
@@ -16,9 +16,10 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ChronicleWriterTest extends QueueTestCommon {
+class ChronicleWriterTest extends QueueTestCommon {
     private static final String METHOD_NAME = "doit";
     private final String cw1;
     private final String cw2;
@@ -35,7 +36,7 @@ public class ChronicleWriterTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testWireMarshallingMapAndDTO() throws IOException {
+    void testWireMarshallingMapAndDTO() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(null, cw1, cw2);
         chronicleWriter.execute();
 
@@ -62,7 +63,7 @@ public class ChronicleWriterTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testWireMarshallingWithInterface() throws IOException {
+    void testWireMarshallingWithInterface() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(MyInterface.class.getTypeName(), cw2);
         chronicleWriter.execute();
 
@@ -84,7 +85,7 @@ public class ChronicleWriterTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void testBytesMarshallingWithInterface() throws IOException {
+    void testBytesMarshallingWithInterface() throws IOException {
         ChronicleWriter chronicleWriter = chronicleWriter(MyInterface2.class.getTypeName(), cw3);
         chronicleWriter.execute();
 
@@ -121,12 +122,12 @@ public class ChronicleWriterTest extends QueueTestCommon {
         void doit(DTO2 dto);
     }
 
-    public static class DTO extends SelfDescribingMarshallable {
+    static class DTO extends SelfDescribingMarshallable {
         private int age;
         private String name;
     }
 
-    public static class DTO2 extends DTO {
+    static class DTO2 extends DTO {
         @Override
         public boolean usesSelfDescribingMessage() {
             return false;

--- a/src/test/java/net/openhft/chronicle/queue/issue/ChangeRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ChangeRollCycleTest.java
@@ -19,15 +19,15 @@ import static org.junit.jupiter.api.Assertions.*;
  * It checks the compatibility and visibility of data written with one Roll Cycle
  * and accessed with another.
  */
-public class ChangeRollCycleTest {
+class ChangeRollCycleTest {
 
     @Test
-    public void changeRollCycleWithReadOnlyTailer() {
+    void changeRollCycleWithReadOnlyTailer() {
         testChangeRollCycle(true);
     }
 
     @Test
-    public void changeRollCycleWithReadWriteTailer() {
+    void changeRollCycleWithReadWriteTailer() {
         testChangeRollCycle(false);
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/issue/ChangeRollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ChangeRollCycleTest.java
@@ -10,10 +10,9 @@ import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.RollCycles;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class to verify the behavior of Chronicle Queue when changing Roll Cycles.
@@ -50,7 +49,7 @@ public class ChangeRollCycleTest {
 
             // Verify the queue is initially empty
             try (DocumentContext dc = tailer.readingDocument()) {
-                assertFalse("Queue should be empty initially", dc.isPresent());
+                assertFalse(dc.isPresent(), "Queue should be empty initially");
             }
 
             // Step 2: Reopen the queue with a WEEKLY roll cycle and write data
@@ -73,8 +72,7 @@ public class ChangeRollCycleTest {
                     appender3.writeText("World");
 
                     if (readOnly && !OS.isWindows())
-                        assertEquals("Roll cycle should match WEEKLY for read-only mode",
-                                RollCycles.WEEKLY, q3.rollCycle());
+                        assertEquals(RollCycles.WEEKLY, q3.rollCycle(), "Roll cycle should match WEEKLY for read-only mode");
                 }
 
                 // If the tailer is read-only, the roll cycle cannot not be changed
@@ -82,20 +80,18 @@ public class ChangeRollCycleTest {
                 if (readOnly) return;
 
                 // Step 4: Verify the data can be read back correctly
-                assertEquals("First message should match", "Hello", tailer.readText());
+                assertEquals("Hello", tailer.readText(), "First message should match");
 
                 if (readOnly)
-                    assertEquals("Roll cycle should match WEEKLY for read-only mode",
-                            RollCycles.WEEKLY,
-                            q1.rollCycle());
+                    assertEquals(RollCycles.WEEKLY, q1.rollCycle(), "Roll cycle should match WEEKLY for read-only mode");
 
-                assertEquals("Second message should match", "World", tailer.readText());
+                assertEquals("World", tailer.readText(), "Second message should match");
 
                 assertEquals(q2.rollCycle(), q1.rollCycle());
 
                 // Verify there is no extra data in the queue
                 try (DocumentContext dc = tailer.readingDocument()) {
-                    assertFalse("No more data should be present in the queue", dc.isPresent());
+                    assertFalse(dc.isPresent(), "No more data should be present in the queue");
                 }
             }
         } finally {

--- a/src/test/java/net/openhft/chronicle/queue/issue/DeleteFileTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/DeleteFileTest.java
@@ -19,9 +19,9 @@ import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class DeleteFileTest {
+class DeleteFileTest {
     @Test
-    public void testMain() {
+    void testMain() {
         final long[] clock = {1730366325_000L};
         final long delay = 1_000L;
         try {

--- a/src/test/java/net/openhft/chronicle/queue/issue/DeleteFileTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/DeleteFileTest.java
@@ -13,12 +13,11 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DeleteFileTest {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
@@ -15,8 +15,8 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ReaderResizesFileTest {
     private static final File QUEUE_DIR = new File(OS.getTarget(), "ReaderResizesFileTest-" + System.nanoTime());
 
-    @After
+    @AfterEach
     public void cleanup() {
         IOTools.deleteDirWithFiles(QUEUE_DIR);
     }

--- a/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/ReaderResizesFileTest.java
@@ -26,16 +26,16 @@ import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ReaderResizesFileTest {
+class ReaderResizesFileTest {
     private static final File QUEUE_DIR = new File(OS.getTarget(), "ReaderResizesFileTest-" + System.nanoTime());
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         IOTools.deleteDirWithFiles(QUEUE_DIR);
     }
 
     @Test
-    public void testReaderResizesFile() throws IOException {
+    void testReaderResizesFile() throws IOException {
         // go for the smallest possible block size to ensure we can test resizing
         int blockSize = 1 << 10;
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(QUEUE_DIR).rollCycle(TestRollCycles.TEST4_DAILY).blockSize(blockSize).build();
@@ -79,7 +79,7 @@ public class ReaderResizesFileTest {
     }
 
     @Test
-    public void testTailerRefCountStableDuringResize() throws IOException {
+    void testTailerRefCountStableDuringResize() throws IOException {
         int blockSize = 1 << 12;
         try (SingleChronicleQueue queue = ChronicleQueue.singleBuilder(QUEUE_DIR)
                 .rollCycle(TestRollCycles.TEST4_DAILY)
@@ -121,7 +121,7 @@ public class ReaderResizesFileTest {
     }
 
     @Test
-    public void testTailerHoldingDocumentAcrossRollsDoesNotResizeOldCycle() throws IOException {
+    void testTailerHoldingDocumentAcrossRollsDoesNotResizeOldCycle() throws IOException {
         File queuePath = new File(QUEUE_DIR, "tailer-hold");
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.currentTimeMillis(0L);
@@ -162,7 +162,7 @@ public class ReaderResizesFileTest {
     }
 
     @Test
-    public void testZeroLengthDocumentDoesNotBlockTailer() {
+    void testZeroLengthDocumentDoesNotBlockTailer() {
         File queuePath = new File(QUEUE_DIR, "zero-length");
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder(queuePath, net.openhft.chronicle.wire.WireType.BINARY)
                 .testBlockSize()

--- a/src/test/java/net/openhft/chronicle/queue/issue/TailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/TailerTest.java
@@ -10,24 +10,24 @@ import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TailerTest extends QueueTestCommon {
 
     private static final Path QUEUE_PATH = Paths.get(OS.getTarget() + "/host-1/queue/broker_out");
     private static final int OFFSET = 3;
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void cleanupFiles() {
         IOTools.deleteDirWithFiles(QUEUE_PATH.toFile());
     }

--- a/src/test/java/net/openhft/chronicle/queue/issue/TailerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/issue/TailerTest.java
@@ -21,19 +21,19 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TailerTest extends QueueTestCommon {
+class TailerTest extends QueueTestCommon {
 
     private static final Path QUEUE_PATH = Paths.get(OS.getTarget() + "/host-1/queue/broker_out");
     private static final int OFFSET = 3;
 
     @BeforeEach
     @AfterEach
-    public void cleanupFiles() {
+    void cleanupFiles() {
         IOTools.deleteDirWithFiles(QUEUE_PATH.toFile());
     }
 
     @Test
-    public void reproduce() {
+    void reproduce() {
         IOTools.deleteDirWithFiles(QUEUE_PATH.toFile());
 
         long firstOutputIndex = Long.MAX_VALUE;

--- a/src/test/java/net/openhft/chronicle/queue/jitter/BareSyncTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/jitter/BareSyncTest.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class BareSyncTest extends QueueTestCommon {
+class BareSyncTest extends QueueTestCommon {
     @Test
-    public void sync() {
+    void sync() {
         try (ChronicleQueue cq = ChronicleQueue.single(OS.getTarget() + "/bare-sync-test");
              ExcerptAppender appender = cq.createAppender()) {
             appender.sync();

--- a/src/test/java/net/openhft/chronicle/queue/jitter/BareSyncTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/jitter/BareSyncTest.java
@@ -8,9 +8,9 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.QueueTestCommon;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BareSyncTest extends QueueTestCommon {
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/main/DumpMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/main/DumpMainTest.java
@@ -15,10 +15,10 @@ import java.io.PrintStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class DumpMainTest extends QueueTestCommon {
+class DumpMainTest extends QueueTestCommon {
 
     @Test
-    public void dumpDirectoryPrintsQueueContents() {
+    void dumpDirectoryPrintsQueueContents() {
         final File dir = getTmpDir();
         try (ChronicleQueue q = SingleChronicleQueueBuilder.binary(dir).build()) {
             // write a couple of simple messages

--- a/src/test/java/net/openhft/chronicle/queue/main/DumpMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/main/DumpMainTest.java
@@ -7,15 +7,13 @@ import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import net.openhft.chronicle.wire.WireType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DumpMainTest extends QueueTestCommon {
 
@@ -37,9 +35,9 @@ public class DumpMainTest extends QueueTestCommon {
         DumpMain.dump(dir, out, Long.MAX_VALUE);
         final String dump = baos.toString();
 
-        assertFalse("Dump should not be empty", dump.trim().isEmpty());
-        assertTrue("Should include header with file path", dump.contains("## "));
-        assertTrue("Should include first message", dump.contains("hello"));
-        assertTrue("Should include second message", dump.contains("world"));
+        assertFalse(dump.trim().isEmpty(), "Dump should not be empty");
+        assertTrue(dump.contains("## "), "Should include header with file path");
+        assertTrue(dump.contains("hello"), "Should include first message");
+        assertTrue(dump.contains("world"), "Should include second message");
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/method/BrokenChainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/method/BrokenChainTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class BrokenChainTest extends QueueTestCommon {
+class BrokenChainTest extends QueueTestCommon {
     interface First {
         Second pre(String pre);
     }
@@ -28,7 +28,7 @@ public class BrokenChainTest extends QueueTestCommon {
     }
 
     @Test
-    public void brokenChainQueue() {
+    void brokenChainQueue() {
         String tmpName = OS.getTarget() + "/brokenChain-" + System.nanoTime();
         try (ChronicleQueue queue = ChronicleQueue.single(tmpName);
              // using createAppender() doesn't work as the chained methods uses acquireAppender()

--- a/src/test/java/net/openhft/chronicle/queue/method/BrokenChainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/method/BrokenChainTest.java
@@ -11,12 +11,12 @@ import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.ThreadLocalAppender;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BrokenChainTest extends QueueTestCommon {
     interface First {

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
@@ -22,7 +22,7 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.easymock.EasyMock.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class OrderManagerTest extends QueueTestCommon {
+class OrderManagerTest extends QueueTestCommon {
 
     @Override
     @BeforeEach
@@ -31,7 +31,7 @@ public class OrderManagerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testOnOrderIdea() {
+    void testOnOrderIdea() {
         ignoreException("Cannot get access to vectorizedMismatch");
         // what we expect to happen
         OrderListener listener = createMock(OrderListener.class);
@@ -56,7 +56,7 @@ public class OrderManagerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testWithQueue() {
+    void testWithQueue() {
         File queuePath = new File(OS.getTarget(), "testWithQueue-" + Time.uniqueId());
         try {
             try (ChronicleQueue queue = ChronicleQueue.singleBuilder(queuePath).testBlockSize().build()) {
@@ -100,7 +100,7 @@ public class OrderManagerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testWithQueueHistory() throws Throwable {
+    void testWithQueueHistory() throws Throwable {
         FlakyTestRunner.builder(this::testWithQueueHistory0).build().run();
     }
 
@@ -173,7 +173,7 @@ public class OrderManagerTest extends QueueTestCommon {
     }
 
     @Test
-    public void testRestartingAService() {
+    void testRestartingAService() {
         File queuePath = DirectoryUtils.tempDir("testRestartingAService");
         File queuePath2 = DirectoryUtils.tempDir("testRestartingAService-down");
         try {

--- a/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/micros/OrderManagerTest.java
@@ -13,19 +13,19 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.testframework.FlakyTestRunner;
 import net.openhft.chronicle.wire.MessageHistory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.easymock.EasyMock.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrderManagerTest extends QueueTestCommon {
 
     @Override
-    @Before
+    @BeforeEach
     public void threadDump() {
         super.threadDump();
     }
@@ -215,13 +215,13 @@ public class OrderManagerTest extends QueueTestCommon {
 
                     SidedMarketDataCombiner combiner = new SidedMarketDataCombiner(mdListener);
                     ExcerptTailer tailer = in.createTailer("test");
-                    assertEquals("tailer.index()=" + Long.toHexString(tailer.index()), i, in.rollCycle().toSequenceNumber(tailer.index()));
+                    assertEquals(i, in.rollCycle().toSequenceNumber(tailer.index()), "tailer.index()=" + Long.toHexString(tailer.index()));
                     MethodReader reader = tailer
                             .methodReader(combiner);
 
                     // System.out.println("#### IN\n" + in.dump());
                     // System.out.println("#### OUT:\n" + out.dump());
-                    assertTrue("i: " + i, reader.readOne());
+                    assertTrue(reader.readOne(), "i: " + i);
                 }
             }
         } finally {

--- a/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerPreconditionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerPreconditionTest.java
@@ -15,10 +15,10 @@ import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class NamedTailerPreconditionTest extends QueueTestCommon {
+class NamedTailerPreconditionTest extends QueueTestCommon {
 
     @Test
-    public void canCreateNonReplicatedNamedTailerOnSink() {
+    void canCreateNonReplicatedNamedTailerOnSink() {
         File queuePath = getTmpDir();
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().path(queuePath).build()) {
             setQueueAsSink(queue);
@@ -31,7 +31,7 @@ public class NamedTailerPreconditionTest extends QueueTestCommon {
     }
 
     @Test
-    public void cannotCreateNonReplicatedNamedTailerOnSink() {
+    void cannotCreateNonReplicatedNamedTailerOnSink() {
         File queuePath = getTmpDir();
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().path(queuePath).build()) {
             setQueueAsSink(queue);

--- a/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerPreconditionTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerPreconditionTest.java
@@ -9,13 +9,11 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.NamedTailerNotAvailableException;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NamedTailerPreconditionTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerVersioningTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerVersioningTest.java
@@ -26,10 +26,10 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class NamedTailerVersioningTest extends QueueTestCommon {
+class NamedTailerVersioningTest extends QueueTestCommon {
 
     @Test
-    public void nonReplicatedNamedTailerShouldNotCreateVersionInMetdata() {
+    void nonReplicatedNamedTailerShouldNotCreateVersionInMetdata() {
         finishedNormally = false;
         File queuePath = getTmpDir();
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().path(queuePath).build();
@@ -54,7 +54,7 @@ public class NamedTailerVersioningTest extends QueueTestCommon {
     }
 
     @Test
-    public void verifyBackwardsCompatibility_tailerPositionsAreRetained() throws IOException, URISyntaxException {
+    void verifyBackwardsCompatibility_tailerPositionsAreRetained() throws IOException, URISyntaxException {
         assumeFalse(PageUtil.isHugePage(OS.getTarget()), "This test must be ignored on hugetlbfs because the test file was generated on a standard linux file system");
 
         // Copy the data from src/test/resources
@@ -85,7 +85,7 @@ public class NamedTailerVersioningTest extends QueueTestCommon {
     }
 
     @Test
-    public void versionAndIndexRetentionAcrossMultipleLifecycles() {
+    void versionAndIndexRetentionAcrossMultipleLifecycles() {
         File queuePath = getTmpDir();
 
         // Open for first time
@@ -110,7 +110,7 @@ public class NamedTailerVersioningTest extends QueueTestCommon {
     }
 
     @Test
-    public void noVersionIncrements() {
+    void noVersionIncrements() {
         File queuePath = getTmpDir();
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().path(queuePath).build();
              ExcerptAppender appender = queue.createAppender();
@@ -128,7 +128,7 @@ public class NamedTailerVersioningTest extends QueueTestCommon {
     }
 
     @Test
-    public void multipleVersionIncrements() {
+    void multipleVersionIncrements() {
         File queuePath = getTmpDir();
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().path(queuePath).build();
              ExcerptAppender appender = queue.createAppender();
@@ -150,7 +150,7 @@ public class NamedTailerVersioningTest extends QueueTestCommon {
     }
 
     @Test
-    public void namedTailerCanRewindToStart() {
+    void namedTailerCanRewindToStart() {
         File queuePath = getTmpDir();
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().path(queuePath).build();
              ExcerptAppender appender = queue.createAppender();
@@ -170,7 +170,7 @@ public class NamedTailerVersioningTest extends QueueTestCommon {
     }
 
     @Test
-    public void namedTailerCanMoveToStoredIndexAfterRestart() {
+    void namedTailerCanMoveToStoredIndexAfterRestart() {
         File queuePath = getTmpDir();
         long[] indexes = new long[4];
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().path(queuePath).build();

--- a/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerVersioningTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/namedtailer/NamedTailerVersioningTest.java
@@ -12,8 +12,7 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,7 +23,8 @@ import java.nio.file.Paths;
 import java.util.stream.Stream;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class NamedTailerVersioningTest extends QueueTestCommon {
 
@@ -55,7 +55,7 @@ public class NamedTailerVersioningTest extends QueueTestCommon {
 
     @Test
     public void verifyBackwardsCompatibility_tailerPositionsAreRetained() throws IOException, URISyntaxException {
-        Assume.assumeFalse("This test must be ignored on hugetlbfs because the test file was generated on a standard linux file system", PageUtil.isHugePage(OS.getTarget()));
+        assumeFalse(PageUtil.isHugePage(OS.getTarget()), "This test must be ignored on hugetlbfs because the test file was generated on a standard linux file system");
 
         // Copy the data from src/test/resources
         Path templatePath = Paths.get(this.getClass().getResource("/named-tailer/5.25ea1-backwards-compat").toURI());
@@ -183,7 +183,7 @@ public class NamedTailerVersioningTest extends QueueTestCommon {
 
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().path(queuePath).build();
              ExcerptTailer tailer = queue.createTailer("replicated:resumer")) {
-            assertTrue("moveToIndex should succeed", tailer.moveToIndex(indexes[2]));
+            assertTrue(tailer.moveToIndex(indexes[2]), "moveToIndex should succeed");
             assertEquals("payload-2", tailer.readText());
         } finally {
             IOTools.deleteDirWithFiles(queuePath);

--- a/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
@@ -14,15 +14,18 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.queue.internal.util.InternalFileUtil;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
@@ -31,18 +34,22 @@ import static java.util.stream.Collectors.toList;
 import static net.openhft.chronicle.queue.internal.util.InternalFileUtil.getAllOpenFilesIsSupportedOnOS;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class FileUtilTest extends QueueTestCommon {
 
-    @Test(timeout = 30_000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void stateNonExisting() {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         assertEquals(FileState.NON_EXISTENT, FileUtil.state(new File("sjduq867q3jqq3t3q3r")));
     }
 
-    @Test(timeout = 30_000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void state() throws IOException {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         final Path dir = IOTools.createTempDirectory("openByAnyProcess");
@@ -73,29 +80,35 @@ public class FileUtilTest extends QueueTestCommon {
         }
     }
 
-    @Test(expected = UnsupportedOperationException.class, timeout = 30_000)
+    @Test
     public void stateWindows() {
         assumeTrue(OS.isWindows());
 
         expectException("closable tracing disabled");
         AbstractCloseable.disableCloseableTracing();
 
-        FileUtil.state(new File("foo"));
+        assertThrows(UnsupportedOperationException.class, () -> FileUtil.state(new File("foo")));
     }
 
-    @Test(timeout = 30_000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void hasQueueSuffixFalse() {
         final File file = new File("foo");
         assertFalse(FileUtil.hasQueueSuffix(file));
     }
 
-    @Test(timeout = 30_000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void hasQueueSuffixTrue() {
         final File file = new File("a" + SingleChronicleQueue.SUFFIX);
         assertTrue(FileUtil.hasQueueSuffix(file));
     }
 
-    @Test(timeout = 30_000)
+    @Test
+
+    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void removableQueueFileCandidates() {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         final int rolls = 4;
@@ -157,12 +170,12 @@ public class FileUtilTest extends QueueTestCommon {
         }
     }
 
-    @Test(expected = UnsupportedOperationException.class, timeout = 30_000)
+    @Test
     public void removableQueueFileCandidatesWindows() {
         assumeTrue(OS.isWindows());
         expectException("closable tracing disabled");
         AbstractCloseable.disableCloseableTracing();
-        FileUtil.removableRollFileCandidates(new File("foo"));
+        assertThrows(UnsupportedOperationException.class, () -> FileUtil.removableRollFileCandidates(new File("foo")));
     }
 
     private <T> void assertSorted(List<T> list, Comparator<T> comparator) {

--- a/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
@@ -18,10 +18,12 @@ import net.openhft.chronicle.queue.internal.util.InternalFileUtil;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.*;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +43,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
     void stateNonExisting() {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         assertEquals(FileState.NON_EXISTENT, FileUtil.state(new File("sjduq867q3jqq3t3q3r")));
@@ -49,7 +51,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
     void state() throws IOException {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         final Path dir = IOTools.createTempDirectory("openByAnyProcess");
@@ -92,7 +94,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
     void hasQueueSuffixFalse() {
         final File file = new File("foo");
         assertFalse(FileUtil.hasQueueSuffix(file));
@@ -100,7 +102,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
     void hasQueueSuffixTrue() {
         final File file = new File("a" + SingleChronicleQueue.SUFFIX);
         assertTrue(FileUtil.hasQueueSuffix(file));
@@ -108,7 +110,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
     void removableQueueFileCandidates() {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         final int rolls = 4;

--- a/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
@@ -37,12 +37,12 @@ import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDL
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
-public class FileUtilTest extends QueueTestCommon {
+class FileUtilTest extends QueueTestCommon {
 
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void stateNonExisting() {
+    void stateNonExisting() {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         assertEquals(FileState.NON_EXISTENT, FileUtil.state(new File("sjduq867q3jqq3t3q3r")));
     }
@@ -50,7 +50,7 @@ public class FileUtilTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void state() throws IOException {
+    void state() throws IOException {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         final Path dir = IOTools.createTempDirectory("openByAnyProcess");
         dir.toFile().mkdir();
@@ -81,7 +81,7 @@ public class FileUtilTest extends QueueTestCommon {
     }
 
     @Test
-    public void stateWindows() {
+    void stateWindows() {
         assumeTrue(OS.isWindows());
 
         expectException("closable tracing disabled");
@@ -93,7 +93,7 @@ public class FileUtilTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void hasQueueSuffixFalse() {
+    void hasQueueSuffixFalse() {
         final File file = new File("foo");
         assertFalse(FileUtil.hasQueueSuffix(file));
     }
@@ -101,7 +101,7 @@ public class FileUtilTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void hasQueueSuffixTrue() {
+    void hasQueueSuffixTrue() {
         final File file = new File("a" + SingleChronicleQueue.SUFFIX);
         assertTrue(FileUtil.hasQueueSuffix(file));
     }
@@ -109,7 +109,7 @@ public class FileUtilTest extends QueueTestCommon {
     @Test
 
     @org.junit.jupiter.api.Timeout(value = 30_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
-    public void removableQueueFileCandidates() {
+    void removableQueueFileCandidates() {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         final int rolls = 4;
         final int intermediateRolls = rolls / 2;
@@ -171,7 +171,7 @@ public class FileUtilTest extends QueueTestCommon {
     }
 
     @Test
-    public void removableQueueFileCandidatesWindows() {
+    void removableQueueFileCandidatesWindows() {
         assumeTrue(OS.isWindows());
         expectException("closable tracing disabled");
         AbstractCloseable.disableCloseableTracing();
@@ -188,7 +188,7 @@ public class FileUtilTest extends QueueTestCommon {
     }
 
     @Test
-    public void testOpenFilesWithPid() throws IOException {
+    void testOpenFilesWithPid() throws IOException {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
 
         // open file for writing, keeping file handle open

--- a/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/FileUtilTest.java
@@ -14,7 +14,6 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import net.openhft.chronicle.queue.internal.util.InternalFileUtil;
 import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -22,12 +21,9 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.*;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
@@ -43,7 +39,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     void stateNonExisting() {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         assertEquals(FileState.NON_EXISTENT, FileUtil.state(new File("sjduq867q3jqq3t3q3r")));
@@ -51,7 +47,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     void state() throws IOException {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         final Path dir = IOTools.createTempDirectory("openByAnyProcess");
@@ -94,7 +90,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     void hasQueueSuffixFalse() {
         final File file = new File("foo");
         assertFalse(FileUtil.hasQueueSuffix(file));
@@ -102,7 +98,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     void hasQueueSuffixTrue() {
         final File file = new File("a" + SingleChronicleQueue.SUFFIX);
         assertTrue(FileUtil.hasQueueSuffix(file));
@@ -110,7 +106,7 @@ class FileUtilTest extends QueueTestCommon {
 
     @Test
 
-    @Timeout(value = 30_000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     void removableQueueFileCandidates() {
         assumeTrue(getAllOpenFilesIsSupportedOnOS());
         final int rolls = 4;

--- a/src/test/java/net/openhft/chronicle/queue/util/HugetlbfsTestUtil.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/HugetlbfsTestUtil.java
@@ -5,8 +5,6 @@ package net.openhft.chronicle.queue.util;
 
 import net.openhft.chronicle.bytes.PageUtil;
 import net.openhft.chronicle.core.Jvm;
-import org.junit.rules.TestName;
-
 import java.io.File;
 import java.nio.file.Paths;
 
@@ -48,15 +46,15 @@ public final class HugetlbfsTestUtil {
     /**
      * Get a path to a queue directory on hugetlbfs.
      *
-     * @param testName Junit {@link TestName} rule that contains the unit test method name.
+     * @param testMethodName the unit test method name.
      * @return a unique path on hugetlbfs scoped for this test method name.
      */
-    public static String getHugetlbfsQueueDirectory(TestName testName) {
+    public static String getHugetlbfsQueueDirectory(String testMethodName) {
         String hugetlbfsPath = hugetlbfsPath();
         if (hugetlbfsPath == null || !isHugetlbfsAvailable()) {
             throw new IllegalStateException("hugetlbfs is not available");
         }
 
-        return Paths.get(hugetlbfsPath, testName.getMethodName()).toString();
+        return Paths.get(hugetlbfsPath, testMethodName).toString();
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/util/HugetlbfsTestUtil.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/HugetlbfsTestUtil.java
@@ -5,6 +5,7 @@ package net.openhft.chronicle.queue.util;
 
 import net.openhft.chronicle.bytes.PageUtil;
 import net.openhft.chronicle.core.Jvm;
+
 import java.io.File;
 import java.nio.file.Paths;
 

--- a/src/test/java/net/openhft/chronicle/queue/util/PretouchUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/PretouchUtilTest.java
@@ -13,10 +13,10 @@ import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PretouchUtilTest extends QueueTestCommon {
+class PretouchUtilTest extends QueueTestCommon {
 
     @Test
-    public void createEventHandlerAndPretoucherFallback() {
+    void createEventHandlerAndPretoucherFallback() {
         ignoreException("Pretoucher is only supported");
         final File dir = getTmpDir();
         try (ChronicleQueue q = SingleChronicleQueueBuilder.binary(dir).build()) {
@@ -35,7 +35,7 @@ public class PretouchUtilTest extends QueueTestCommon {
     }
 
     @Test
-    public void eventHandlerActionOnClosedQueueDoesNotThrow() {
+    void eventHandlerActionOnClosedQueueDoesNotThrow() {
         ignoreException("Pretoucher is only supported");
         final File dir = getTmpDir();
         EventHandler handler;

--- a/src/test/java/net/openhft/chronicle/queue/util/PretouchUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/PretouchUtilTest.java
@@ -6,13 +6,12 @@ package net.openhft.chronicle.queue.util;
 import net.openhft.chronicle.core.threads.EventHandler;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.QueueTestCommon;
-import net.openhft.chronicle.queue.impl.single.Pretoucher;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PretouchUtilTest extends QueueTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/queue/util/RollCyclesAsciiDocGeneratingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/RollCyclesAsciiDocGeneratingTest.java
@@ -13,12 +13,12 @@ import org.junit.jupiter.api.Test;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RollCyclesAsciiDocGeneratingTest extends QueueTestCommon {
+class RollCyclesAsciiDocGeneratingTest extends QueueTestCommon {
     /**
      * This generates the asciidoc for the table in /docs/FAQ.adoc
      */
     @Test
-    public void dumpAllRollCycles() {
+    void dumpAllRollCycles() {
         StringBuilder stringBuilder = new StringBuilder().append("\n\n");
         for (RollCycle cycle : RollCycles.all()) {
             stringBuilder.append(format("| %s | %,d | `0x%x` | %,d%n",

--- a/src/test/java/net/openhft/chronicle/queue/util/RollCyclesAsciiDocGeneratingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/util/RollCyclesAsciiDocGeneratingTest.java
@@ -8,10 +8,10 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.queue.RollCycles;
 import net.openhft.chronicle.queue.RollCyclesTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RollCyclesAsciiDocGeneratingTest extends QueueTestCommon {
     /**


### PR DESCRIPTION
## Summary
Migrate Chronicle Queue tests to Jupiter and harden the updated assertions across the queue test suite.

## Included Work
- Harden migrated queue tests
- Migrate Chronicle Queue implementation tests to Jupiter
- Migrate remaining Chronicle Queue tests to Jupiter

## Changed Areas
- `src/test`

## Notes
- Compared against `develop` after refreshing `origin/develop` on 2026-03-24.
- Full repository test suites were not rerun during this bulk PR creation pass.
