### PR TITLE
QUEUE-130: Release parked store after StoreAppender construction

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -49,15 +49,6 @@ class StoreAppender extends AbstractCloseable
      */
     private static final String NORMALISED_EOFS_TO_TABLESTORE_KEY = "normalisedEOFsTo";
 
-    /**
-     * When set, a freshly-constructed appender releases the store its EOF back-scan parked on, so it
-     * holds no roll-cycle file open until its first write re-acquires the current cycle. This prevents
-     * an appender on a thread that then goes idle (or, in async/BUFFERED mode, never writes to the file
-     * directly at all) from pinning an old {@code .cq4} open for the life of the queue - which defeats
-     * {@code FileUtil.removableRollFileCandidates()}. See QUEUE-130.
-     */
-    private static final boolean RELEASE_PARKED_STORE_ON_CONSTRUCTION =
-            Jvm.getBoolean("queue.appender.releaseParkedStoreOnConstruction");
     @NotNull
     private final SingleChronicleQueue queue;
     @NotNull
@@ -109,6 +100,7 @@ class StoreAppender extends AbstractCloseable
             int lastExistingCycle = queue.lastCycle();
             int firstCycle = queue.firstCycle();
             long start = System.nanoTime();
+            int scannedCycle = Integer.MIN_VALUE;
             final WriteLock writeLock = this.queue.writeLock();
             writeLock.lock();
             try {
@@ -130,20 +122,16 @@ class StoreAppender extends AbstractCloseable
                     }
                     if (wire != null)
                         resetPosition();
+                    scannedCycle = cycle;
 
-                    // The back-scan above parks this appender on a store (the newest EOF-ed cycle, or
-                    // the first non-EOF cycle after it). If we hold on to that store and this thread
-                    // then never writes, its file stays mapped/open forever. Release it so we start in
-                    // the same state as an appender created on an empty queue (null store, no FD); the
-                    // first write re-acquires the current cycle via setWireIfNull/rollCycleTo.
-                    if (RELEASE_PARKED_STORE_ON_CONSTRUCTION)
-                        releaseParkedStore();
+                    // Don't hold the back-scan's store open; the first write re-acquires it
+                    releaseParkedStore();
                 }
             } finally {
                 writeLock.unlock();
                 long tookMillis = (System.nanoTime() - start) / 1_000_000;
-                if (tookMillis > WARN_SLOW_APPENDER_MS || (lastExistingCycle >= 0 && cycle != lastExistingCycle))
-                    Jvm.perf().on(getClass(), "Took " + tookMillis + "ms to find first open cycle " + cycle);
+                if (tookMillis > WARN_SLOW_APPENDER_MS || (lastExistingCycle >= 0 && scannedCycle != lastExistingCycle))
+                    Jvm.perf().on(getClass(), "Took " + tookMillis + "ms to find first open cycle " + scannedCycle);
             }
         } catch (RuntimeException ex) {
             // Perhaps initialization code needs to be moved away from constructor

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -48,6 +48,16 @@ class StoreAppender extends AbstractCloseable
      * This is the key in the table-store where we store that information
      */
     private static final String NORMALISED_EOFS_TO_TABLESTORE_KEY = "normalisedEOFsTo";
+
+    /**
+     * When set, a freshly-constructed appender releases the store its EOF back-scan parked on, so it
+     * holds no roll-cycle file open until its first write re-acquires the current cycle. This prevents
+     * an appender on a thread that then goes idle (or, in async/BUFFERED mode, never writes to the file
+     * directly at all) from pinning an old {@code .cq4} open for the life of the queue - which defeats
+     * {@code FileUtil.removableRollFileCandidates()}. See QUEUE-130.
+     */
+    private static final boolean RELEASE_PARKED_STORE_ON_CONSTRUCTION =
+            Jvm.getBoolean("queue.appender.releaseParkedStoreOnConstruction");
     @NotNull
     private final SingleChronicleQueue queue;
     @NotNull
@@ -120,6 +130,14 @@ class StoreAppender extends AbstractCloseable
                     }
                     if (wire != null)
                         resetPosition();
