### PR TITLE
CORE-67 update warning ignoring for direct memory cleaner check

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/QueueTestCommon.java
@@ -167,7 +167,8 @@ public class QueueTestCommon {
                 "File released ",
                 "Overriding roll length from existing metadata",
                 " was 3600000",
-                " overriding to 86400000   ")) {
+                " overriding to 86400000   ",
+                "does not free direct memory")) {
             ignoreException(msg);
         }
     }


### PR DESCRIPTION
Ensures that if the test cleaner is present, it does not fail the test