### PR TITLE
QUEUE-122 Pin node version used by docs creation to 22

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
 #
 
-FROM node:alpine AS base
+FROM node:22-alpine AS base
 RUN apk --update add git
 RUN npm install -g gitlab:antora/xref-validator
 


### PR DESCRIPTION
Pin node:alpine version to 22 to avoid issues introduced in later Node versions using isomorphic-git.
Antora is silently failing to generate docs presently - the root cause appears to be the interaction of git metadata pulled into the generated Docker image and the specific form of git used when building the Docker image.
This PR is intended to stabilise the Docker base image going forward to avoid introduced errors.