### PR TITLE
SUPERSEDED: QUEUE-144 appender EOF prerequisite

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -48,6 +48,7 @@ class StoreAppender extends AbstractCloseable
      * This is the key in the table-store where we store that information
      */
     private static final String NORMALISED_EOFS_TO_TABLESTORE_KEY = "normalisedEOFsTo";
+
     @NotNull
     private final SingleChronicleQueue queue;
     @NotNull
@@ -99,6 +100,7 @@ class StoreAppender extends AbstractCloseable
             int lastExistingCycle = queue.lastCycle();
             int firstCycle = queue.firstCycle();
             long start = System.nanoTime();
+            int scannedCycle = Integer.MIN_VALUE;
             final WriteLock writeLock = this.queue.writeLock();
             writeLock.lock();
             try {
@@ -120,12 +122,16 @@ class StoreAppender extends AbstractCloseable
                     }
                     if (wire != null)
                         resetPosition();
+                    scannedCycle = cycle;
+
+                    // Don't hold the back-scan's store open; the first write re-acquires it
+                    releaseParkedStore();
                 }
             } finally {
                 writeLock.unlock();
                 long tookMillis = (System.nanoTime() - start) / 1_000_000;
-                if (tookMillis > WARN_SLOW_APPENDER_MS || (lastExistingCycle >= 0 && cycle != lastExistingCycle))
-                    Jvm.perf().on(getClass(), "Took " + tookMillis + "ms to find first open cycle " + cycle);
+                if (tookMillis > WARN_SLOW_APPENDER_MS || (lastExistingCycle >= 0 && scannedCycle != lastExistingCycle))
+                    Jvm.perf().on(getClass(), "Took " + tookMillis + "ms to find first open cycle " + scannedCycle);
             }
         } catch (RuntimeException ex) {
             // Perhaps initialization code needs to be moved away from constructor
@@ -400,6 +406,26 @@ class StoreAppender extends AbstractCloseable
     }
 
     /**
+     * Releases the store (and its wires) that the construction-time EOF back-scan left this appender
+     * parked on, returning the appender to the same "never written" state as one created on an empty
+     * queue. The next write re-acquires the current cycle. Only the mapped-file reservation and open
+     * FD are dropped; nothing on disk changes.
+     */
+    private void releaseParkedStore() {
+        if (store == null)
+            return;
+
+        releaseBytesFor(wireForIndex);
+        releaseBytesFor(wire);
+        wireForIndex = null;
+        wire = null;
+
+        storePool.closeStore(store);
+        store = null;
+        cycle = Integer.MIN_VALUE;
+    }
+
+    /**
      * Resets the wires (primary and indexing) for this appender based on the store.
      * Releases any existing wire resources before creating new ones.
      *
@@ -603,7 +629,9 @@ class StoreAppender extends AbstractCloseable
         final WriteLock writeLock = queue.writeLock();
         writeLock.lock();
         try {
-            normaliseEOFs0(cycle);
+            // use the getter, not the raw field: after the construction-time back-scan releases its
+            // parked store the field is Integer.MIN_VALUE, and the getter resolves that to lastCycle
+            normaliseEOFs0(cycle());
         } finally {
             writeLock.unlock();
             long tookMillis = (System.nanoTime() - start) / 1_000_000;

--- a/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
@@ -18,7 +18,9 @@ import java.io.File;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.single;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 @RequiredForClient
 public class CreateAtIndexTest extends QueueTestCommon {
@@ -43,7 +45,11 @@ public class CreateAtIndexTest extends QueueTestCommon {
             String before = queue.dump();
             appender.writeBytes(0x421d00000000L, HELLO_WORLD);
             String after = queue.dump();
-            assertEquals(before, after);
+            // the appender's first write normalises EOFs, adding a normalisedEOFsTo record;
+            // assert that delta explicitly, then require the dumps to match once it is masked out
+            assertFalse(before.contains("normalisedEOFsTo"));
+            assertTrue(after.contains("normalisedEOFsTo"));
+            assertEquals(cleanDump(before), cleanDump(after));
         }
 
 /*
@@ -90,6 +96,13 @@ public class CreateAtIndexTest extends QueueTestCommon {
             IOTools.deleteDirWithFiles(tmp, 2);
         } catch (IORuntimeException ignored) {
         }
+    }
+
+    private static String cleanDump(String dump) {
+        return dump
+                .replaceAll("# \\d+ bytes remaining", "# NN bytes remaining")
+                .replaceAll("modCount: (\\d+)", "modCount: 00")
+                .replaceAll("# position: \\d+, header: \\d+\\R--- !!data #binary\\RnormalisedEOFsTo: \\d+\\R", "");
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderReleasesParkedStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderReleasesParkedStoreTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
+import net.openhft.chronicle.queue.util.FileUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static net.openhft.chronicle.queue.internal.util.InternalFileUtil.getAllOpenFilesIsSupportedOnOS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Verifies through {@link FileUtil#removableRollFileCandidates} that an appender does not keep an old
+ * roll-cycle file open once it has rolled into the past. Removal stops at the first still-open file
+ * (oldest first), so a pinned old file blocks everything after it.
+ * <p>
+ * These tests inspect open descriptors via {@code /proc/self/fd} and are skipped where unsupported.
+ */
+class AppenderReleasesParkedStoreTest extends IndexingTestCommon {
+
+    private static final Comparator<File> EARLIEST_FIRST = Comparator.comparing(File::getName);
+
+    // Control: with only the writer active, the current cycle stays open and earlier cycles are removable.
+    @Test
+    void writerAloneLeavesEveryEarlierCycleRemovable() {
+        assumeTrue(getAllOpenFilesIsSupportedOnOS());
+
+        appender.writeText("cycle-0");
+        timeProvider.advanceMillis(1_001);
+        appender.writeText("cycle-1");
+        timeProvider.advanceMillis(1_001);
+        appender.writeText("cycle-2");
+
+        final List<File> created = cycleFiles();
+        assertEquals(3, created.size(), "expected three roll-cycle files, got " + created);
+        assertEquals(created.subList(0, 2), removableCandidates());
+    }
+
+    // A fresh appender parks on the current cycle at construction and never writes; after the writer rolls
+    // past it, it must not keep the now-old file open.
+    @Test
+    void parkedAppenderDoesNotPinAnOldCycle() {
+        assumeTrue(getAllOpenFilesIsSupportedOnOS());
+
+        appender.writeText("cycle-0");
+        timeProvider.advanceMillis(1_001);
+        appender.writeText("cycle-1");
+
+        final StoreAppender parked = (StoreAppender) queue.createAppender();
+        try {
+            timeProvider.advanceMillis(1_001);
+            appender.writeText("cycle-2");
+
+            final List<File> created = cycleFiles();
+            assertEquals(3, created.size(), "expected three roll-cycle files, got " + created);
+            assertEquals(created.subList(0, 2), removableCandidates());
+        } finally {
+            parked.close();
+        }
+    }
+
+    // All roll-cycle files, earliest first.
+    private List<File> cycleFiles() {
+        final File[] files = queue.file().listFiles(FileUtil::hasQueueSuffix);
+        assertNotNull(files, "no queue files found in " + queue.file());
+        return Stream.of(files).sorted(EARLIEST_FIRST).collect(toList());
+    }
+
+    // Removable candidates, earliest first. The parked store's file descriptor is dropped on a
+    // background thread, so drain the releaser before inspecting open descriptors.
+    private List<File> removableCandidates() {
+        BackgroundResourceReleaser.releasePendingResources();
+        final List<File> candidates = FileUtil.removableRollFileCandidates(queue.file()).collect(toList());
+        assertEquals(candidates.stream().sorted(EARLIEST_FIRST).collect(toList()), candidates);
+        return candidates;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/IndexingTestCommon.java
@@ -24,7 +24,7 @@ import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
  */
 public class IndexingTestCommon extends QueueTestCommon {
 
-    SetTimeProvider timeProvider;
+    protected SetTimeProvider timeProvider;
     SingleChronicleQueue queue;
     StoreAppender appender;
     private List<Closeable> closeables;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
@@ -98,6 +98,34 @@ public class NormaliseEOFsTest extends QueueTestCommon {
         }
     }
 
+    // A freshly constructed appender parks on the current cycle during its EOF back-scan and then
+    // releases that store, leaving its cycle field unset. normaliseEOFs() must still finalise the older
+    // cycles rather than silently no-op - the watermark it advances is "normalisedEOFsTo" in the table store.
+    @Test
+    public void freshlyConstructedAppenderNormalisesWithoutWriting() {
+        SetTimeProvider setTimeProvider = new SetTimeProvider();
+        try (final SingleChronicleQueue queue = createQueue(setTimeProvider);
+             final ExcerptAppender writer = queue.createAppender()) {
+            writer.writeText("cycle-0");
+            setTimeProvider.advanceMillis(1_001);
+            writer.writeText("cycle-1");
+            setTimeProvider.advanceMillis(1_001);
+            writer.writeText("cycle-2");
+
+            final int firstCycle = queue.firstCycle();
+            try (final ExcerptAppender fresh = queue.createAppender()) {
+                final long normalisedBefore = queue.tableStoreAcquire("normalisedEOFsTo", firstCycle).getVolatileValue();
+
+                fresh.normaliseEOFs();
+
+                final long normalisedAfter = queue.tableStoreAcquire("normalisedEOFsTo", firstCycle).getVolatileValue();
+                assertTrue(normalisedAfter > normalisedBefore,
+                        "normaliseEOFs on a never-written appender should have advanced the watermark past "
+                                + normalisedBefore + " but it stayed at " + normalisedAfter);
+            }
+        }
+    }
+
     private void createNewRollCycles(ExcerptAppender appender, SetTimeProvider timeProvider) {
         for (int i = 0; i < 10; i++) {
             timeProvider.advanceMillis(3_000);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NotCompleteTest.java
@@ -152,7 +152,10 @@ public class NotCompleteTest extends QueueTestCommon {
 
     // the last line of the dump changes - haven't spent the time to get to the bottom of this
     private String cleanQueueDump(String from) {
-        return from.replaceAll("# [0-9]+ bytes remaining$", "").replaceAll("modCount: (\\d+)", "modCount: 00");
+        return from.replaceAll("# [0-9]+ bytes remaining", "# NN bytes remaining")
+                .replaceAll("modCount: (\\d+)", "modCount: 00")
+                // strip the normalisedEOFsTo record written by first-write EOF normalisation
+                .replaceAll("# position: \\d+, header: \\d+\\R--- !!data #binary\\RnormalisedEOFsTo: \\d+\\R", "");
     }
 
     private void doWrite(ChronicleQueue queue, BiConsumer<PersonListener, ChronicleQueue> action) {


### PR DESCRIPTION
> [!IMPORTANT]
> **Superseded: do not merge this PR.**
>
> The underlying fix was merged into `develop` by [#1714](https://github.com/OpenHFT/Chronicle-Queue/pull/1714). This PR only reapplied it to the earlier QUEUE-143 branch. On the corrected minimal QUEUE-143 base the change cherry-picks as empty. Continue with [#1724](https://github.com/OpenHFT/Chronicle-Queue/pull/1724), then the recreated QUEUE-144 stack starting at [#1725](https://github.com/OpenHFT/Chronicle-Queue/pull/1725).

## Purpose of the underlying fix

Constructing a `StoreAppender` performs an EOF back-scan over existing roll cycles. Before this fix, that scan left the appender holding the selected store, wires, mapped-file reservation and file descriptor even when the appender never wrote.

If another appender subsequently rolled forward, the unused appender could keep an old `.cq4` file open. `FileUtil.removableRollFileCandidates(...)` scans oldest-first and stops at the first open file, so the parked file also prevented all later files from being considered removable.

`releaseParkedStore()` releases those resources after the scan and returns the appender to a never-written state. Its first write reacquires the current cycle. The related `normaliseEOFs0(cycle())` change is required because the raw `cycle` field is reset when the parked store is released.

## Regression evidence

The tests do demonstrate the failure, rather than only execute the changed code:

- `AppenderReleasesParkedStoreTest.parkedAppenderDoesNotPinAnOldCycle` fails if only the `releaseParkedStore()` call is removed. It expects cycles 0 and 1 to be removable but receives only cycle 0, showing that cycle 1 remains pinned.
- `NormaliseEOFsTest.freshlyConstructedAppenderNormalisesWithoutWriting` fails if `normaliseEOFs0(cycle())` is changed back to the raw `cycle` field. The `normalisedEOFsTo` watermark remains at 0.
- `CreateAtIndexTest` and `NotCompleteTest` account for the expected `normalisedEOFsTo` metadata written on the first append after reacquisition; they are compatibility adjustments, not the primary regression proof.

All four touched test classes pass at this PR head.

## Remaining test limitation

The file-pinning regression test relies on `/proc/self/fd` and is skipped on unsupported operating systems. If this behaviour is changed again, add a portable lifecycle assertion that a fresh appender on a non-empty queue has `currentFile() == null` until its first write, then has the current roll file afterward. Also assert exactly one `normalisedEOFsTo` record rather than allowing dump cleanup to remove duplicates.