+
+                    // The back-scan above parks this appender on a store (the newest EOF-ed cycle, or
+                    // the first non-EOF cycle after it). If we hold on to that store and this thread
+                    // then never writes, its file stays mapped/open forever. Release it so we start in
+                    // the same state as an appender created on an empty queue (null store, no FD); the
+                    // first write re-acquires the current cycle via setWireIfNull/rollCycleTo.
+                    if (RELEASE_PARKED_STORE_ON_CONSTRUCTION)
+                        releaseParkedStore();
                 }
             } finally {
                 writeLock.unlock();
@@ -397,6 +415,26 @@ class StoreAppender extends AbstractCloseable
         wire.pauser(queue.pauserSupplier.get());
         resetPosition();
         queue.onRoll(cycle);
+    }
+
+    /**
+     * Releases the store (and its wires) that the construction-time EOF back-scan left this appender
+     * parked on, returning the appender to the same "never written" state as one created on an empty
+     * queue. The next write re-acquires the current cycle. Only the mapped-file reservation and open
+     * FD are dropped; nothing on disk changes.
+     */
+    private void releaseParkedStore() {
+        if (store == null)
+            return;
+
+        releaseBytesFor(wireForIndex);
+        releaseBytesFor(wire);
+        wireForIndex = null;
+        wire = null;
+
+        storePool.closeStore(store);
+        store = null;
+        cycle = Integer.MIN_VALUE;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -629,7 +629,9 @@ class StoreAppender extends AbstractCloseable
         final WriteLock writeLock = queue.writeLock();
         writeLock.lock();
         try {
-            normaliseEOFs0(cycle);
+            // use the getter, not the raw field: after the construction-time back-scan releases its
+            // parked store the field is Integer.MIN_VALUE, and the getter resolves that to lastCycle
+            normaliseEOFs0(cycle());
         } finally {
             writeLock.unlock();
             long tookMillis = (System.nanoTime() - start) / 1_000_000;

--- a/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
@@ -18,7 +18,9 @@ import java.io.File;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.single;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 @RequiredForClient
 public class CreateAtIndexTest extends QueueTestCommon {
@@ -43,7 +45,10 @@ public class CreateAtIndexTest extends QueueTestCommon {
             String before = queue.dump();
             appender.writeBytes(0x421d00000000L, HELLO_WORLD);
             String after = queue.dump();
-            // ignore benign metadata deltas from the appender's first-write EOF normalisation
+            // the appender's first write normalises EOFs, adding a normalisedEOFsTo record;
+            // assert that delta explicitly, then require the dumps to match once it is masked out
+            assertFalse(before.contains("normalisedEOFsTo"));
+            assertTrue(after.contains("normalisedEOFsTo"));
             assertEquals(cleanDump(before), cleanDump(after));
         }
 

--- a/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
@@ -43,7 +43,12 @@ public class CreateAtIndexTest extends QueueTestCommon {
             String before = queue.dump();
             appender.writeBytes(0x421d00000000L, HELLO_WORLD);
             String after = queue.dump();
-            assertEquals(before, after);
+            // The duplicate-index write appends no data. With queue.appender.releaseParkedStoreOnConstruction
+            // (QUEUE-130) the fresh appender first re-acquires the current cycle's store and re-runs EOF
+            // normalisation. That leaves only non-semantic metadata deltas - a modCount tick, the
+            // normalisedEOFsTo watermark record, and store free-space counts - none of which are the data
+            // this test guards, so normalise them out before asserting the contents are unchanged.
+            assertEquals(cleanDump(before), cleanDump(after));
         }
 
 /*
@@ -90,6 +95,13 @@ public class CreateAtIndexTest extends QueueTestCommon {
             IOTools.deleteDirWithFiles(tmp, 2);
         } catch (IORuntimeException ignored) {
         }
+    }
+
+    private static String cleanDump(String dump) {
+        return dump
+                .replaceAll("# \\d+ bytes remaining", "# NN bytes remaining")
+                .replaceAll("modCount: (\\d+)", "modCount: 00")
+                .replaceAll("# position: \\d+, header: \\d+\\R--- !!data #binary\\RnormalisedEOFsTo: \\d+\\R", "");
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
@@ -43,11 +43,7 @@ public class CreateAtIndexTest extends QueueTestCommon {
             String before = queue.dump();
             appender.writeBytes(0x421d00000000L, HELLO_WORLD);
             String after = queue.dump();
-            // The duplicate-index write appends no data. With queue.appender.releaseParkedStoreOnConstruction
-            // (QUEUE-130) the fresh appender first re-acquires the current cycle's store and re-runs EOF
-            // normalisation. That leaves only non-semantic metadata deltas - a modCount tick, the
-            // normalisedEOFsTo watermark record, and store free-space counts - none of which are the data
-            // this test guards, so normalise them out before asserting the contents are unchanged.
+            // ignore benign metadata deltas from the appender's first-write EOF normalisation
             assertEquals(cleanDump(before), cleanDump(after));
         }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderReleasesParkedStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderReleasesParkedStoreTest.java
@@ -70,7 +70,6 @@ class AppenderReleasesParkedStoreTest extends IndexingTestCommon {
 
     // All roll-cycle files, earliest first; the pause lets freshly rolled files appear.
     private List<File> cycleFiles() {
-        Jvm.pause(300);
         final File[] files = queue.file().listFiles(FileUtil::hasQueueSuffix);
         assertNotNull(files, "no queue files found in " + queue.file());
         return Stream.of(files).sorted(EARLIEST_FIRST).collect(toList());
@@ -78,7 +77,6 @@ class AppenderReleasesParkedStoreTest extends IndexingTestCommon {
 
     // Removable candidates, earliest first; the pause lets rolled-off files be released first.
     private List<File> removableCandidates() {
-        Jvm.pause(300);
         final List<File> candidates = FileUtil.removableRollFileCandidates(queue.file()).collect(toList());
         assertEquals(candidates.stream().sorted(EARLIEST_FIRST).collect(toList()), candidates);
         return candidates;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderReleasesParkedStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderReleasesParkedStoreTest.java
@@ -3,7 +3,7 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
-import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
 import net.openhft.chronicle.queue.util.FileUtil;
 import org.junit.jupiter.api.Test;
 
@@ -68,15 +68,17 @@ class AppenderReleasesParkedStoreTest extends IndexingTestCommon {
         }
     }
 
-    // All roll-cycle files, earliest first; the pause lets freshly rolled files appear.
+    // All roll-cycle files, earliest first.
     private List<File> cycleFiles() {
         final File[] files = queue.file().listFiles(FileUtil::hasQueueSuffix);
         assertNotNull(files, "no queue files found in " + queue.file());
         return Stream.of(files).sorted(EARLIEST_FIRST).collect(toList());
     }
 
-    // Removable candidates, earliest first; the pause lets rolled-off files be released first.
+    // Removable candidates, earliest first. The parked store's file descriptor is dropped on a
+    // background thread, so drain the releaser before inspecting open descriptors.
     private List<File> removableCandidates() {
+        BackgroundResourceReleaser.releasePendingResources();
         final List<File> candidates = FileUtil.removableRollFileCandidates(queue.file()).collect(toList());
         assertEquals(candidates.stream().sorted(EARLIEST_FIRST).collect(toList()), candidates);
         return candidates;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderReleasesParkedStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderReleasesParkedStoreTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.queue.util.FileUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static net.openhft.chronicle.queue.internal.util.InternalFileUtil.getAllOpenFilesIsSupportedOnOS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Verifies through {@link FileUtil#removableRollFileCandidates} that an appender does not keep an old
+ * roll-cycle file open once it has rolled into the past. Removal stops at the first still-open file
+ * (oldest first), so a pinned old file blocks everything after it.
+ * <p>
+ * These tests inspect open descriptors via {@code /proc/self/fd} and are skipped where unsupported.
+ */
+class AppenderReleasesParkedStoreTest extends IndexingTestCommon {
+
+    private static final Comparator<File> EARLIEST_FIRST = Comparator.comparing(File::getName);
+
+    // Control: with only the writer active, the current cycle stays open and earlier cycles are removable.
+    @Test
+    void writerAloneLeavesEveryEarlierCycleRemovable() {
+        assumeTrue(getAllOpenFilesIsSupportedOnOS());
+
+        appender.writeText("cycle-0");
+        timeProvider.advanceMillis(1_001);
+        appender.writeText("cycle-1");
+        timeProvider.advanceMillis(1_001);
+        appender.writeText("cycle-2");
+
+        final List<File> created = cycleFiles();
+        assertEquals(3, created.size(), "expected three roll-cycle files, got " + created);
+        assertEquals(created.subList(0, 2), removableCandidates());
+    }
+
+    // A fresh appender parks on the current cycle at construction and never writes; after the writer rolls
+    // past it, it must not keep the now-old file open.
+    @Test
+    void parkedAppenderDoesNotPinAnOldCycle() {
+        assumeTrue(getAllOpenFilesIsSupportedOnOS());
+
+        appender.writeText("cycle-0");
+        timeProvider.advanceMillis(1_001);
+        appender.writeText("cycle-1");
+
+        final StoreAppender parked = (StoreAppender) queue.createAppender();
+        try {
+            timeProvider.advanceMillis(1_001);
+            appender.writeText("cycle-2");
+
+            final List<File> created = cycleFiles();
+            assertEquals(3, created.size(), "expected three roll-cycle files, got " + created);
+            assertEquals(created.subList(0, 2), removableCandidates());
+        } finally {
+            parked.close();
+        }
+    }
+
+    // All roll-cycle files, earliest first; the pause lets freshly rolled files appear.
+    private List<File> cycleFiles() {
+        Jvm.pause(300);
+        final File[] files = queue.file().listFiles(FileUtil::hasQueueSuffix);
+        assertNotNull(files, "no queue files found in " + queue.file());
+        return Stream.of(files).sorted(EARLIEST_FIRST).collect(toList());
+    }
+
+    // Removable candidates, earliest first; the pause lets rolled-off files be released first.
+    private List<File> removableCandidates() {
+        Jvm.pause(300);
+        final List<File> candidates = FileUtil.removableRollFileCandidates(queue.file()).collect(toList());
+        assertEquals(candidates.stream().sorted(EARLIEST_FIRST).collect(toList()), candidates);
+        return candidates;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
@@ -24,7 +24,7 @@ import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
  */
 public class IndexingTestCommon extends QueueTestCommon {
 
-   protected SetTimeProvider timeProvider;
+    protected SetTimeProvider timeProvider;
     SingleChronicleQueue queue;
     StoreAppender appender;
     private List<Closeable> closeables;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
@@ -24,7 +24,7 @@ import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
  */
 public class IndexingTestCommon extends QueueTestCommon {
 
-    SetTimeProvider timeProvider;
+   protected SetTimeProvider timeProvider;
     SingleChronicleQueue queue;
     StoreAppender appender;
     private List<Closeable> closeables;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
@@ -98,6 +98,34 @@ public class NormaliseEOFsTest extends QueueTestCommon {
         }
     }
 
+    // A freshly constructed appender parks on the current cycle during its EOF back-scan and then
+    // releases that store, leaving its cycle field unset. normaliseEOFs() must still finalise the older
+    // cycles rather than silently no-op - the watermark it advances is "normalisedEOFsTo" in the table store.
+    @Test
+    public void freshlyConstructedAppenderNormalisesWithoutWriting() {
+        SetTimeProvider setTimeProvider = new SetTimeProvider();
+        try (final SingleChronicleQueue queue = createQueue(setTimeProvider);
+             final ExcerptAppender writer = queue.createAppender()) {
+            writer.writeText("cycle-0");
+            setTimeProvider.advanceMillis(1_001);
+            writer.writeText("cycle-1");
+            setTimeProvider.advanceMillis(1_001);
+            writer.writeText("cycle-2");
+
+            final int firstCycle = queue.firstCycle();
+            try (final ExcerptAppender fresh = queue.createAppender()) {
+                final long normalisedBefore = queue.tableStoreAcquire("normalisedEOFsTo", firstCycle).getVolatileValue();
+
+                fresh.normaliseEOFs();
+
+                final long normalisedAfter = queue.tableStoreAcquire("normalisedEOFsTo", firstCycle).getVolatileValue();
+                assertTrue(normalisedAfter > normalisedBefore,
+                        "normaliseEOFs on a never-written appender should have advanced the watermark past "
+                                + normalisedBefore + " but it stayed at " + normalisedAfter);
+            }
+        }
+    }
+
     private void createNewRollCycles(ExcerptAppender appender, SetTimeProvider timeProvider) {
         for (int i = 0; i < 10; i++) {
             timeProvider.advanceMillis(3_000);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
@@ -152,7 +152,13 @@ public class NotCompleteTest extends QueueTestCommon {
 
     // the last line of the dump changes - haven't spent the time to get to the bottom of this
     private String cleanQueueDump(String from) {
-        return from.replaceAll("# [0-9]+ bytes remaining$", "").replaceAll("modCount: (\\d+)", "modCount: 00");
+        return from.replaceAll("# [0-9]+ bytes remaining", "# NN bytes remaining")
+                .replaceAll("modCount: (\\d+)", "modCount: 00")
+                // With queue.appender.releaseParkedStoreOnConstruction (QUEUE-130) a fresh appender's
+                // first write re-runs EOF normalisation, which records the normalisedEOFsTo watermark
+                // (and shifts store free-space counts). That is EOF bookkeeping (covered by the dedicated
+                // EOF tests), not the interrupted-write data this test guards, so strip it before comparing.
+                .replaceAll("# position: \\d+, header: \\d+\\R--- !!data #binary\\RnormalisedEOFsTo: \\d+\\R", "");
     }
 
     private void doWrite(ChronicleQueue queue, BiConsumer<PersonListener, ChronicleQueue> action) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
@@ -154,10 +154,7 @@ public class NotCompleteTest extends QueueTestCommon {
     private String cleanQueueDump(String from) {
         return from.replaceAll("# [0-9]+ bytes remaining", "# NN bytes remaining")
                 .replaceAll("modCount: (\\d+)", "modCount: 00")
-                // With queue.appender.releaseParkedStoreOnConstruction (QUEUE-130) a fresh appender's
-                // first write re-runs EOF normalisation, which records the normalisedEOFsTo watermark
-                // (and shifts store free-space counts). That is EOF bookkeeping (covered by the dedicated
-                // EOF tests), not the interrupted-write data this test guards, so strip it before comparing.
+                // strip the normalisedEOFsTo record written by first-write EOF normalisation
                 .replaceAll("# position: \\d+, header: \\d+\\R--- !!data #binary\\RnormalisedEOFsTo: \\d+\\R", "");
     }
 


### PR DESCRIPTION
## QUEUE-130: Release parked store after StoreAppender construction

### Issue

When a `StoreAppender` is constructed, it runs an EOF back-scan that walks cycles from the last existing cycle down to the first, and parks the appender on a store (the newest EOF-ed cycle, or the first cycle). This parked store — its mapped-file reservation, wires, and open file descriptor — was held open even though the appender had not written anything yet.

An appender created against a queue that already has older roll cycles therefore pinned an old `.cq4` file open. Because `FileUtil.removableRollFileCandidates(...)` scans oldest-first and stops at the first still-open file, a single pinned old file blocked removal of that file and every file after it. A parked appender that never wrote could thus prevent old roll files from being cleaned up.

### Fix

`StoreAppender` now calls a new `releaseParkedStore()` at the end of the back-scan. This drops the store, its wires, and the FD, returning the appender to the same "never written" state as one created against an empty queue. The next write re-acquires the current cycle as normal. Nothing on disk is changed — only the in-memory reservation and open descriptor are released.

A `scannedCycle` local was added so the "took Nms to find first open cycle" perf log still reports the cycle the scan landed on, since `cycle` is now reset by the release.

### New test

`AppenderReleasesParkedStoreTest` (extends `IndexingTestCommon`) proves the behaviour at the symptom level via `FileUtil.removableRollFileCandidates(...)`:

- `writerAloneLeavesEveryEarlierCycleRemovable` — control: with only the writer active, all earlier cycles are removable.
- `parkedAppenderDoesNotPinAnOldCycle` — a fresh appender parks at construction and never writes; after the writer rolls past it, every earlier cycle must still be removable.

`removableRollFileCandidates` inspects open descriptors via `/proc/self/fd`, so both tests are gated on `getAllOpenFilesIsSupportedOnOS()` and skip on platforms where that is unsupported (macOS/Windows). Commenting out the `releaseParkedStore()` call turns `parkedAppenderDoesNotPinAnOldCycle` red while the control stays green.

### Why existing tests needed changing

`CreateAtIndexTest` and `NotCompleteTest` compare queue dumps before/after an append. With the fix, the appender's first write now performs EOF normalisation, which writes a benign `normalisedEOFsTo` metadata record and shifts byte/`modCount` counters. These are expected, harmless deltas, not behavioural changes, so the dump-comparison helpers were extended to normalise them out:

- Strip the `normalisedEOFsTo` metadata record.
- Mask `modCount` values.
- Mask `# N bytes remaining` counts.

`IndexingTestCommon.timeProvider` was made `protected` so the new test in the same package hierarchy can advance time to force rolls.


### Observable behaviour changes

- `ExcerptAppender.currentFile()` on a freshly created appender now returns `null` until the first write (previously it returned the file the back-scan parked on).
- The store acquire/mmap cost moves from construction to the appender's first write; `pretouch()` can be used to keep it off the first live message.
- The first write on a non-empty queue now creates the `normalisedEOFsTo` tablestore record where previously it did not; `CreateAtIndexTest` asserts this delta explicitly rather than only masking it.
