### PR TITLE
QUEUE-129: make ChronicleHistoryReaderMainTest run on JDK 17+

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
@@ -140,6 +140,21 @@ public class ChronicleHistoryReaderMain {
                 true
         );
         writer.flush();
+        exit(status);
+    }
+
+    /**
+     * Terminates the JVM with the given status.
+     * <p>
+     * Exposed as an overridable seam so that tests can verify exit behaviour without
+     * terminating the test runner. This replaces the previous SecurityManager-based
+     * interception, which no longer works: the SecurityManager is disabled from JDK 17
+     * and {@code System.setSecurityManager} throws {@code UnsupportedOperationException}
+     * from JDK 24 (JEP 486).
+     *
+     * @param status Exit status
+     */
+    protected void exit(int status) {
         System.exit(status);
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMain.java
@@ -148,8 +148,8 @@ public class ChronicleHistoryReaderMain {
      * <p>
      * Exposed as an overridable seam so that tests can verify exit behaviour without
      * terminating the test runner. This replaces the previous SecurityManager-based
-     * interception, which no longer works: the SecurityManager is disabled from JDK 17
-     * and {@code System.setSecurityManager} throws {@code UnsupportedOperationException}
+     * interception, which is deprecated for removal since JDK 17 (JEP 411), and
+     * {@code System.setSecurityManager} throws {@code UnsupportedOperationException}
      * from JDK 24 (JEP 486).
      *
      * @param status Exit status

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainTest.java
@@ -3,47 +3,45 @@
  */
 package net.openhft.chronicle.queue;
 
-import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.queue.reader.ChronicleHistoryReader;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.file.Path;
-import java.security.Permission;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
 
-@SuppressWarnings({"deprecation", "removal"})
 public class ChronicleHistoryReaderMainTest {
 
-    private static class NoExitSecurityManager extends SecurityManager {
-        @Override
-        public void checkPermission(Permission perm) {
-            // allow anything
-        }
+    /**
+     * Thrown by an overridden {@link ChronicleHistoryReaderMain#exit(int)} so that tests can
+     * observe an attempted JVM exit (and the status it was called with) without terminating the
+     * test runner. This replaces the old SecurityManager-based interception, which is disabled
+     * from JDK 17 and unavailable from JDK 24 (JEP 486).
+     */
+    private static final class ExitInvoked extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+        final int status;
 
-        @Override
-        public void checkExit(int status) {
-            throw new SecurityException("System exit attempted with status: " + status);
+        ExitInvoked(int status) {
+            this.status = status;
         }
     }
 
-    @Before
-    public void setUp() {
-        // SecurityManager is effectively disabled from JDK 17 onwards
-        assumeTrue(Jvm.majorVersion() < 17);
-        System.setSecurityManager(new NoExitSecurityManager());
-    }
-
-    @After
-    public void tearDown() {
-        System.setSecurityManager(null);
+    /**
+     * A named subclass whose {@link #exit(int)} records the requested status rather than
+     * terminating the JVM. Deliberately a named (non-anonymous) class so that
+     * {@code getClass().getSimpleName()} is non-empty: {@code printHelpAndExit} passes it to
+     * commons-cli as the command-line syntax, which rejects an empty value.
+     */
+    private static final class ExitCapturingMain extends ChronicleHistoryReaderMain {
+        @Override
+        protected void exit(int status) {
+            throw new ExitInvoked(status);
+        }
     }
 
     @Test
@@ -131,25 +129,14 @@ public class ChronicleHistoryReaderMainTest {
 
     @Test
     public void testParseCommandLineHelpOption() {
-        ChronicleHistoryReaderMain main = new ChronicleHistoryReaderMain() {
-            @Override
-            protected void printHelpAndExit(Options options, int status, String message) {
-                assertEquals(0, status);  // Ensure help is printed with status 0 (success)
-                throw new ThreadDeath();  // Exit without calling System.exit()
-            }
-        };
+        ChronicleHistoryReaderMain main = new ExitCapturingMain();
         String[] args = {"-h"};
 
-        // Manually setting the security manager to catch System.exit() if needed
         try {
-            main.run(args);  // Should trigger the help message and exit with 0
-            fail("Expected ThreadDeath to be thrown");
-
-        } catch (ThreadDeath e) {
-            // Expected exception
-
-        } catch (SecurityException e) {
-            fail("System.exit was called unexpectedly.");
+            main.run(args);  // Should print help and request exit with status 0
+            fail("Expected exit to be invoked");
+        } catch (ExitInvoked e) {
+            assertEquals(0, e.status);  // Help is requested explicitly, so a clean exit
         }
     }
 
@@ -171,13 +158,13 @@ public class ChronicleHistoryReaderMainTest {
 
     @Test
     public void testPrintHelpAndExit() {
-        ChronicleHistoryReaderMain main = new ChronicleHistoryReaderMain();
+        ChronicleHistoryReaderMain main = new ExitCapturingMain();
         Options options = main.options();
         try {
             main.printHelpAndExit(options, 0, "Optional message");
-            fail("Expected SecurityException due to System.exit(0)");
-        } catch (SecurityException e) {
-            assertTrue(e.getMessage().contains("System exit attempted with status: 0"));
+            fail("Expected exit to be invoked with status 0");
+        } catch (ExitInvoked e) {
+            assertEquals(0, e.status);
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleHistoryReaderMainTest.java
@@ -19,8 +19,8 @@ public class ChronicleHistoryReaderMainTest {
     /**
      * Thrown by an overridden {@link ChronicleHistoryReaderMain#exit(int)} so that tests can
      * observe an attempted JVM exit (and the status it was called with) without terminating the
-     * test runner. This replaces the old SecurityManager-based interception, which is disabled
-     * from JDK 17 and unavailable from JDK 24 (JEP 486).
+     * test runner. This replaces the old SecurityManager-based interception, which is deprecated
+     * for removal since JDK 17 (JEP 411) and unavailable from JDK 24 (JEP 486).
      */
     private static final class ExitInvoked extends RuntimeException {
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
## Summary

The Build-All Java 25 run (`Chronicle_BuildAll_Java25` #1312293) failed with exactly six tests, all in `ChronicleHistoryReaderMainTest`. This PR resolves them and restores coverage that had been silently skipped on every modern JDK.

## Root cause

The generated tests used a `SecurityManager` (`NoExitSecurityManager`) purely to intercept the `System.exit()` call in `ChronicleHistoryReaderMain.printHelpAndExit`, and gated the whole class behind `assumeTrue(Jvm.majorVersion() < 17)`. Two problems:

- From JDK 24 (JEP 486) `System.setSecurityManager` throws `UnsupportedOperationException` for any argument, including `null`. The unconditional reset in `@After` ran even when `@Before` aborted the assumption, so JUnit turned the intended skip into six `TestCouldNotBeSkippedException` failures on Java 25.
- The class-level assumption skipped all six tests on every JDK >= 17, including the five that never touch `System.exit`, leaving CLI parsing, options and setup wiring with no coverage on modern JDKs.

## Change

- Add an overridable `protected void exit(int status)` seam on `ChronicleHistoryReaderMain` (defaults to `System.exit(status)`); `printHelpAndExit` now calls it. No behavioural change for real usage.
- Drop the `SecurityManager`, the `@Before`/`@After` setup, the class-wide `assumeTrue(< 17)` guard, and the deprecated `ThreadDeath`. Exit-path tests override `exit(...)` to capture the requested status instead of terminating the runner.
- Use a named `ExitCapturingMain` subclass so `getClass().getSimpleName()` stays non-empty: `printHelpAndExit` passes it to commons-cli as the command-line syntax, which rejects an empty value (an anonymous subclass triggers `cmdLineSyntax not provided`). Production is unaffected because it uses the concrete class.

## Verification

`mvn -Dtest=ChronicleHistoryReaderMainTest test` run under both JDKs:

| JDK | Before | After |
| --- | --- | --- |
| 25 (`25.0.3-tem`) | 6 failures | 6 run, 0 failures, 0 errors, 0 skipped |
| 8 (`8.0.482-tem`) | n/a (skipped on >= 17) | 6 run, 0 failures, 0 errors, 0 skipped |

All six tests now run and pass on both JDKs with no skips.

Fixes QUEUE-129