### PR TITLE
SUPERSEDED: QUEUE-144 Queue context listener core

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
@@ -7,6 +7,7 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.core.annotation.SingleThreaded;
 import net.openhft.chronicle.wire.MarshallableOut;
+import net.openhft.chronicle.wire.MessageHistory;
 import net.openhft.chronicle.wire.UnrecoverableTimeoutException;
 import net.openhft.chronicle.wire.VanillaMethodWriterBuilder;
 import net.openhft.chronicle.wire.Wire;
@@ -74,6 +75,84 @@ public interface ExcerptAppender extends ExcerptCommon<ExcerptAppender>, Marshal
      * NOTE: This pretoucher is assumed to be called periodically at longer regular intervals such a 100 ms or 1 second.
      */
     default void pretouch() {
+    }
+
+    /**
+     * Sets a listener to be called before this appender writes to a newly-created output context.
+     * For Queue, the output context is a newly-created roll file.
+     * <p>
+     * The listener receives a preset method writer for {@code writerType}. Calls made on that
+     * writer are appended before the write that triggered creation of that context. The listener
+     * must write only through that supplied writer and must not re-enter the appender (for example
+     * by opening its own writing document) during the callback. The supplied writer is scoped to the
+     * callback; retaining it or using it after the callback returns is unsupported.
+     * <p>
+     * The listener fires only before the first ordinary data append into a new, empty roll file,
+     * including first use of an empty queue; it is not limited to later clock-driven rolls.
+     * It is not fired for metadata writes, for an append-locked (replication sink) queue, or for explicit
+     * index writes ({@code writeBytes(index, ...)}) - injecting records there would bypass the
+     * append lock or shift the caller's index.
+     * <p>
+     * With double buffering enabled, the callback may run when the buffered write is flushed; the
+     * context records still precede the buffered data in the queue. A caller that uses
+     * {@link net.openhft.chronicle.wire.DocumentContext#contextCount()} for progressive
+     * context resends must not use double buffering; the final target cycle is selected when
+     * the buffer is flushed, so buffered contexts reject context-count access.
+     * <p>
+     * The callback runs while the queue write lock is held. It must be allocation-light, must not
+     * block, and must not perform slow I/O. Each configured appender constructs its method-writer
+     * proxy before its first write and reuses that proxy for later roll callbacks.
+     * <p>
+     * The supplied writer emits normal method-writer documents. Do not enable this listener on a
+     * queue whose readers require one fixed raw payload format unless those readers explicitly
+     * tolerate the context records.
+     * <p>
+     * A context record is advisory, not guaranteed session state: it is not written when appending
+     * to an existing non-empty roll file, for example after restart or failover into the middle of a
+     * roll.
+     * <p>
+     * Context records are synthetic and do not record {@link MessageHistory} by default. A listener
+     * may write history explicitly if that context has a real causal history, but normal usage
+     * assumes no history is written.
+     * <p>
+     * Context that must exist before the first appender write is application state and must be
+     * written by the application as it is built; this listener is not a construction-time callback.
+     * On first use, and on later new-roll callbacks, the listener can dump the current state and
+     * resend any previously written context that new readers may rely on. If there is no context to
+     * write for that callback, it may return without writing anything; Queue treats the context as
+     * handled and does not write a placeholder record.
+     * <p>
+     * A low-latency resend can clear any local "already sent" assumptions first, then write the
+     * missing context while one {@link net.openhft.chronicle.wire.DocumentContext} is held if the
+     * supplied writer also exposes {@link net.openhft.chronicle.wire.DocumentWritten}. This is the
+     * same method-writer pattern as creating a writer with
+     * {@code methodWriter(EventType.class, DocumentWritten.class)} and making several writer calls
+     * before closing the document.
+     * <p>
+     * This method must be called before the appender's first write attempt. If the listener also implements
+     * {@link java.lang.AutoCloseable}, it is closed when this appender is closed, unless the same
+     * instance is configured on the queue builder (then the queue owns it) or is shared with another
+     * appender on the same queue (then it is closed once, by the last appender to release it).
+     * Ownership coordination is queue-local, so a closeable listener instance must not be shared
+     * between appenders belonging to different queues.
+     * <p>
+     * If different listeners are configured on appenders of the same queue, the first appender to
+     * write into an empty roll cycle supplies that cycle's context; the other listeners are not
+     * called for that cycle.
+     *
+     * @param writerType event interface type for the supplied method writer
+     * @param listener   listener to call for new output contexts
+     * @param <T>        event interface type
+     * @return this appender
+     * @throws IllegalStateException         if called after this appender has written
+     * @throws UnsupportedOperationException from the default implementation - only appenders that
+     *                                       support context listeners override this method
+     */
+    @NotNull
+    @Override
+    default <T> ExcerptAppender contextListener(@NotNull Class<T> writerType,
+                                                @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerBinding.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerBinding.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.wire.MarshallableOut;
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Resolved, non-null pairing of a context-listener method-writer type and callback.
+ *
+ * <p>The builder keeps the possibly supplier-backed {@link ContextListenerConfiguration}; a queue
+ * resolves that description once into this value. The same value can then be shared with every
+ * appender that inherits the queue listener. Appender-local configuration creates its own value.
+ * Keeping the pair together prevents partially configured lifecycle state and confines the raw
+ * callback invocation to one place.</p>
+ */
+final class ContextListenerBinding {
+    private final Class<?> writerType;
+    private final MarshallableOut.ContextListener<?> listener;
+
+    private ContextListenerBinding(@NotNull Class<?> writerType,
+                                   @NotNull MarshallableOut.ContextListener<?> listener) {
+        this.writerType = requireNonNull(writerType);
+        this.listener = requireNonNull(listener);
+    }
+
+    @NotNull
+    static ContextListenerBinding of(@NotNull Class<?> writerType,
+                                     @NotNull MarshallableOut.ContextListener<?> listener) {
+        return new ContextListenerBinding(writerType, listener);
+    }
+
+    @NotNull
+    MarshallableOut.ContextListener<?> listener() {
+        return listener;
+    }
+
+    @NotNull
+    Object newMethodWriter(@NotNull LockedContextListenerMarshallableOut out) {
+        return out.methodWriter(writerType);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void notifyListener(@NotNull Object methodWriter) {
+        ((MarshallableOut.ContextListener) listener).onNewContext(methodWriter);
+    }
+}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerConfiguration.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.wire.MarshallableOut;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Immutable builder-side description of the advanced context-listener feature.
+ *
+ * <p>{@link SingleChronicleQueueBuilder} keeps this as its only context-listener field. A direct
+ * listener is reused by every queue built from that builder; a supplier creates a separately owned
+ * listener for each queue. Listener-free builders share {@link #NONE}, so the builder field remains
+ * non-null without allocating configuration state per builder.</p>
+ */
+final class ContextListenerConfiguration {
+    static final ContextListenerConfiguration NONE =
+            new ContextListenerConfiguration(null, null, null);
+
+    @Nullable
+    private final Class<?> writerType;
+    @Nullable
+    private final MarshallableOut.ContextListener<?> listener;
+    @Nullable
+    private final Supplier<? extends MarshallableOut.ContextListener<?>> listenerSupplier;
+
+    private ContextListenerConfiguration(@Nullable Class<?> writerType,
+                                         @Nullable MarshallableOut.ContextListener<?> listener,
+                                         @Nullable Supplier<? extends MarshallableOut.ContextListener<?>> listenerSupplier) {
+        this.writerType = writerType;
+        this.listener = listener;
+        this.listenerSupplier = listenerSupplier;
+    }
+
+    static <T> ContextListenerConfiguration of(Class<T> writerType,
+                                               MarshallableOut.ContextListener<? super T> listener) {
+        return new ContextListenerConfiguration(requireNonNull(writerType), requireNonNull(listener), null);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    static <T> ContextListenerConfiguration supplied(Class<T> writerType,
+                                                     Supplier<? extends MarshallableOut.ContextListener<? super T>> listenerSupplier) {
+        return new ContextListenerConfiguration(
+                requireNonNull(writerType), null, (Supplier) requireNonNull(listenerSupplier));
+    }
+
+    boolean configured() {
+        return writerType != null;
+    }
+
+    @Nullable
+    MarshallableOut.ContextListener<?> listener() {
+        return listener;
+    }
+
+    @NotNull
+    ContextListenerBinding resolve() {
+        MarshallableOut.ContextListener<?> resolvedListener = newListener();
+        return ContextListenerBinding.of(requireNonNull(writerType), resolvedListener);
+    }
+
+    @NotNull
+    private MarshallableOut.ContextListener<?> newListener() {
+        if (!configured())
+            throw new IllegalStateException("No context listener is configured");
+        return listenerSupplier == null
+                ? requireNonNull(listener)
+                : requireNonNull(listenerSupplier.get(), "contextListenerSupplier.get()");
+    }
+}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoordinator.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoordinator.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.queue.impl.ExcerptContext;
+import net.openhft.chronicle.wire.MarshallableOut;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.StreamCorruptedException;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * Queue-scoped coordination and ownership for the advanced context-listener feature.
+ *
+ * <p>This is deliberately a coordinator rather than another lifecycle interface. It provides the
+ * state that must be shared by all appenders: the resolved queue-default listener, at-most-once
+ * notification per roll cycle, and queue-local ownership of appender listeners. The actual write
+ * entry points live in {@link ContextListenerLifecycle}.</p>
+ *
+ * <p>Listener-free queues share {@link #NONE}. An active coordinator is allocated only when a
+ * builder listener exists or an appender-local listener is configured.</p>
+ */
+final class ContextListenerCoordinator implements AutoCloseable {
+    static final ContextListenerCoordinator NONE = new ContextListenerCoordinator(null);
+
+    @Nullable
+    private final ContextListenerBinding defaultBinding;
+    private volatile long lastCycleChecked = Long.MIN_VALUE;
+    @Nullable
+    private Map<MarshallableOut.ContextListener<?>, int[]> appenderListenerRefs;
+
+    private ContextListenerCoordinator(@Nullable ContextListenerBinding defaultBinding) {
+        this.defaultBinding = defaultBinding;
+    }
+
+    @NotNull
+    static ContextListenerCoordinator from(@NotNull ContextListenerConfiguration configuration) {
+        return configuration.configured()
+                ? new ContextListenerCoordinator(configuration.resolve())
+                : NONE;
+    }
+
+    @NotNull
+    static ContextListenerCoordinator activeWithoutQueueListener() {
+        return new ContextListenerCoordinator(null);
+    }
+
+    @Nullable
+    ContextListenerBinding defaultBinding() {
+        return defaultBinding;
+    }
+
+    /**
+     * Checks, under the queue write lock, whether the target cycle is still empty.
+     *
+     * @return {@code true} when the caller may write that cycle's context records
+     */
+    boolean shouldNotify(int cycle,
+                         @NotNull SingleChronicleQueueStore store,
+                         @NotNull ExcerptContext context) {
+        if (this == NONE || lastCycleChecked >= cycle)
+            return false;
+        try {
+            if (store.lastSequenceNumber(context) >= 0) {
+                lastCycleChecked = cycle;
+                return false;
+            }
+            return true;
+        } catch (StreamCorruptedException e) {
+            Jvm.warn().on(SingleChronicleQueue.class,
+                    "Could not read last sequence for cycle " + cycle +
+                            "; skipping context listener", e);
+            lastCycleChecked = cycle;
+            return false;
+        }
+    }
+
+    /** Records successful handling of a cycle, including a callback that wrote no documents. */
+    void complete(int cycle) {
+        if (this != NONE)
+            lastCycleChecked = Math.max(lastCycleChecked, cycle);
+    }
+
+    /** Acquires queue-local ownership of an appender listener. */
+    synchronized void retain(@NotNull MarshallableOut.ContextListener<?> listener) {
+        if (this == NONE || isQueueListener(listener))
+            return;
+        if (appenderListenerRefs == null)
+            appenderListenerRefs = new IdentityHashMap<>();
+        appenderListenerRefs.computeIfAbsent(listener, ignored -> new int[1])[0]++;
+    }
+
+    /** Releases and, when appropriate, closes an appender listener. */
+    void release(@NotNull MarshallableOut.ContextListener<?> listener) {
+        if (this == NONE || isQueueListener(listener))
+            return;
+
+        boolean close = false;
+        synchronized (this) {
+            if (appenderListenerRefs == null)
+                return;
+            int[] count = appenderListenerRefs.get(listener);
+            if (count == null)
+                return;
+            if (--count[0] <= 0) {
+                appenderListenerRefs.remove(listener);
+                close = true;
+            }
+        }
+        if (close)
+            Closeable.closeQuietly(listener);
+    }
+
+    private boolean isQueueListener(@NotNull MarshallableOut.ContextListener<?> listener) {
+        return defaultBinding != null && listener == defaultBinding.listener();
+    }
+
+    @Override
+    public void close() {
+        if (defaultBinding != null)
+            Closeable.closeQuietly(defaultBinding.listener());
+    }
+}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerLifecycle.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerLifecycle.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.wire.MarshallableOut;
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Per-appender entry points and state for the advanced context-listener feature.
+ *
+ * <p>{@link StoreAppender} stores exactly one reference of this type. Before an unconfigured
+ * appender writes, that field is {@code null}, preserving the opportunity to configure an
+ * appender-local listener. Its first write changes the field to {@link #NO_OP}; configured
+ * appenders instead hold an {@link ActiveContextListenerLifecycle}. The hot write paths compare
+ * against {@code NO_OP} before invoking these methods, so listener-free users do not make an
+ * interface call.</p>
+ *
+ * <p>Queue-wide cycle coordination and listener ownership are provided by the concrete
+ * {@link ContextListenerCoordinator}; they are intentionally not mixed into this write-facing
+ * interface.</p>
+ */
+interface ContextListenerLifecycle extends AutoCloseable {
+    /** Shared state for an appender that has started without a listener. */
+    ContextListenerLifecycle NO_OP = NoOpContextListenerLifecycle.INSTANCE;
+
+    /** @return whether this appender has made its first write attempt */
+    boolean started();
+
+    /** Marks a write attempt and rejects callback re-entry through the public appender. */
+    void onWriteAttempt();
+
+    /**
+     * Runs the callback, when required, before a regular document.
+     *
+     * @return {@code true} when listener output changed the appender position
+     */
+    boolean beforeDocument(boolean metaData, long safeLength);
+
+    /**
+     * Runs the callback, when required, before a raw document.
+     *
+     * @return {@code true} when listener output changed the appender position
+     */
+    boolean beforeRawDocument(long safeLength);
+
+    /** Replaces the appender-local listener before the first write attempt. */
+    ContextListenerLifecycle configure(Class<?> writerType,
+                                       MarshallableOut.ContextListener<?> listener);
+
+    @Override
+    void close();
+
+    @NotNull
+    static ContextListenerLifecycle active(@NotNull StoreAppender appender,
+                                           @NotNull StoreAppender.StoreAppenderContext context,
+                                           @NotNull ContextListenerCoordinator coordinator,
+                                           @NotNull ContextListenerBinding binding) {
+        return new ActiveContextListenerLifecycle(appender, context, coordinator, binding);
+    }
+}
+
+/** Shared, allocation-free lifecycle used after the first listener-free write attempt. */
+enum NoOpContextListenerLifecycle implements ContextListenerLifecycle {
+    INSTANCE;
+
+    @Override
+    public boolean started() {
+        return true;
+    }
+
+    @Override
+    public void onWriteAttempt() {
+    }
+
+    @Override
+    public boolean beforeDocument(boolean metaData, long safeLength) {
+        return false;
+    }
+
+    @Override
+    public boolean beforeRawDocument(long safeLength) {
+        return false;
+    }
+
+    @Override
+    public ContextListenerLifecycle configure(Class<?> writerType,
+                                              MarshallableOut.ContextListener<?> listener) {
+        throw new IllegalStateException(
+                "Cannot change contextListener after this appender has written");
+    }
+
+    @Override
+    public void close() {
+    }
+}
+
+/**
+ * Active lifecycle allocated only for a configured appender.
+ *
+ * <p>It prevents re-entry and creates one method writer when the appender is configured. The
+ * appender-bound output enables that writer only for the callback thread while the write lock is
+ * held, avoiding proxy construction on every roll. The shared coordinator owns cycle-wide and
+ * listener-reference state.</p>
+ */
+final class ActiveContextListenerLifecycle implements ContextListenerLifecycle {
+    private final StoreAppender appender;
+    private final ContextListenerCoordinator coordinator;
+    private final LockedContextListenerMarshallableOut out;
+    private ContextListenerBinding binding;
+    private Object methodWriter;
+    private boolean started;
+    private boolean notifying;
+
+    ActiveContextListenerLifecycle(@NotNull StoreAppender appender,
+                                   @NotNull StoreAppender.StoreAppenderContext context,
+                                   @NotNull ContextListenerCoordinator coordinator,
+                                   @NotNull ContextListenerBinding binding) {
+        this.appender = requireNonNull(appender);
+        this.coordinator = requireNonNull(coordinator);
+        this.binding = requireNonNull(binding);
+        this.out = new LockedContextListenerMarshallableOut(
+                appender, requireNonNull(context), appender.queue().wireType());
+        this.methodWriter = binding.newMethodWriter(out);
+        coordinator.retain(binding.listener());
+    }
+
+    @Override
+    public boolean started() {
+        return started;
+    }
+
+    @Override
+    public void onWriteAttempt() {
+        if (notifying)
+            throw new IllegalStateException("Cannot write to the appender from " +
+                    "within a ContextListener; write through the supplied method writer instead");
+        started = true;
+    }
+
+    @Override
+    public boolean beforeDocument(boolean metaData, long safeLength) {
+        if (metaData || !appender.contextListenerWriteReady())
+            return false;
+        return notifyIfNeeded(safeLength);
+    }
+
+    @Override
+    public boolean beforeRawDocument(long safeLength) {
+        appender.resetPositionForContextListener();
+        return notifyIfNeeded(safeLength);
+    }
+
+    private boolean notifyIfNeeded(long safeLength) {
+        if (!coordinator.shouldNotify(appender.cycle(), appender.store, appender))
+            return false;
+
+        notifying = true;
+        try {
+            notifyListener(safeLength);
+            coordinator.complete(appender.cycle());
+            return true;
+        } finally {
+            notifying = false;
+        }
+    }
+
+    private void notifyListener(long safeLength) {
+        out.beginCallback(safeLength);
+        try {
+            binding.notifyListener(methodWriter);
+        } finally {
+            out.endCallback();
+        }
+    }
+
+    @Override
+    public ContextListenerLifecycle configure(@NotNull Class<?> writerType,
+                                              @NotNull MarshallableOut.ContextListener<?> listener) {
+        if (started)
+            throw new IllegalStateException(
+                    "Cannot change contextListener after this appender has written");
+
+        ContextListenerBinding replacement = ContextListenerBinding.of(
+                requireNonNull(writerType), requireNonNull(listener));
+        Object replacementWriter = replacement.newMethodWriter(out);
+
+        MarshallableOut.ContextListener<?> previous = binding.listener();
+        if (previous != listener) {
+            coordinator.retain(listener);
+            coordinator.release(previous);
+        }
+        binding = replacement;
+        methodWriter = replacementWriter;
+        return this;
+    }
+
+    @Override
+    public void close() {
+        coordinator.release(binding.listener());
+    }
+}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/LockedContextListenerMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/LockedContextListenerMarshallableOut.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.bytes.MethodWriterBuilder;
+import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.wire.BinaryMethodWriterInvocationHandler;
+import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.MarshallableOut;
+import net.openhft.chronicle.wire.VanillaMethodWriterBuilder;
+import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireType;
+import net.openhft.chronicle.wire.WriteDocumentContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A callback-scoped {@link MarshallableOut} that writes through an already-locked
+ * {@link StoreAppender}.
+ *
+ * <p>{@link StoreAppender} invokes a context listener while holding its non-reentrant write lock.
+ * Using the appender's public write methods from that callback would attempt to acquire the same
+ * lock again. This adapter instead opens documents directly on the locked appender and also acts
+ * as their {@link WriteDocumentContext}, committing them without unlocking the appender.</p>
+ *
+ * <p>One adapter and method writer are created per configured appender, outside the write lock.
+ * {@link #beginCallback(long)} activates that writer for the callback thread and
+ * {@link #endCallback()} invalidates it again. A retained writer therefore cannot write between
+ * callbacks or from another thread, while later roll callbacks avoid reconstructing the method
+ * writer. Combining the output and document-context roles avoids allocating a delegating wrapper
+ * for every listener document.</p>
+ *
+ * <p>This bridge remains separate from {@link ActiveContextListenerLifecycle}: the
+ * lifecycle decides <em>when</em> to notify and holds its binding, while this object is the stable
+ * {@code MarshallableOut} captured by the cached method writer and defines <em>how</em> that writer
+ * uses the already-held appender lock. Using the appender itself as the writer target would try to
+ * acquire its non-reentrant lock again.</p>
+ */
+final class LockedContextListenerMarshallableOut implements MarshallableOut, WriteDocumentContext {
+    private final StoreAppender appender;
+    private final StoreAppender.StoreAppenderContext context;
+    private final WireType wireType;
+    private long safeLength;
+    private int nesting;
+    @Nullable
+    private volatile Thread callbackThread;
+
+    /**
+     * Creates the reusable, appender-bound output used to build one method writer.
+     *
+     * @param appender appender whose write lock is held during callbacks
+     * @param context  appender context used for listener documents
+     * @param wireType wire type used to construct the listener's method writer
+     */
+    LockedContextListenerMarshallableOut(StoreAppender appender,
+                                         StoreAppender.StoreAppenderContext context,
+                                         WireType wireType) {
+        this.appender = appender;
+        this.context = context;
+        this.wireType = wireType;
+    }
+
+    @NotNull
+    @Override
+    public DocumentContext writingDocument() {
+        return writingDocument(false);
+    }
+
+    @Override
+    public DocumentContext writingDocument(boolean metaData) {
+        return acquireWritingDocument(metaData);
+    }
+
+    @Override
+    public DocumentContext acquireWritingDocument(boolean metaData) {
+        requireCallbackThread();
+        if (nesting > 0 && context.wire() != null && context.isOpen()) {
+            if (!context.chainedElement()) {
+                assert metaData == context.isMetaData();
+                nesting++;
+            }
+            return this;
+        }
+
+        appender.openContextForContextListener(metaData, safeLength);
+        nesting = 1;
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public <T> MethodWriterBuilder<T> methodWriterBuilder(boolean metaData, @NotNull Class<T> tClass) {
+        VanillaMethodWriterBuilder<T> builder = new VanillaMethodWriterBuilder<>(tClass,
+                wireType,
+                () -> new BinaryMethodWriterInvocationHandler(tClass, metaData,
+                        () -> LockedContextListenerMarshallableOut.this));
+        builder.marshallableOut(this);
+        builder.metaData(metaData);
+        return builder;
+    }
+
+    @Override
+    public void rollbackIfNotComplete() {
+        requireCallbackThread();
+        if (nesting == 0 || !context.isOpen())
+            return;
+        context.chainedElement(false);
+        context.rollbackOnClose();
+        nesting = 1;
+        close();
+    }
+
+    @Override
+    public boolean writingIsComplete() {
+        requireCallbackThread();
+        return context.writingIsComplete();
+    }
+
+    /**
+     * Activates the prebuilt method writer for one callback on the current thread.
+     *
+     * @param safeLength maximum number of bytes that may be written without overlapping a mapping
+     */
+    void beginCallback(long safeLength) {
+        if (callbackThread != null)
+            throw new IllegalStateException("ContextListener method writer is already in a callback");
+        this.safeLength = safeLength;
+        nesting = 0;
+        callbackThread = Thread.currentThread();
+    }
+
+    /**
+     * Ends the callback scope, rolling back an unclosed document before invalidating the writer.
+     */
+    void endCallback() {
+        try {
+            rollbackIfNotComplete();
+        } finally {
+            nesting = 0;
+            callbackThread = null;
+        }
+    }
+
+    @Override
+    public void start(boolean metaData) {
+        context.start(metaData);
+    }
+
+    @Override
+    public boolean chainedElement() {
+        return context.chainedElement();
+    }
+
+    @Override
+    public void chainedElement(boolean chainedElement) {
+        context.chainedElement(chainedElement);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return context.isEmpty();
+    }
+
+    @Override
+    public boolean isMetaData() {
+        return context.isMetaData();
+    }
+
+    @Override
+    public boolean isPresent() {
+        return context.isPresent();
+    }
+
+    @Nullable
+    @Override
+    public Wire wire() {
+        return context.wire();
+    }
+
+    @Override
+    public boolean isNotComplete() {
+        return context.isNotComplete();
+    }
+
+    @Override
+    public void rollbackOnClose() {
+        context.rollbackOnClose();
+    }
+
+    /**
+     * Closes one listener document scope, committing only when its outermost scope closes.
+     * Chained method-writer elements remain open until the terminating method clears the chain.
+     */
+    @Override
+    public void close() {
+        requireCallbackThread();
+        if (nesting == 0)
+            throw new IllegalStateException("No ContextListener document is open");
+        if (context.chainedElement())
+            return;
+        if (nesting > 1) {
+            nesting--;
+            return;
+        }
+        nesting = 0;
+        appender.closeContextForContextListener();
+    }
+
+    @Override
+    public void reset() {
+        context.reset();
+        nesting = 0;
+    }
+
+    @Override
+    public int sourceId() {
+        return context.sourceId();
+    }
+
+    @Override
+    public long index() throws IORuntimeException {
+        return context.index();
+    }
+
+    @Override
+    public long contextCount() {
+        return context.contextCount();
+    }
+
+    private void requireCallbackThread() {
+        if (callbackThread != Thread.currentThread())
+            throw new IllegalStateException(
+                    "ContextListener method writer can only be used by the active callback thread");
+    }
+}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -127,6 +127,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @NotNull
     private final RollCycle rollCycle;
     final AppenderListener appenderListener;
+    @NotNull
+    private volatile ContextListenerCoordinator contextListenerCoordinator = ContextListenerCoordinator.NONE;
     protected int sourceId;
     private int cycleFileRenamed = -1;
     @NotNull
@@ -185,6 +187,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             }
             readOnly = builder.readOnly();
             appenderListener = builder.appenderListener();
+            contextListenerCoordinator = ContextListenerCoordinator.from(builder.contextListenerConfiguration());
 
             if (metaStore.readOnly()) {
                 this.directoryListing = new FileSystemDirectoryListing(path, fileNameToCycleFunction(), time);
@@ -629,6 +632,24 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         return storeFileListener;
     }
 
+    @Nullable
+    ContextListenerLifecycle newContextListenerLifecycle(
+            StoreAppender appender, StoreAppender.StoreAppenderContext context) {
+        ContextListenerCoordinator coordinator = contextListenerCoordinator;
+        if (coordinator == ContextListenerCoordinator.NONE)
+            return null;
+        ContextListenerBinding binding = coordinator.defaultBinding();
+        return binding == null
+                ? null
+                : ContextListenerLifecycle.active(appender, context, coordinator, binding);
+    }
+
+    synchronized ContextListenerCoordinator activeContextListenerCoordinator() {
+        if (contextListenerCoordinator == ContextListenerCoordinator.NONE)
+            contextListenerCoordinator = ContextListenerCoordinator.activeWithoutQueueListener();
+        return contextListenerCoordinator;
+    }
+
     // used by enterprise CQ
     WireStoreSupplier storeSupplier() {
         return storeSupplier;
@@ -980,6 +1001,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             metaStoreMap.clear();
             closers.forEach(Closeable::closeQuietly);
             closers.clear();
+            contextListenerCoordinator.close();
 
             // must be closed after closers.
             closeQuietly(

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -139,6 +139,8 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     private Function<SingleChronicleQueue, Condition> createAppenderConditionCreator;
     private long forceDirectoryListingRefreshIntervalMs = 60_000;
     private AppenderListener appenderListener;
+    @NotNull
+    private ContextListenerConfiguration contextListenerConfiguration = ContextListenerConfiguration.NONE;
     private SyncMode syncMode;
 
     protected SingleChronicleQueueBuilder() {
@@ -370,6 +372,7 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
      */
     @NotNull
     public SingleChronicleQueue build() {
+        validateContextListenerCompatibility();
         preBuild();
 
         SingleChronicleQueue chronicleQueue;
@@ -384,6 +387,15 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
         postBuild(chronicleQueue);
 
         return chronicleQueue;
+    }
+
+    private void validateContextListenerCompatibility() {
+        if (!contextListenerConfiguration.configured())
+            return;
+        if (key != null || encodingSupplier != null)
+            throw new UnsupportedOperationException("contextListener is not supported on encoded or encrypted Enterprise queues");
+        if (writeBufferMode == BufferMode.Asynchronous)
+            throw new UnsupportedOperationException("contextListener is not supported on asynchronous Enterprise write buffers");
     }
 
     /**
@@ -1265,12 +1277,12 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
 
     /**
      * Returns the {@link TimeProvider} for the queue. If not explicitly set, it defaults to the
-     * {@link SystemTimeProvider#INSTANCE}.
+     * current {@link SystemTimeProvider#CLOCK}.
      *
      * @return the time provider used by the queue
      */
     public TimeProvider timeProvider() {
-        return timeProvider == null ? SystemTimeProvider.INSTANCE : timeProvider;
+        return timeProvider == null ? SystemTimeProvider.CLOCK : timeProvider;
     }
 
     /**
@@ -1617,6 +1629,81 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
      */
     public AppenderListener appenderListener() {
         return appenderListener;
+    }
+
+    /**
+     * Sets a listener to be called before an appender writes to a newly-created output context.
+     * For Queue, the output context is a newly-created roll file.
+     * <p>
+     * Context records are synthetic and do not record {@link MessageHistory} by default. A listener
+     * may write history explicitly if that context has a real causal history, but normal usage
+     * assumes no history is written.
+     * <p>
+     * The supplied writer emits normal method-writer documents. Do not enable this listener on a
+     * queue whose readers require one fixed raw payload format unless those readers explicitly
+     * tolerate the context records.
+     * <p>
+     * A context record is advisory, not guaranteed session state: it is not written when appending
+     * to an existing non-empty roll file, for example after restart or failover into the middle of a
+     * roll. The callback runs while the queue write lock is held, so it must be allocation-light,
+     * must not block, and must not perform slow I/O.
+     * <p>
+     * The listener is called on first use of a new, empty queue roll file as well as on later
+     * new-roll callbacks. Context that must exist before the first appender write is application
+     * state and must be written by the application as it is built; this listener is not a
+     * construction-time callback. On callback, the listener can dump the current state and resend
+     * any previously written context that new readers may rely on. If there is no context to write
+     * for that callback, it may return without writing anything; Queue treats the context as handled
+     * and does not write a placeholder record. For a low-latency resend, clear
+     * any local "already sent" assumptions first and then write the missing context while one
+     * {@link net.openhft.chronicle.wire.DocumentContext} is held, if the supplied writer also exposes
+     * {@link net.openhft.chronicle.wire.DocumentWritten}.
+     * <p>
+     * The listener instance is owned by every queue built by this builder and is closed when each
+     * queue is closed if it implements {@link java.lang.AutoCloseable}. Do not reuse or clone a
+     * builder configured with a closeable listener instance for several queues. Use
+     * {@link #contextListenerSupplier(Class, Supplier)} when a builder may be reused or cloned.
+     *
+     * @param writerType event interface type for the supplied method writer
+     * @param listener   listener to call for new output contexts
+     * @param <T>        event interface type
+     * @return the current builder instance for method chaining
+     */
+    public <T> SingleChronicleQueueBuilder contextListener(@NotNull Class<T> writerType,
+                                                            @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        contextListenerConfiguration = ContextListenerConfiguration.of(writerType, listener);
+        return this;
+    }
+
+    /**
+     * Sets a factory to create a queue-owned listener for each queue built from this builder.
+     * Use this form when the builder may be reused or cloned, especially when the listener owns
+     * closeable state.
+     *
+     * @param writerType       event interface type for the supplied method writer
+     * @param listenerSupplier creates one listener for each built queue
+     * @param <T>              event interface type
+     * @return the current builder instance for method chaining
+     */
+    public <T> SingleChronicleQueueBuilder contextListenerSupplier(@NotNull Class<T> writerType,
+                                                                    @NotNull Supplier<? extends MarshallableOut.ContextListener<? super T>> listenerSupplier) {
+        contextListenerConfiguration = ContextListenerConfiguration.supplied(writerType, listenerSupplier);
+        return this;
+    }
+
+    /**
+     * Returns the listener instance configured by {@link #contextListener(Class, MarshallableOut.ContextListener)}.
+     *
+     * @return the listener, or {@code null} if none is configured or the supplier form is used
+     */
+    @Nullable
+    public MarshallableOut.ContextListener<?> contextListener() {
+        return contextListenerConfiguration.listener();
+    }
+
+    @NotNull
+    ContextListenerConfiguration contextListenerConfiguration() {
+        return contextListenerConfiguration;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StreamCorruptedException;
 import java.nio.BufferOverflowException;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueue.WARN_SLOW_APPENDER_MS;
@@ -75,6 +76,8 @@ class StoreAppender extends AbstractCloseable
     private Pretoucher pretoucher = null;
     private MicroToucher microtoucher = null;
     private Wire bufferWire = null;
+    @Nullable
+    private ContextListenerLifecycle contextListenerLifecycle;
     private int count = 0;
 
     /**
@@ -94,6 +97,7 @@ class StoreAppender extends AbstractCloseable
         this.writeLock = queue.writeLock();
         this.appendLock = queue.appendLock();
         this.context = new StoreAppenderContext();
+        this.contextListenerLifecycle = queue.newContextListenerLifecycle(this, context);
         this.finalizer = Jvm.isResourceTracing() ? new Finalizer() : null;
 
         try {
@@ -243,6 +247,10 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     protected void performClose() {
+        ContextListenerLifecycle lifecycle = contextListenerLifecycle;
+        if (lifecycle != null)
+            lifecycle.close();
+        contextListenerLifecycle = ContextListenerLifecycle.NO_OP;
         releaseBytesFor(wireForIndex);
         releaseBytesFor(wire);
         releaseBytesFor(bufferWire);
@@ -513,6 +521,27 @@ class StoreAppender extends AbstractCloseable
 
     @NotNull
     @Override
+    public <T> ExcerptAppender contextListener(@NotNull Class<T> writerType,
+                                                @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        throwExceptionIfClosed();
+        Objects.requireNonNull(writerType);
+        Objects.requireNonNull(listener);
+        ContextListenerLifecycle lifecycle = contextListenerLifecycle;
+        if (lifecycle == null) {
+            lifecycle = ContextListenerLifecycle.active(
+                    this,
+                    context,
+                    queue.activeContextListenerCoordinator(),
+                    ContextListenerBinding.of(writerType, listener));
+        } else {
+            lifecycle = lifecycle.configure(writerType, listener);
+        }
+        contextListenerLifecycle = lifecycle;
+        return this;
+    }
+
+    @NotNull
+    @Override
     // throws UnrecoverableTimeoutException
     public DocumentContext writingDocument() {
         return writingDocument(false); // avoid overhead of a default method.
@@ -532,13 +561,27 @@ class StoreAppender extends AbstractCloseable
         throwExceptionIfClosed();
         // we allow the sink process to write metaData
         checkAppendLock(metaData);
+        ContextListenerLifecycle listenerLifecycle = startContextListenerWriteAttempt();
         count++;
         try {
-            return prepareAndReturnWriteContext(metaData);
-        } catch (RuntimeException e) {
+            return prepareAndReturnWriteContext(metaData, listenerLifecycle);
+        } catch (Throwable e) {
+            // Throwable, not just RuntimeException: an Error from a context listener must also
+            // restore count, or the next write takes the count>1 fast path and is handed a stale,
+            // never-opened context - permanently wedging the appender.
             count--;
-            throw e;
+            throw Jvm.rethrow(e);
         }
+    }
+
+    private ContextListenerLifecycle startContextListenerWriteAttempt() {
+        ContextListenerLifecycle lifecycle = contextListenerLifecycle;
+        if (lifecycle == null) {
+            contextListenerLifecycle = lifecycle = ContextListenerLifecycle.NO_OP;
+        } else if (lifecycle != ContextListenerLifecycle.NO_OP) {
+            lifecycle.onWriteAttempt();
+        }
+        return lifecycle;
     }
 
     /**
@@ -549,7 +592,8 @@ class StoreAppender extends AbstractCloseable
      * @param metaData indicates if the write context is for metadata
      * @return the prepared {@link StoreAppenderContext} ready for writing
      */
-    private StoreAppender.StoreAppenderContext prepareAndReturnWriteContext(boolean metaData) {
+    private StoreAppender.StoreAppenderContext prepareAndReturnWriteContext(
+            boolean metaData, ContextListenerLifecycle listenerLifecycle) {
         if (count > 1) {
             assert metaData == context.metaData;
             return context;
@@ -572,6 +616,9 @@ class StoreAppender extends AbstractCloseable
 
                 long safeLength = queue.overlapSize();
                 resetPosition();
+                if (listenerLifecycle != ContextListenerLifecycle.NO_OP &&
+                        listenerLifecycle.beforeDocument(metaData, safeLength))
+                    resetPosition();
                 assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
 
                 // sets the writeLimit based on the safeLength
@@ -579,9 +626,12 @@ class StoreAppender extends AbstractCloseable
 
                 // Move readPosition to the start of the context. i.e. readRemaining() == 0
                 wire.bytes().readPosition(wire.bytes().writePosition());
-            } catch (RuntimeException e) {
+            } catch (Throwable e) {
+                // Catch Throwable, not just RuntimeException: a context listener (or a corrupt-index
+                // AssertionError) can throw an Error, and leaking the cross-process write lock would
+                // stall every appender in every process until the lock times out.
                 writeLock.unlock();
-                throw e;
+                throw Jvm.rethrow(e);
             }
         }
 
@@ -727,6 +777,52 @@ class StoreAppender extends AbstractCloseable
     }
 
     /**
+     * Opens a document for a context listener while this appender's write lock is already held.
+     *
+     * <p>This is package-private solely for {@link LockedContextListenerMarshallableOut}. Context
+     * listeners cannot use the regular appender entry points because those paths attempt to acquire
+     * the non-reentrant write lock again.</p>
+     *
+     * @param metaData   whether the listener document contains metadata
+     * @param safeLength maximum number of bytes that may be written without overlapping a mapping
+     */
+    void openContextForContextListener(boolean metaData, long safeLength) {
+        resetPosition();
+        openContext(metaData, safeLength);
+    }
+
+    boolean contextListenerWriteReady() {
+        return store != null && wire != null;
+    }
+
+    void resetPositionForContextListener() {
+        resetPosition();
+    }
+
+    /** Package-private injection point for lifecycle integration tests. */
+    void contextListenerLifecycle(ContextListenerLifecycle lifecycle) {
+        contextListenerLifecycle = Objects.requireNonNull(lifecycle);
+    }
+
+    /**
+     * Closes the document written by a context listener without releasing the appender's write
+     * lock, which remains owned by the outer application write.
+     *
+     * <p>The temporary count prevents any nesting state from the application write from suppressing
+     * the listener document's commit. The original count is restored for the application document
+     * that follows.</p>
+     */
+    void closeContextForContextListener() {
+        int savedCount = count;
+        try {
+            count = 1;
+            context.close(false);
+        } finally {
+            count = savedCount;
+        }
+    }
+
+    /**
      * Checks if the current header number matches the expected sequence in the queue.
      * Throws an {@link AssertionError} if there is a mismatch.
      *
@@ -778,6 +874,7 @@ class StoreAppender extends AbstractCloseable
     public void writeBytes(@NotNull final BytesStore<?, ?> bytes) {
         throwExceptionIfClosed();
         checkAppendLock();
+        ContextListenerLifecycle listenerLifecycle = startContextListenerWriteAttempt();
         writeLock.lock();
         try {
             int cycle = queue.cycle();
@@ -787,7 +884,12 @@ class StoreAppender extends AbstractCloseable
             if (this.cycle != cycle)
                 rollCycleTo(cycle);
 
-            this.positionOfHeader = writeHeader(wire, (int) queue.overlapSize()); // writeHeader sets wire.byte().writePosition
+            long safeLength = queue.overlapSize();
+            if (listenerLifecycle != ContextListenerLifecycle.NO_OP &&
+                    listenerLifecycle.beforeRawDocument(safeLength))
+                resetPosition();
+
+            this.positionOfHeader = writeHeader(wire, (int) safeLength); // writeHeader sets wire.byte().writePosition
 
             assert isInsideHeader(wire);
             beforeAppend(wire, wire.headerNumber() + 1);
@@ -827,6 +929,7 @@ class StoreAppender extends AbstractCloseable
     public void writeBytes(final long index, @NotNull final BytesStore<?, ?> bytes) {
         throwExceptionIfClosed();
         checkAppendLock();
+        startContextListenerWriteAttempt();
         writeLock.lock();
         try {
             writeBytesInternal(index, bytes);
@@ -1269,9 +1372,14 @@ class StoreAppender extends AbstractCloseable
                     updateHeaderAndIndex();
                 } else if (wire != null) {
                     if (buffered) {
-                        writeBytes(wire.bytes());
+                        // Capture the buffer wire before flushing: the context listener firing
+                        // inside writeBytes reassigns this context's wire to the mapped wire, so
+                        // clearing through the field would clear the wrong wire and leave the
+                        // flushed body in the buffer to be re-flushed by the next buffered write.
+                        Wire buffered0 = wire;
+                        writeBytes(buffered0.bytes());
                         unlock = false;
-                        wire.clear();
+                        buffered0.clear();
                     } else {
                         writeBytesInternal(wire.bytes(), metaData);
                         wire = StoreAppender.this.wire;
@@ -1431,6 +1539,16 @@ class StoreAppender extends AbstractCloseable
                     throw e;
                 }
             }
+        }
+
+        @Override
+        public long contextCount() {
+            // Reject on any double-buffered queue, not just when this write happened to hit lock
+            // contention: otherwise the same code works or throws depending on runtime contention.
+            // Progressive contextCount usage and double buffering are an unsupported combination.
+            if (queue.doubleBuffer || buffered)
+                throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
+            return isClosed ? -1 : StoreAppender.this.cycle();
         }
 
         /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -1814,6 +1814,14 @@ class StoreTailer extends AbstractCloseable
             return StoreTailer.this.sourceId();
         }
 
+        @Override
+        public long contextCount() {
+            // negative = no known context (absent document, or queried after close); a valid
+            // count is always positive and never 0
+            long index = index();
+            return isPresent() && index != Long.MIN_VALUE ? queue.rollCycle().toCycle(index) : -1;
+        }
+
         /**
          * Closes the context, and if necessary, increments the index after reading a document.
          */

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerLifecycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerLifecycleTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.MarshallableOut;
+import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Verifies that {@link StoreAppender} delegates its listener-related entry points to one lifecycle
+ * object. The recording implementation deliberately avoids listener mechanics so these tests fail
+ * when a write path bypasses the lifecycle abstraction.
+ */
+public class ContextListenerLifecycleTest extends QueueTestCommon {
+
+    @Test
+    public void defaultBuilderHasNonNullSharedConfiguration() {
+        SingleChronicleQueueBuilder first = SingleChronicleQueueBuilder.binary(getTmpDir());
+        SingleChronicleQueueBuilder second = SingleChronicleQueueBuilder.binary(getTmpDir());
+
+        assertNotNull(first.contextListenerConfiguration());
+        assertSame(ContextListenerConfiguration.NONE, first.contextListenerConfiguration());
+        assertSame(first.contextListenerConfiguration(), second.contextListenerConfiguration());
+        assertFalse(first.contextListenerConfiguration().configured());
+    }
+
+    @Test
+    public void documentWritesUseInjectedLifecycle() {
+        finishedNormally = false;
+        RecordingLifecycle lifecycle = new RecordingLifecycle();
+
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(getTmpDir()).testBlockSize().build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appender.contextListenerLifecycle(lifecycle);
+
+            try (DocumentContext dc = appender.writingDocument()) {
+                dc.wire().write("message").text("one");
+            }
+
+            assertEquals(1, lifecycle.writeAttempts);
+            assertEquals(1, lifecycle.documentCalls);
+            assertFalse(lifecycle.lastMetaData);
+            assertEquals(0, lifecycle.rawDocumentCalls);
+
+            appender.close();
+            assertEquals(1, lifecycle.closeCalls);
+        }
+    }
+
+    @Test
+    public void rawWritesUseInjectedLifecycle() {
+        finishedNormally = false;
+        RecordingLifecycle lifecycle = new RecordingLifecycle();
+
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(getTmpDir()).testBlockSize().build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appender.contextListenerLifecycle(lifecycle);
+
+            Bytes<?> payload = binaryPayload("raw");
+            try {
+                appender.writeBytes(payload);
+            } finally {
+                payload.releaseLast();
+            }
+
+            assertEquals(1, lifecycle.writeAttempts);
+            assertEquals(0, lifecycle.documentCalls);
+            assertEquals(1, lifecycle.rawDocumentCalls);
+        }
+    }
+
+    @Test
+    public void indexedWritesStartButDoNotNotifyLifecycle() {
+        finishedNormally = false;
+        RecordingLifecycle lifecycle = new RecordingLifecycle();
+
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(getTmpDir()).testBlockSize().build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appender.contextListenerLifecycle(lifecycle);
+            int cycle = ((SingleChronicleQueue) queue).cycle();
+            long index = queue.rollCycle().toIndex(cycle, 0);
+
+            Bytes<?> payload = binaryPayload("indexed");
+            try {
+                appender.writeBytes(index, payload);
+            } finally {
+                payload.releaseLast();
+            }
+
+            assertEquals(1, lifecycle.writeAttempts);
+            assertEquals(0, lifecycle.documentCalls);
+            assertEquals(0, lifecycle.rawDocumentCalls);
+        }
+    }
+
+    private static Bytes<?> binaryPayload(String value) {
+        Bytes<?> payload = Bytes.allocateElasticOnHeap();
+        Wire wire = WireType.BINARY.apply(payload);
+        wire.write("message").text(value);
+        return payload;
+    }
+
+    /**
+     * Test-only lifecycle implementation that records every appender entry point without creating
+     * a method writer or writing a synthetic context document.
+     */
+    private static final class RecordingLifecycle implements ContextListenerLifecycle {
+        private int writeAttempts;
+        private int documentCalls;
+        private int rawDocumentCalls;
+        private int closeCalls;
+        private boolean lastMetaData;
+
+        @Override
+        public boolean started() {
+            return writeAttempts != 0;
+        }
+
+        @Override
+        public void onWriteAttempt() {
+            writeAttempts++;
+        }
+
+        @Override
+        public boolean beforeDocument(boolean metaData, long safeLength) {
+            documentCalls++;
+            lastMetaData = metaData;
+            return false;
+        }
+
+        @Override
+        public boolean beforeRawDocument(long safeLength) {
+            rawDocumentCalls++;
+            return false;
+        }
+
+        @Override
+        public ContextListenerLifecycle configure(
+                Class<?> writerType, MarshallableOut.ContextListener<?> listener) {
+            return this;
+        }
+
+        @Override
+        public void close() {
+            closeCalls++;
+        }
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Superseded: do not merge this PR.**
>
> The current replacement is [#1725](https://github.com/OpenHFT/Chronicle-Queue/pull/1725), based on the minimal QUEUE-143 Queue integration branch from [#1724](https://github.com/OpenHFT/Chronicle-Queue/pull/1724).

## Why this PR cannot simply be retargeted

This branch is descended from the obsolete appender prerequisite [#1719](https://github.com/OpenHFT/Chronicle-Queue/pull/1719), which was itself based on the old full `feature/QUEUE-143-RollFileCleanupMain` branch. Retargeting this head to the new QUEUE-143 integration branch would make removed cleanup implementation appear in the merge diff.

PR #1725 reapplies the context-listener core patch and merges `feature/QUEUE-143-queue-integration-points`. Its configured base is an ancestor of its head, and its merge diff is limited to the intended eleven Queue context-listener core files.

## Review findings carried to the replacement stack

- The core patch still says the supplied method writer is callback-scoped and implements that restriction. This conflicts with the final Wire contract, under which the writer may be retained for normal use.
- Listener failure before writing currently retries in the same roll context, while the Wire contract says a failed notification is not retried for that context.
- This core layer adds roughly 1,000 lines of production behaviour but its only test class injects a recording lifecycle. The black-box roll, persistence, failure and ownership tests are deferred to [#1726](https://github.com/OpenHFT/Chronicle-Queue/pull/1726). At least a minimal successful-write/once-per-roll test should accompany the core change, or #1725 and #1726 must be reviewed and merged as one behavioural unit.

Review and merge should continue on #1725 after those contract differences are reconciled.
