### PR TITLE
FIX-251 Drop redundant Chronicle test-jar dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,13 +113,6 @@
         </dependency>
 
         <dependency>
-            <groupId>net.openhft</groupId>
-            <artifactId>chronicle-core</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Summary
- remove the redundant chronicle-core test-jar dependency

## Verification
- mvn -q -DskipTests test-compile