### PR TITLE
QUEUE-143: Legacy maintenance source; deliver through #1745 [do not merge]

### DIFF
--- a/docs/antora/modules/tailing/pages/tailing.adoc
+++ b/docs/antora/modules/tailing/pages/tailing.adoc
@@ -194,6 +194,12 @@ NOTE: The `direction()` is not preserved across restarts, only the next index to
 NOTE: The index of a tailer is only progressed when the `DocumentContext.close()` is called.
 If this is prevented by an error, the same message will be read on each restart.
 
+WARNING: Named tailer ids ending in `.lock` or `.version`, ignoring case, are reserved by current
+releases and are rejected. Before upgrading a queue created by an older release, create a replacement
+tailer with a legal id, move it to the old tailer's committed index, and confirm that the replacement
+position has been persisted before retiring the old id. Maintenance snapshots continue to report
+distinguishable legacy entries so that roll-file retention remains conservative during migration.
+
 == Command Line Tools - Reading and Writing a Chronicle Queue
 
 Chronicle Queue stores its data in binary format, with a file extension of `cq4`:

--- a/docs/antora/modules/tailing/pages/tailing.adoc
+++ b/docs/antora/modules/tailing/pages/tailing.adoc
@@ -194,10 +194,10 @@ NOTE: The `direction()` is not preserved across restarts, only the next index to
 NOTE: The index of a tailer is only progressed when the `DocumentContext.close()` is called.
 If this is prevented by an error, the same message will be read on each restart.
 
-WARNING: Named tailer ids ending in the exact lowercase suffix `.lock` or `.version` are reserved and
-are rejected. Mixed-case variants remain accepted for compatibility with existing queues, although
-their metadata-shaped names are best migrated when practical. Maintenance snapshots continue to
-report distinguishable entries conservatively during migration.
+WARNING: Named tailer ids ending in `.lock` or `.version`, in any letter case, are reserved and are
+rejected. Table-store key matching is case-insensitive, so a mixed-case suffix can otherwise bind to
+replicated lock or version metadata. Migrate existing ids with these suffixes before upgrading.
+Maintenance snapshots continue to report distinguishable raw entries conservatively during migration.
 
 == Command Line Tools - Reading and Writing a Chronicle Queue
 

--- a/docs/antora/modules/tailing/pages/tailing.adoc
+++ b/docs/antora/modules/tailing/pages/tailing.adoc
@@ -194,11 +194,10 @@ NOTE: The `direction()` is not preserved across restarts, only the next index to
 NOTE: The index of a tailer is only progressed when the `DocumentContext.close()` is called.
 If this is prevented by an error, the same message will be read on each restart.
 
-WARNING: Named tailer ids ending in `.lock` or `.version`, ignoring case, are reserved by current
-releases and are rejected. Before upgrading a queue created by an older release, create a replacement
-tailer with a legal id, move it to the old tailer's committed index, and confirm that the replacement
-position has been persisted before retiring the old id. Maintenance snapshots continue to report
-distinguishable legacy entries so that roll-file retention remains conservative during migration.
+WARNING: Named tailer ids ending in the exact lowercase suffix `.lock` or `.version` are reserved and
+are rejected. Mixed-case variants remain accepted for compatibility with existing queues, although
+their metadata-shaped names are best migrated when practical. Maintenance snapshots continue to
+report distinguishable entries conservatively during migration.
 
 == Command Line Tools - Reading and Writing a Chronicle Queue
 

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -160,18 +160,18 @@ public interface ChronicleQueue extends Closeable {
      * If the provided {@code id} is {@code null}, the Tailer will be unnamed and this is
      * equivalent to invoking {@link #createTailer()}.
      * <p>
-     * Ids ending in {@code .lock} or {@code .version}, ignoring case, are rejected because those
-     * suffixes are used by replicated tailer metadata. Releases before this restriction could
-     * create such ids. Before upgrading, create a replacement with a legal id, move it to the old
-     * tailer's committed index, and confirm the replacement position is persisted before retiring
-     * the old id. Existing legacy entries remain visible to maintenance snapshots so that they
-     * conservatively retain data.
+     * Ids ending in the exact lowercase suffix {@code .lock} or {@code .version} are rejected because
+     * those suffixes are used by replicated tailer metadata. Mixed-case variants remain accepted for
+     * compatibility. Releases before this restriction could create exact-lowercase ids. Before
+     * upgrading, create a replacement with a legal id, move it to the old tailer's committed index,
+     * and confirm the replacement position is persisted before retiring the old id. Existing legacy
+     * entries remain visible to maintenance snapshots so that they conservatively retain data.
      *
      * @param id unique id for a tailer which uses to track where it was up to
      * @return a new ExcerptTailer for this ChronicleQueue with the given unique {@code id}
      * @throws net.openhft.chronicle.core.io.ClosedIllegalStateException                if required resources are closed
      * @throws net.openhft.chronicle.queue.impl.single.NamedTailerNotAvailableException if named tailer is not available
-     * @throws IllegalArgumentException if {@code id} has a reserved suffix
+     * @throws IllegalArgumentException if {@code id} has an exact lowercase reserved suffix
      * @see #createTailer()
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -160,18 +160,18 @@ public interface ChronicleQueue extends Closeable {
      * If the provided {@code id} is {@code null}, the Tailer will be unnamed and this is
      * equivalent to invoking {@link #createTailer()}.
      * <p>
-     * Ids ending in the exact lowercase suffix {@code .lock} or {@code .version} are rejected because
-     * those suffixes are used by replicated tailer metadata. Mixed-case variants remain accepted for
-     * compatibility. Releases before this restriction could create exact-lowercase ids. Before
-     * upgrading, create a replacement with a legal id, move it to the old tailer's committed index,
-     * and confirm the replacement position is persisted before retiring the old id. Existing legacy
-     * entries remain visible to maintenance snapshots so that they conservatively retain data.
+     * Ids ending in {@code .lock} or {@code .version}, in any letter case, are rejected because those
+     * suffixes are used by replicated tailer metadata and table-store key matching is case-insensitive.
+     * Releases before this restriction could create such ids. Before upgrading, create a replacement
+     * with a legal id, move it to the old tailer's committed index, and confirm the replacement position
+     * is persisted before retiring the old id. Existing legacy entries remain visible under their exact
+     * raw persisted keys in maintenance snapshots so that they conservatively retain data.
      *
      * @param id unique id for a tailer which uses to track where it was up to
      * @return a new ExcerptTailer for this ChronicleQueue with the given unique {@code id}
      * @throws net.openhft.chronicle.core.io.ClosedIllegalStateException                if required resources are closed
      * @throws net.openhft.chronicle.queue.impl.single.NamedTailerNotAvailableException if named tailer is not available
-     * @throws IllegalArgumentException if {@code id} has an exact lowercase reserved suffix
+     * @throws IllegalArgumentException if {@code id} has a reserved suffix, ignoring case
      * @see #createTailer()
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -159,11 +159,19 @@ public interface ChronicleQueue extends Closeable {
      * <p>
      * If the provided {@code id} is {@code null}, the Tailer will be unnamed and this is
      * equivalent to invoking {@link #createTailer()}.
+     * <p>
+     * Ids ending in {@code .lock} or {@code .version}, ignoring case, are rejected because those
+     * suffixes are used by replicated tailer metadata. Releases before this restriction could
+     * create such ids. Before upgrading, create a replacement with a legal id, move it to the old
+     * tailer's committed index, and confirm the replacement position is persisted before retiring
+     * the old id. Existing legacy entries remain visible to maintenance snapshots so that they
+     * conservatively retain data.
      *
      * @param id unique id for a tailer which uses to track where it was up to
      * @return a new ExcerptTailer for this ChronicleQueue with the given unique {@code id}
      * @throws net.openhft.chronicle.core.io.ClosedIllegalStateException                if required resources are closed
      * @throws net.openhft.chronicle.queue.impl.single.NamedTailerNotAvailableException if named tailer is not available
+     * @throws IllegalArgumentException if {@code id} has a reserved suffix
      * @see #createTailer()
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
@@ -52,28 +52,13 @@ public interface TableStore<T extends Metadata> extends CommonStore, ManagedClos
     LongValue acquireValueFor(CharSequence key, long defaultValue);
 
     /**
-     * Acquires or looks up a {@link LongValue} for the given key.
-     * <p>
-     * This is the non-mutating counterpart to {@link #acquireValueFor(CharSequence, long)} when
-     * {@code createIfAbsent} is {@code false}: implementations that support it return existing values
-     * without inserting missing keys. The default implementation preserves compatibility for existing
-     * implementations by delegating to {@link #acquireValueFor(CharSequence, long)} when
-     * {@code createIfAbsent} is {@code true}.
+     * Looks up an existing {@link LongValue} without creating a missing key.
      *
-     * @param key            the key for which to acquire or look up the {@link LongValue}
-     * @param defaultValue   the default value to use when creating a missing key
-     * @param createIfAbsent whether a missing key should be created
-     * @return the existing or newly-created {@link LongValue}, or {@code null} when the key is missing,
-     * {@code createIfAbsent} is {@code false} and the implementation supports non-mutating lookup
-     * @throws UnsupportedOperationException from the default implementation when
-     *                                       {@code createIfAbsent} is {@code false}: an implementation
-     *                                       that predates this method has no non-mutating lookup to
-     *                                       delegate to, so it must override this method to support
-     *                                       {@code createIfAbsent = false}
+     * @param key the key to look up
+     * @return the existing value, or {@code null} if the key is missing
+     * @throws UnsupportedOperationException if this implementation does not support non-mutating lookup
      */
-    default LongValue acquireOrGetValueFor(CharSequence key, long defaultValue, boolean createIfAbsent) {
-        if (createIfAbsent)
-            return acquireValueFor(key, defaultValue);
+    default LongValue getValueFor(CharSequence key) {
         throw new UnsupportedOperationException("Non-mutating lookup is not supported");
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
@@ -52,6 +52,32 @@ public interface TableStore<T extends Metadata> extends CommonStore, ManagedClos
     LongValue acquireValueFor(CharSequence key, long defaultValue);
 
     /**
+     * Acquires or looks up a {@link LongValue} for the given key.
+     * <p>
+     * This is the non-mutating counterpart to {@link #acquireValueFor(CharSequence, long)} when
+     * {@code createIfAbsent} is {@code false}: implementations that support it return existing values
+     * without inserting missing keys. The default implementation preserves compatibility for existing
+     * implementations by delegating to {@link #acquireValueFor(CharSequence, long)} when
+     * {@code createIfAbsent} is {@code true}.
+     *
+     * @param key            the key for which to acquire or look up the {@link LongValue}
+     * @param defaultValue   the default value to use when creating a missing key
+     * @param createIfAbsent whether a missing key should be created
+     * @return the existing or newly-created {@link LongValue}, or {@code null} when the key is missing,
+     * {@code createIfAbsent} is {@code false} and the implementation supports non-mutating lookup
+     * @throws UnsupportedOperationException from the default implementation when
+     *                                       {@code createIfAbsent} is {@code false}: an implementation
+     *                                       that predates this method has no non-mutating lookup to
+     *                                       delegate to, so it must override this method to support
+     *                                       {@code createIfAbsent = false}
+     */
+    default LongValue acquireOrGetValueFor(CharSequence key, long defaultValue, boolean createIfAbsent) {
+        if (createIfAbsent)
+            return acquireValueFor(key, defaultValue);
+        throw new UnsupportedOperationException("Non-mutating lookup is not supported");
+    }
+
+    /**
      * Iterates over each key in the table store and applies the given {@link TableStoreIterator} on it.
      *
      * @param <A>          the type of the accumulator

--- a/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
@@ -52,6 +52,17 @@ public interface TableStore<T extends Metadata> extends CommonStore, ManagedClos
     LongValue acquireValueFor(CharSequence key, long defaultValue);
 
     /**
+     * Looks up an existing {@link LongValue} without creating a missing key.
+     *
+     * @param key the key to look up
+     * @return the existing value, or {@code null} if the key is missing
+     * @throws UnsupportedOperationException if this implementation does not support non-mutating lookup
+     */
+    default LongValue getValueFor(CharSequence key) {
+        throw new UnsupportedOperationException("Non-mutating lookup is not supported");
+    }
+
+    /**
      * Iterates over each key in the table store and applies the given {@link TableStoreIterator} on it.
      *
      * @param <A>          the type of the accumulator

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/NamedTailerParkResult.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/NamedTailerParkResult.java
@@ -4,7 +4,8 @@
 package net.openhft.chronicle.queue.impl.single;
 
 /**
- * Outcome of an attempt to park a named tailer.
+ * Operational outcome of an attempt to park a named tailer. Invalid caller input is reported by
+ * {@link SingleChronicleQueue#parkNamedTailer(String)} as an exception rather than an outcome.
  */
 public enum NamedTailerParkResult {
     /** The named tailer existed and its persisted index was reset to zero. */
@@ -12,7 +13,5 @@ public enum NamedTailerParkResult {
     /** No persisted named tailer exists with the supplied name. */
     NOT_FOUND,
     /** The named tailer is replicated and cannot safely be parked locally. */
-    REFUSED_REPLICATED,
-    /** The supplied name is null or uses a reserved metadata suffix. */
-    INVALID_NAME
+    REFUSED_REPLICATED
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/NamedTailerParkResult.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/NamedTailerParkResult.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+/**
+ * Outcome of an attempt to park a named tailer.
+ */
+public enum NamedTailerParkResult {
+    /** The named tailer existed and its persisted index was reset to zero. */
+    PARKED,
+    /** No persisted named tailer exists with the supplied name. */
+    NOT_FOUND,
+    /** The named tailer is replicated and cannot safely be parked locally. */
+    REFUSED_REPLICATED,
+    /** The supplied name is null or uses a reserved metadata suffix. */
+    INVALID_NAME
+}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQMeta.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQMeta.java
@@ -9,7 +9,10 @@ import net.openhft.chronicle.queue.impl.table.Metadata;
 import net.openhft.chronicle.wire.WireIn;
 import net.openhft.chronicle.wire.WireOut;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Objects;
 
 /**
@@ -69,6 +72,56 @@ public class SCQMeta implements Metadata {
      */
     public int sourceId() {
         return sourceId;
+    }
+
+    /**
+     * Returns the persisted roll length without exposing the package-private mutable
+     * {@link SCQRoll} representation.
+     *
+     * @return the persisted roll length in milliseconds
+     */
+    public int rollLengthInMillis() {
+        return roll.length();
+    }
+
+    /**
+     * Returns the persisted roll-file name format without exposing the package-private mutable
+     * {@link SCQRoll} representation.
+     *
+     * @return the persisted roll-file name format
+     */
+    public String rollFormat() {
+        return roll.format();
+    }
+
+    /**
+     * Returns the persisted roll epoch without exposing the package-private mutable
+     * {@link SCQRoll} representation.
+     *
+     * @return the persisted roll epoch in milliseconds
+     */
+    public long rollEpoch() {
+        return roll.epoch();
+    }
+
+    /**
+     * Returns the persisted local roll time, when the queue uses time-zone-aware rolling.
+     *
+     * @return the persisted local roll time, or {@code null} when none is configured
+     */
+    @Nullable
+    public LocalTime rollTime() {
+        return roll.rollTime();
+    }
+
+    /**
+     * Returns the persisted roll time zone, when the queue uses time-zone-aware rolling.
+     *
+     * @return the persisted roll time zone, or {@code null} when none is configured
+     */
+    @Nullable
+    public ZoneId rollTimeZone() {
+        return roll.rollTimeZone();
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1392,28 +1392,28 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * read, discardable.
      * <p>
      * Replicated named tailers (those whose id starts with {@link #REPLICATED_NAMED_TAILER_PREFIX})
-     * are refused, returning {@code false} without change: their position is coordinated with sinks
-     * through version metadata, and a backward reset here would not bump that version, so parking one
-     * could desynchronise replication.
+     * are refused without change: their position is coordinated with sinks through version metadata,
+     * and a backward reset here would not bump that version, so parking one could desynchronise
+     * replication. The result distinguishes this safety refusal from an unknown or invalid name so
+     * operators can diagnose the outcome without duplicating Queue's metadata rules.
      *
      * @param name the named-tailer id to park
-     * @return {@code true} if the tailer existed and was parked; {@code false} if it is unknown or
-     * {@code null}, or if it is a replicated named tailer (which is never parked)
-     * @throws IllegalArgumentException if {@code name} ends, ignoring case, with the reserved
-     *                                  suffix {@code .lock} or {@code .version}
+     * @return the outcome of the parking attempt
      */
-    public boolean parkNamedTailer(String name) {
+    public NamedTailerParkResult parkNamedTailer(String name) {
         if (name == null)
-            return false;
-        validateNamedTailerId(name);
+            return NamedTailerParkResult.INVALID_NAME;
+        if (isReservedNamedTailerId(name))
+            return NamedTailerParkResult.INVALID_NAME;
         if (name.startsWith(REPLICATED_NAMED_TAILER_PREFIX))
-            return false;
+            return NamedTailerParkResult.REFUSED_REPLICATED;
         try (final ScopedResource<Bytes<Void>> bytesTl = acquireBytesScoped()) {
             Bytes<Void> bytes = bytesTl.get().clear().append("index.").append(name);
             LongValue longValue = tableStoreAcquireOrGet(bytes, 0, false);
-            if (longValue == null) return false;
+            if (longValue == null)
+                return NamedTailerParkResult.NOT_FOUND;
             longValue.setOrderedValue(0);
-            return true;
+            return NamedTailerParkResult.PARKED;
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1285,19 +1285,17 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     /**
-     * Returns the committed index of every named tailer registered against this queue, keyed by
-     * tailer name. Positions are read directly during a single scan of the metadata keys; no tailer
-     * is opened or advanced, so on a queue opened read-write this is safe to call from any process
-     * while the owning consumers run. (A queue opened {@code readOnly} may fall back to a read-only
-     * metadata store that does not support this scan.)
+     * Returns a detached snapshot of committed named-tailer indexes collected by a single metadata
+     * scan. The result is not live: subsequent registrations and index changes are not reflected.
+     * This method allocates and takes the metadata-store exclusive lock, so it is intended for
+     * periodic, off-critical-path maintenance or diagnostics rather than application polling.
      * <p>
-     * This exposes what retention by named-tailer position and consumer-lag monitoring need: the
-     * cycle a tailer is indexed to is {@code rollCycle().toCycle(index)}. Internal lock and version
-     * metadata entries are excluded; replicated named tailers are returned under their persisted ids.
-     * An index of {@code 0} means the tailer has never read, or has been parked, and should not be
-     * interpreted as a real roll-cycle position.
+     * For retention, the cycle a tailer is indexed to is {@code rollCycle().toCycle(index)}. Internal
+     * lock and version metadata entries are excluded; replicated named tailers are returned under
+     * their persisted ids. An index of {@code 0} means the tailer has never read, or has been parked,
+     * and should not be interpreted as a real roll-cycle position.
      *
-     * @return a name-ordered map of named-tailer id to its committed index (empty if none)
+     * @return a name-ordered snapshot of named-tailer id to committed index (empty if none)
      * @throws UnsupportedOperationException if the metadata store does not support locked key scans
      */
     public NavigableMap<String, Long> namedTailerIndexes() {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -711,14 +711,29 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * Creates an {@link ExcerptTailer} with a specific ID. The tailer will use the
      * provided ID to track its position, and the preconditions for creating a tailer
      * are verified before initialization.
+     * <p>
+     * Ids ending in {@code .lock} or {@code .version} are rejected: a named tailer keeps its state
+     * in the queue metadata under the keys {@code index.<id>}, {@code index.<id>.lock} and
+     * {@code index.<id>.version}, so a tailer named {@code a.lock} or {@code a.version} would write
+     * its position into the very keys that hold tailer {@code a}'s lock and version metadata, and
+     * the two tailers would silently corrupt each other's state.
+     * <p>
+     * This is a deliberate breaking change: earlier releases accepted such ids, but the overlap in
+     * the metadata key namespace made their state ambiguous, so they are now rejected to guarantee
+     * every tailer's keys are non-overlapping. Rename any existing tailer using a reserved suffix
+     * before upgrading.
      *
      * @param id the identifier for the tailer
      * @return a new ExcerptTailer
+     * @throws IllegalArgumentException         if {@code id} ends with the reserved suffix
+     *                                          {@code .lock} or {@code .version}
      * @throws NamedTailerNotAvailableException if the tailer is not available due to replication locks
      */
     @NotNull
     @Override
     public ExcerptTailer createTailer(String id) {
+        if (isReservedNamedTailerId(id))
+            throw reservedNamedTailerIdException(id);
         verifyTailerPreconditions(id);
         IndexUpdater indexUpdater = IndexUpdaterFactory.createIndexUpdater(id, this); // NOSONAR
 
@@ -1266,6 +1281,97 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     /**
+     * Returns the committed index of every named tailer registered against this queue, keyed by
+     * tailer name. Positions are read directly during a single scan of the metadata keys; no tailer
+     * is opened or advanced, so on a queue opened read-write this is safe to call from any process
+     * while the owning consumers run. (A queue opened {@code readOnly} may fall back to a read-only
+     * metadata store that does not support this scan.)
+     * <p>
+     * This exposes what retention by named-tailer position and consumer-lag monitoring need: the
+     * cycle a tailer is indexed to is {@code rollCycle().toCycle(index)}. Internal lock and version
+     * metadata entries are excluded; replicated named tailers are returned under their persisted ids.
+     * An index of {@code 0} means the tailer has never read, or has been parked, and should not be
+     * interpreted as a real roll-cycle position.
+     *
+     * @return a name-ordered map of named-tailer id to its committed index (empty if none)
+     */
+    public NavigableMap<String, Long> namedTailerIndexes() {
+        final NavigableMap<String, Long> result = new TreeMap<>();
+        metaStore.forEachKey(result, (acc, key, value) -> {
+            final String k = key.toString();
+            if (k.startsWith("index.")) {
+                String namedTailer = k.substring("index.".length());
+                if (!isReservedNamedTailerId(namedTailer))
+                    acc.put(namedTailer, value.int64());
+            }
+        });
+        return result;
+    }
+
+    /**
+     * Returns the roll file backing the given cycle, or {@code null} if that cycle is not present.
+     * The path is resolved from the cycle number alone and only the file's existence is checked, so
+     * no store is acquired and nothing is memory-mapped - a caller may safely delete the returned
+     * file (a mapping held by this process would make that fail on Windows and defer the space
+     * reclaim on Linux).
+     *
+     * @param cycle the roll cycle
+     * @return the cycle's {@code .cq4} file, or {@code null} if absent
+     */
+    public File fileForCycle(int cycle) {
+        final File file = dateCache.resourceFor(cycle).path;
+        return file.exists() ? file : null;
+    }
+
+    /**
+     * Parks a named tailer for retention purposes by resetting its committed index to {@code 0} - the
+     * same value a freshly created, never-read tailer has - so retention by named-tailer position
+     * treats it as not pinning any roll. Use this to retire a dead or over-lagging reader when free
+     * disk matters more than its unread backlog: the registration remains (there is no clean way to
+     * delete a table-store entry), but it stops blocking removal. If that consumer is ever restarted
+     * it simply resumes from the oldest roll still available - losing only what retention has since
+     * removed, never everything - which makes this a self-adjusting, minimal-loss retirement.
+     * <p>
+     * Replicated named tailers (those whose id starts with {@link #REPLICATED_NAMED_TAILER_PREFIX})
+     * are refused, returning {@code false} without change: their position is coordinated with sinks
+     * through version metadata, and a backward reset here would not bump that version, so parking one
+     * could desynchronise replication.
+     *
+     * @param name the named-tailer id to park
+     * @return {@code true} if the tailer existed and was parked; {@code false} if it is unknown or
+     * {@code null}, or if it is a replicated named tailer (which is never parked)
+     * @throws IllegalArgumentException if {@code name} ends with the reserved suffix {@code .lock} or
+     *                                  {@code .version}
+     */
+    public boolean parkNamedTailer(String name) {
+        if (name == null)
+            return false;
+        if (isReservedNamedTailerId(name))
+            throw reservedNamedTailerIdException(name);
+        if (name.startsWith(REPLICATED_NAMED_TAILER_PREFIX))
+            return false;
+        try (final ScopedResource<Bytes<Void>> bytesTl = acquireBytesScoped()) {
+            Bytes<Void> bytes = bytesTl.get().clear().append("index.").append(name);
+            LongValue longValue = tableStoreAcquireOrGet(bytes, 0, false);
+            if (longValue == null) return false;
+            longValue.setOrderedValue(0);
+            return true;
+        }
+    }
+
+    private static boolean isReservedNamedTailerId(String id) {
+        return id != null && (id.endsWith(".lock") || id.endsWith(".version"));
+    }
+
+    private static IllegalArgumentException reservedNamedTailerIdException(String id) {
+        return new IllegalArgumentException("Invalid named tailer id '" + id + "': the suffixes "
+                + "'.lock' and '.version' are reserved. Tailer state is kept under the metadata "
+                + "keys 'index.<id>', 'index.<id>.lock' and 'index.<id>.version', so this id "
+                + "would collide with the metadata of the tailer named '"
+                + id.substring(0, id.lastIndexOf('.')) + "'");
+    }
+
+    /**
      * Puts a new value in the table store for the given key and index. If the index is Long.MIN_VALUE,
      * it sets the value as volatile, otherwise, it sets the max value.
      *
@@ -1291,14 +1397,30 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      */
     @Nullable
     protected LongValue tableStoreAcquire(CharSequence key, long defaultValue) {
+        return tableStoreAcquireOrGet(key, defaultValue, true);
+    }
+
+    /**
+     * Acquires or reads a {@link LongValue} from the queue metadata table.
+     *
+     * @param key            the table-store key
+     * @param defaultValue   the default value to use when creating a missing key
+     * @param createIfAbsent whether a missing key should be created
+     * @return the existing or newly-created {@link LongValue}, or {@code null} when the key is missing
+     * and {@code createIfAbsent} is {@code false}
+     */
+    protected LongValue tableStoreAcquireOrGet(CharSequence key, long defaultValue, boolean createIfAbsent) {
         try (final ScopedResource<Bytes<Void>> bytesTl = acquireBytesScoped()) {
             BytesStore<?, ?> keyBytes = asBytes(key, bytesTl.get());
             LongValue longValue = metaStoreMap.get(keyBytes);
-            if (longValue == null) {
+            if (longValue == null || longValue.isClosed()) {
                 synchronized (closers) {
                     longValue = metaStoreMap.get(keyBytes);
-                    if (longValue == null) {
-                        longValue = metaStore.acquireValueFor(key, defaultValue);
+                    if (longValue == null || longValue.isClosed()) {
+                        longValue = metaStore.acquireOrGetValueFor(key, defaultValue, createIfAbsent);
+                        if (longValue == null) {
+                            return null;
+                        }
                         int length = key.length();
                         HeapBytesStore<byte[]> key2 = HeapBytesStore.wrap(new byte[length]);
                         key2.write(0, keyBytes, 0, length);
@@ -1314,12 +1436,19 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     /**
      * Gets the value for the given key from the table store. If the key does not exist,
      * returns Long.MIN_VALUE.
+     * <p>
+     * This is a pure read: a missing key is never created or cached, because a matching entry (for
+     * example a named tailer's index) may legitimately appear later - a named tailer can be
+     * registered by another process at any time without notice. A miss is therefore always
+     * expensive (a scan of the table store on every call, not just the first); callers polling a
+     * key that may not exist yet should expect that cost. Use
+     * {@link #tableStoreAcquire(CharSequence, long)} for get-or-create semantics.
      *
      * @param key the key for the entry in the table store
      * @return the value associated with the key, or Long.MIN_VALUE if not found
      */
     public long tableStoreGet(CharSequence key) {
-        LongValue longValue = tableStoreAcquire(key, Long.MIN_VALUE);
+        LongValue longValue = tableStoreAcquireOrGet(key, Long.MIN_VALUE, false);
         if (longValue == null) return Long.MIN_VALUE;
         return longValue.getVolatileValue();
     }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1313,13 +1313,17 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     private static NavigableMap<String, Long> scanNamedTailerIndexes(TableStore<SCQMeta> tableStore) {
-        final NavigableMap<String, Long> metadataIndexes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        final NavigableMap<String, Long> metadataIndexes = new TreeMap<>();
         tableStore.forEachKey(metadataIndexes, (acc, key, value) -> {
             final String k = key.toString();
             if (k.startsWith("index."))
                 acc.put(k.substring("index.".length()), value.int64());
         });
 
+        return selectNamedTailerIndexes(metadataIndexes);
+    }
+
+    static NavigableMap<String, Long> selectNamedTailerIndexes(Map<String, Long> metadataIndexes) {
         final NavigableMap<String, Long> result = new TreeMap<>();
         metadataIndexes.forEach((namedTailer, index) -> {
             if (isInternalNamedTailerMetadata(metadataIndexes, namedTailer))
@@ -1346,22 +1350,32 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             return false;
 
         final String owner = candidate.substring(0, candidate.length() - suffix.length());
-        if (!owner.startsWith(REPLICATED_NAMED_TAILER_PREFIX) || !metadataIndexes.containsKey(owner))
+        if (!owner.startsWith(REPLICATED_NAMED_TAILER_PREFIX)
+                || !containsKeyIgnoreCase(metadataIndexes, owner))
             return false;
 
         // Older releases allowed a replicated tailer whose primary id collided with this record.
         // Its own lock and version records make that legacy registration distinguishable.
-        return !metadataIndexes.containsKey(candidate + ".lock")
-                || !metadataIndexes.containsKey(candidate + ".version");
+        return !containsKeyIgnoreCase(metadataIndexes, candidate + ".lock")
+                || !containsKeyIgnoreCase(metadataIndexes, candidate + ".version");
     }
 
-    private static String persistedNamedTailerId(NavigableMap<String, Long> metadataIndexes,
-                                                   String candidate) {
+    private static String persistedNamedTailerId(Map<String, Long> metadataIndexes,
+                                                  String candidate) {
         final String nestedLock = candidate + ".lock";
-        final String persistedNestedLock = metadataIndexes.ceilingKey(nestedLock);
-        if (persistedNestedLock != null && persistedNestedLock.equalsIgnoreCase(nestedLock))
-            return persistedNestedLock.substring(0, persistedNestedLock.length() - ".lock".length());
+        for (String persistedKey : metadataIndexes.keySet()) {
+            if (persistedKey.equalsIgnoreCase(nestedLock))
+                return persistedKey.substring(0, persistedKey.length() - ".lock".length());
+        }
         return candidate;
+    }
+
+    private static boolean containsKeyIgnoreCase(Map<String, Long> metadataIndexes, String candidate) {
+        for (String persistedKey : metadataIndexes.keySet()) {
+            if (persistedKey.equalsIgnoreCase(candidate))
+                return true;
+        }
+        return false;
     }
 
     /**
@@ -1393,17 +1407,18 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * Replicated named tailers (those whose id starts with {@link #REPLICATED_NAMED_TAILER_PREFIX})
      * are refused without change: their position is coordinated with sinks through version metadata,
      * and a backward reset here would not bump that version, so parking one could desynchronise
-     * replication. The result distinguishes this safety refusal from an unknown or invalid name so
-     * operators can diagnose the outcome without duplicating Queue's metadata rules.
+     * replication. The result distinguishes this safety refusal from an unknown name so operators
+     * can diagnose the outcome without duplicating Queue's metadata rules. A {@code null} name or a
+     * reserved metadata suffix is a caller error rather than an operational outcome.
      *
      * @param name the named-tailer id to park
      * @return the outcome of the parking attempt
+     * @throws NullPointerException     if {@code name} is {@code null}
+     * @throws IllegalArgumentException if {@code name} has a reserved metadata suffix
      */
     public NamedTailerParkResult parkNamedTailer(String name) {
-        if (name == null)
-            return NamedTailerParkResult.INVALID_NAME;
-        if (isReservedNamedTailerId(name))
-            return NamedTailerParkResult.INVALID_NAME;
+        Objects.requireNonNull(name, "name");
+        validateNamedTailerId(name);
         if (name.startsWith(REPLICATED_NAMED_TAILER_PREFIX))
             return NamedTailerParkResult.REFUSED_REPLICATED;
         try (final ScopedResource<Bytes<Void>> bytesTl = acquireBytesScoped()) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -711,14 +711,27 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * Creates an {@link ExcerptTailer} with a specific ID. The tailer will use the
      * provided ID to track its position, and the preconditions for creating a tailer
      * are verified before initialization.
+     * <p>
+     * Ids ending in {@code .lock} or {@code .version}, ignoring case, are rejected. Every named
+     * tailer uses {@code index.<id>}; versioned named tailers additionally use
+     * {@code index.<id>.lock} and {@code index.<id>.version}. Reserving those suffixes prevents one
+     * tailer's primary index from overlapping another tailer's version metadata.
+     * <p>
+     * This is a deliberate breaking change: earlier releases accepted such ids, but the overlap in
+     * the metadata key namespace made their state ambiguous, so they are now rejected to guarantee
+     * every tailer's keys are non-overlapping. Rename any existing tailer using a reserved suffix
+     * before upgrading.
      *
      * @param id the identifier for the tailer
      * @return a new ExcerptTailer
+     * @throws IllegalArgumentException         if {@code id} ends, ignoring case, with the reserved suffix
+     *                                          {@code .lock} or {@code .version}
      * @throws NamedTailerNotAvailableException if the tailer is not available due to replication locks
      */
     @NotNull
     @Override
     public ExcerptTailer createTailer(String id) {
+        validateNamedTailerId(id);
         verifyTailerPreconditions(id);
         IndexUpdater indexUpdater = IndexUpdaterFactory.createIndexUpdater(id, this); // NOSONAR
 
@@ -755,10 +768,12 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      *
      * @param id the identifier for which to acquire the index
      * @return a LongValue representing the index for the given ID
+     * @throws IllegalArgumentException if the id has a reserved suffix
      */
     @Override
     @NotNull
     public LongValue indexForId(@NotNull String id) {
+        validateNamedTailerId(id);
         return this.metaStore.doWithExclusiveLock((ts) -> ts.acquireValueFor("index." + id, 0L));
     }
 
@@ -767,9 +782,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      *
      * @param id the identifier for which to acquire the version index
      * @return a LongValue representing the version index for the given ID
+     * @throws IllegalArgumentException if the id has a reserved suffix
      */
     @NotNull
     public LongValue indexVersionForId(@NotNull String id) {
+        validateNamedTailerId(id);
         return this.metaStore.doWithExclusiveLock((ts) -> ts.acquireValueFor(String.format(INDEX_VERSION_FORMAT, id), -1L));
     }
 
@@ -778,9 +795,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      *
      * @param id the identifier for which to create the write lock
      * @return a new TableStoreWriteLock for the version index
+     * @throws IllegalArgumentException if the id has a reserved suffix
      */
     @NotNull
     public TableStoreWriteLock versionIndexLockForId(@NotNull String id) {
+        validateNamedTailerId(id);
         return new TableStoreWriteLock(
                 metaStore,
                 pauserSupplier,
@@ -1266,6 +1285,109 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     /**
+     * Returns the committed index of every named tailer registered against this queue, keyed by
+     * tailer name. Positions are read directly during a single scan of the metadata keys; no tailer
+     * is opened or advanced, so on a queue opened read-write this is safe to call from any process
+     * while the owning consumers run. (A queue opened {@code readOnly} may fall back to a read-only
+     * metadata store that does not support this scan.)
+     * <p>
+     * This exposes what retention by named-tailer position and consumer-lag monitoring need: the
+     * cycle a tailer is indexed to is {@code rollCycle().toCycle(index)}. Internal lock and version
+     * metadata entries are excluded; replicated named tailers are returned under their persisted ids.
+     * An index of {@code 0} means the tailer has never read, or has been parked, and should not be
+     * interpreted as a real roll-cycle position.
+     *
+     * @return a name-ordered map of named-tailer id to its committed index (empty if none)
+     * @throws UnsupportedOperationException if the metadata store does not support locked key scans
+     */
+    public NavigableMap<String, Long> namedTailerIndexes() {
+        return metaStore.doWithExclusiveLock(tableStore -> {
+            final NavigableMap<String, Long> result = new TreeMap<>();
+            tableStore.forEachKey(result, (acc, key, value) -> {
+                final String k = key.toString();
+                if (k.startsWith("index.")) {
+                    String namedTailer = k.substring("index.".length());
+                    if (!isReservedNamedTailerId(namedTailer))
+                        acc.put(namedTailer, value.int64());
+                }
+            });
+            return result;
+        });
+    }
+
+    /**
+     * Returns the roll file backing the given cycle, or {@code null} if that cycle is not present.
+     * The path is resolved from the cycle number alone and only the file's existence is checked; this
+     * method does not acquire or memory-map the store. The file may disappear or be opened after this
+     * method returns, so callers remain responsible for coordinating archival or deletion.
+     *
+     * @param cycle the roll cycle
+     * @return the cycle's {@code .cq4} file, or {@code null} if absent
+     */
+    public File fileForCycle(int cycle) {
+        final File file = dateCache.resourceFor(cycle).path;
+        return file.exists() ? file : null;
+    }
+
+    /**
+     * Parks a named tailer for retention purposes by resetting its committed index to {@code 0} - the
+     * same value a freshly created, never-read tailer has - so retention by named-tailer position
+     * treats it as not pinning any roll. Use this to retire a dead or over-lagging reader when free
+     * disk matters more than its unread backlog: the registration remains (there is no clean way to
+     * delete a table-store entry), but it stops blocking removal. On restart the persisted index
+     * remains {@code 0}; the queue does not infer a new resume point, so the application must
+     * explicitly reinitialise that consumer.
+     * <p>
+     * Replicated named tailers (those whose id starts with {@link #REPLICATED_NAMED_TAILER_PREFIX})
+     * are refused, returning {@code false} without change: their position is coordinated with sinks
+     * through version metadata, and a backward reset here would not bump that version, so parking one
+     * could desynchronise replication.
+     *
+     * @param name the named-tailer id to park
+     * @return {@code true} if the tailer existed and was parked; {@code false} if it is unknown or
+     * {@code null}, or if it is a replicated named tailer (which is never parked)
+     * @throws IllegalArgumentException if {@code name} ends, ignoring case, with the reserved
+     *                                  suffix {@code .lock} or {@code .version}
+     */
+    public boolean parkNamedTailer(String name) {
+        if (name == null)
+            return false;
+        validateNamedTailerId(name);
+        if (name.startsWith(REPLICATED_NAMED_TAILER_PREFIX))
+            return false;
+        try (final ScopedResource<Bytes<Void>> bytesTl = acquireBytesScoped()) {
+            Bytes<Void> bytes = bytesTl.get().clear().append("index.").append(name);
+            LongValue longValue = tableStoreAcquireOrGet(bytes, 0, false);
+            if (longValue == null) return false;
+            longValue.setOrderedValue(0);
+            return true;
+        }
+    }
+
+    private static boolean isReservedNamedTailerId(String id) {
+        return endsWithIgnoreCase(id, ".lock") || endsWithIgnoreCase(id, ".version");
+    }
+
+    private static boolean endsWithIgnoreCase(String value, String suffix) {
+        return value != null
+                && value.length() >= suffix.length()
+                && value.regionMatches(true, value.length() - suffix.length(), suffix, 0, suffix.length());
+    }
+
+    private static void validateNamedTailerId(String id) {
+        if (isReservedNamedTailerId(id))
+            throw reservedNamedTailerIdException(id);
+    }
+
+    private static IllegalArgumentException reservedNamedTailerIdException(String id) {
+        return new IllegalArgumentException("Invalid named tailer id '" + id + "': the suffixes "
+                + "'.lock' and '.version' are reserved regardless of case. Tailer state is kept under the metadata "
+                + "keys 'index.<id>', 'index.<id>.lock' and 'index.<id>.version', so this id "
+                + "would collide with the metadata of the tailer named '"
+                + id.substring(0, id.lastIndexOf('.')) + "'");
+    }
+
+    /**
      * Puts a new value in the table store for the given key and index. If the index is Long.MIN_VALUE,
      * it sets the value as volatile, otherwise, it sets the max value.
      *
@@ -1291,14 +1413,32 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      */
     @Nullable
     protected LongValue tableStoreAcquire(CharSequence key, long defaultValue) {
+        return tableStoreAcquireOrGet(key, defaultValue, true);
+    }
+
+    /**
+     * Acquires or reads a {@link LongValue} from the queue metadata table.
+     *
+     * @param key            the table-store key
+     * @param defaultValue   the default value to use when creating a missing key
+     * @param createIfAbsent whether a missing key should be created
+     * @return the existing or newly-created {@link LongValue}, or {@code null} when the key is missing
+     * and {@code createIfAbsent} is {@code false}
+     */
+    protected LongValue tableStoreAcquireOrGet(CharSequence key, long defaultValue, boolean createIfAbsent) {
         try (final ScopedResource<Bytes<Void>> bytesTl = acquireBytesScoped()) {
             BytesStore<?, ?> keyBytes = asBytes(key, bytesTl.get());
             LongValue longValue = metaStoreMap.get(keyBytes);
-            if (longValue == null) {
+            if (longValue == null || longValue.isClosed()) {
                 synchronized (closers) {
                     longValue = metaStoreMap.get(keyBytes);
-                    if (longValue == null) {
-                        longValue = metaStore.acquireValueFor(key, defaultValue);
+                    if (longValue == null || longValue.isClosed()) {
+                        longValue = createIfAbsent
+                                ? metaStore.acquireValueFor(key, defaultValue)
+                                : metaStore.getValueFor(key);
+                        if (longValue == null) {
+                            return null;
+                        }
                         int length = key.length();
                         HeapBytesStore<byte[]> key2 = HeapBytesStore.wrap(new byte[length]);
                         key2.write(0, keyBytes, 0, length);
@@ -1314,12 +1454,19 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     /**
      * Gets the value for the given key from the table store. If the key does not exist,
      * returns Long.MIN_VALUE.
+     * <p>
+     * This is a pure read: a missing key is never created or cached, because a matching entry (for
+     * example a named tailer's index) may legitimately appear later - a named tailer can be
+     * registered by another process at any time without notice. A miss is therefore always
+     * expensive (a scan of the table store on every call, not just the first); callers polling a
+     * key that may not exist yet should expect that cost. Use
+     * {@link #tableStoreAcquire(CharSequence, long)} for get-or-create semantics.
      *
      * @param key the key for the entry in the table store
      * @return the value associated with the key, or Long.MIN_VALUE if not found
      */
     public long tableStoreGet(CharSequence key) {
-        LongValue longValue = tableStoreAcquire(key, Long.MIN_VALUE);
+        LongValue longValue = tableStoreAcquireOrGet(key, Long.MIN_VALUE, false);
         if (longValue == null) return Long.MIN_VALUE;
         return longValue.getVolatileValue();
     }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -712,18 +712,16 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * provided ID to track its position, and the preconditions for creating a tailer
      * are verified before initialization.
      * <p>
-     * Ids ending in the exact lowercase suffix {@code .lock} or {@code .version} are rejected. Every
+     * Ids ending in {@code .lock} or {@code .version}, in any letter case, are rejected. Every
      * named tailer uses {@code index.<id>}; versioned named tailers additionally use
      * {@code index.<id>.lock} and {@code index.<id>.version}. Reserving those suffixes prevents one
-     * tailer's primary index from overlapping another tailer's version metadata.
-     * <p>
-     * Mixed-case variants remain accepted for compatibility with existing queues. Maintenance scans
-     * therefore continue to recognise their metadata conservatively.
+     * tailer's primary index from overlapping another tailer's version metadata. Table-store key
+     * matching is case-insensitive, so accepting a case variant would not avoid that collision.
      *
      * @param id the identifier for the tailer
      * @return a new ExcerptTailer
-     * @throws IllegalArgumentException         if {@code id} ends with the exact lowercase reserved suffix
-     *                                          {@code .lock} or {@code .version}
+     * @throws IllegalArgumentException         if {@code id} ends with the reserved suffix
+     *                                          {@code .lock} or {@code .version}, ignoring case
      * @throws NamedTailerNotAvailableException if the tailer is not available due to replication locks
      */
     @NotNull
@@ -1292,8 +1290,10 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * <p>
      * For retention, the cycle a tailer is indexed to is {@code rollCycle().toCycle(index)}. Internal
      * lock and version metadata entries are excluded; replicated named tailers are returned under
-     * their persisted ids. An index of {@code 0} means the tailer has never read, or has been parked,
-     * and should not be interpreted as a real roll-cycle position.
+     * their exact raw persisted ids. This differs from public named-tailer lookup, whose historical
+     * table-store key comparison is case-insensitive. Case-variant raw keys are reported separately
+     * so retention considers every persisted position. An index of {@code 0} means the tailer has
+     * never read, or has been parked, and should not be interpreted as a real roll-cycle position.
      * Tailer ids ending in a metadata-shaped variant of {@code .lock} or {@code .version} are
      * retained in the result when they can be distinguished from internal metadata, and a warning
      * identifies each id that should be considered for migration. This is deliberately conservative
@@ -1328,11 +1328,10 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         metadataIndexes.forEach((namedTailer, index) -> {
             if (isInternalNamedTailerMetadata(metadataIndexes, namedTailer))
                 return;
-            final String persistedId = persistedNamedTailerId(metadataIndexes, namedTailer);
-            result.put(persistedId, index);
-            if (hasMetadataShapedSuffix(persistedId))
+            result.put(namedTailer, index);
+            if (hasMetadataShapedSuffix(namedTailer))
                 Jvm.warn().on(SingleChronicleQueue.class,
-                        "Named tailer id '" + persistedId + "' uses a metadata-shaped suffix "
+                        "Named tailer id '" + namedTailer + "' uses a metadata-shaped suffix "
                                 + "'.lock' or '.version'. It remains in this snapshot for safe retention; "
                                 + "consider migrating its committed position to an unambiguous id.");
         });
@@ -1358,16 +1357,6 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         // Its own lock and version records make that legacy registration distinguishable.
         return !containsKeyIgnoreCase(metadataIndexes, candidate + ".lock")
                 || !containsKeyIgnoreCase(metadataIndexes, candidate + ".version");
-    }
-
-    private static String persistedNamedTailerId(Map<String, Long> metadataIndexes,
-                                                  String candidate) {
-        final String nestedLock = candidate + ".lock";
-        for (String persistedKey : metadataIndexes.keySet()) {
-            if (persistedKey.equalsIgnoreCase(nestedLock))
-                return persistedKey.substring(0, persistedKey.length() - ".lock".length());
-        }
-        return candidate;
     }
 
     private static boolean containsKeyIgnoreCase(Map<String, Long> metadataIndexes, String candidate) {
@@ -1404,12 +1393,14 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * parked consumer: parking declares its unread backlog, up to the oldest surviving roll at next
      * read, discardable.
      * <p>
-     * Replicated named tailers (those whose id starts with {@link #REPLICATED_NAMED_TAILER_PREFIX})
-     * are refused without change: their position is coordinated with sinks through version metadata,
-     * and a backward reset here would not bump that version, so parking one could desynchronise
-     * replication. The result distinguishes this safety refusal from an unknown name so operators
-     * can diagnose the outcome without duplicating Queue's metadata rules. A {@code null} name or a
-     * reserved metadata suffix is a caller error rather than an operational outcome.
+     * Replicated named tailers (those whose id starts with {@link #REPLICATED_NAMED_TAILER_PREFIX},
+     * ignoring case) are refused without change: their position is coordinated with sinks through
+     * version metadata, and a backward reset here would not bump that version, so parking one could
+     * desynchronise replication. The case-insensitive check is deliberately as broad as the
+     * historical table-store lookup that follows it. The result distinguishes this safety refusal
+     * from an unknown name so operators can diagnose the outcome without duplicating Queue's
+     * metadata rules. A {@code null} name or a reserved metadata suffix is a caller error rather
+     * than an operational outcome.
      *
      * @param name the named-tailer id to park
      * @return the outcome of the parking attempt
@@ -1419,7 +1410,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     public NamedTailerParkResult parkNamedTailer(String name) {
         Objects.requireNonNull(name, "name");
         validateNamedTailerId(name);
-        if (name.startsWith(REPLICATED_NAMED_TAILER_PREFIX))
+        if (startsWithIgnoreCase(name, REPLICATED_NAMED_TAILER_PREFIX))
             return NamedTailerParkResult.REFUSED_REPLICATED;
         try (final ScopedResource<Bytes<Void>> bytesTl = acquireBytesScoped()) {
             Bytes<Void> bytes = bytesTl.get().clear().append("index.").append(name);
@@ -1432,7 +1423,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     private static boolean isReservedNamedTailerId(String id) {
-        return id != null && (id.endsWith(".lock") || id.endsWith(".version"));
+        return hasMetadataShapedSuffix(id);
     }
 
     private static boolean hasMetadataShapedSuffix(String value) {
@@ -1445,6 +1436,12 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 && value.regionMatches(true, value.length() - suffix.length(), suffix, 0, suffix.length());
     }
 
+    private static boolean startsWithIgnoreCase(String value, String prefix) {
+        return value != null
+                && value.length() >= prefix.length()
+                && value.regionMatches(true, 0, prefix, 0, prefix.length());
+    }
+
     private static void validateNamedTailerId(String id) {
         if (isReservedNamedTailerId(id))
             throw reservedNamedTailerIdException(id);
@@ -1452,7 +1449,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
     private static IllegalArgumentException reservedNamedTailerIdException(String id) {
         return new IllegalArgumentException("Invalid named tailer id '" + id + "': the suffixes "
-                + "'.lock' and '.version' are reserved in exact lowercase. Tailer state is kept under the metadata "
+                + "'.lock' and '.version' are reserved in any letter case. Tailer state is kept under the metadata "
                 + "keys 'index.<id>', 'index.<id>.lock' and 'index.<id>.version', so this id "
                 + "would collide with the metadata of the tailer named '"
                 + id.substring(0, id.lastIndexOf('.')) + "'");

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1333,8 +1333,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * treats it as not pinning any roll. Use this to retire a dead or over-lagging reader when free
      * disk matters more than its unread backlog: the registration remains (there is no clean way to
      * delete a table-store entry), but it stops blocking removal. On restart the persisted index
-     * remains {@code 0}; the queue does not infer a new resume point, so the application must
-     * explicitly reinitialise that consumer.
+     * remains {@code 0}; a tailer whose stored index is {@code 0} resumes from {@code firstIndex()}
+     * at its next read - the oldest roll still present - exactly as a freshly created, never-read
+     * tailer does. Consequently rolls deleted below that surviving floor are never replayed to the
+     * parked consumer: parking declares its unread backlog, up to the oldest surviving roll at next
+     * read, discardable.
      * <p>
      * Replicated named tailers (those whose id starts with {@link #REPLICATED_NAMED_TAILER_PREFIX})
      * are refused, returning {@code false} without change: their position is coordinated with sinks

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -712,19 +712,17 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * provided ID to track its position, and the preconditions for creating a tailer
      * are verified before initialization.
      * <p>
-     * Ids ending in {@code .lock} or {@code .version}, ignoring case, are rejected. Every named
-     * tailer uses {@code index.<id>}; versioned named tailers additionally use
+     * Ids ending in the exact lowercase suffix {@code .lock} or {@code .version} are rejected. Every
+     * named tailer uses {@code index.<id>}; versioned named tailers additionally use
      * {@code index.<id>.lock} and {@code index.<id>.version}. Reserving those suffixes prevents one
      * tailer's primary index from overlapping another tailer's version metadata.
      * <p>
-     * This is a deliberate breaking change: earlier releases accepted such ids, but the overlap in
-     * the metadata key namespace made their state ambiguous, so they are now rejected to guarantee
-     * every tailer's keys are non-overlapping. Rename any existing tailer using a reserved suffix
-     * before upgrading.
+     * Mixed-case variants remain accepted for compatibility with existing queues. Maintenance scans
+     * therefore continue to recognise their metadata conservatively.
      *
      * @param id the identifier for the tailer
      * @return a new ExcerptTailer
-     * @throws IllegalArgumentException         if {@code id} ends, ignoring case, with the reserved suffix
+     * @throws IllegalArgumentException         if {@code id} ends with the exact lowercase reserved suffix
      *                                          {@code .lock} or {@code .version}
      * @throws NamedTailerNotAvailableException if the tailer is not available due to replication locks
      */
@@ -1296,9 +1294,10 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * lock and version metadata entries are excluded; replicated named tailers are returned under
      * their persisted ids. An index of {@code 0} means the tailer has never read, or has been parked,
      * and should not be interpreted as a real roll-cycle position.
-     * Legacy tailer ids ending in the now-reserved suffix {@code .lock} or {@code .version} are
+     * Tailer ids ending in a metadata-shaped variant of {@code .lock} or {@code .version} are
      * retained in the result when they can be distinguished from internal metadata, and a warning
-     * identifies each id that must be migrated. This is deliberately conservative for retention.
+     * identifies each id that should be considered for migration. This is deliberately conservative
+     * for retention.
      *
      * @return a name-ordered snapshot of named-tailer id to committed index (empty if none)
      * @throws UnsupportedOperationException if the metadata store does not support locked key scans
@@ -1327,11 +1326,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 return;
             final String persistedId = persistedNamedTailerId(metadataIndexes, namedTailer);
             result.put(persistedId, index);
-            if (isReservedNamedTailerId(persistedId))
+            if (hasMetadataShapedSuffix(persistedId))
                 Jvm.warn().on(SingleChronicleQueue.class,
-                        "Legacy named tailer id '" + persistedId + "' uses the now-reserved suffix "
+                        "Named tailer id '" + persistedId + "' uses a metadata-shaped suffix "
                                 + "'.lock' or '.version'. It remains in this snapshot for safe retention; "
-                                + "migrate its committed position to a new id before using it again.");
+                                + "consider migrating its committed position to an unambiguous id.");
         });
         return result;
     }
@@ -1418,7 +1417,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     private static boolean isReservedNamedTailerId(String id) {
-        return endsWithIgnoreCase(id, ".lock") || endsWithIgnoreCase(id, ".version");
+        return id != null && (id.endsWith(".lock") || id.endsWith(".version"));
+    }
+
+    private static boolean hasMetadataShapedSuffix(String value) {
+        return endsWithIgnoreCase(value, ".lock") || endsWithIgnoreCase(value, ".version");
     }
 
     private static boolean endsWithIgnoreCase(String value, String suffix) {
@@ -1434,7 +1437,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
     private static IllegalArgumentException reservedNamedTailerIdException(String id) {
         return new IllegalArgumentException("Invalid named tailer id '" + id + "': the suffixes "
-                + "'.lock' and '.version' are reserved regardless of case. Tailer state is kept under the metadata "
+                + "'.lock' and '.version' are reserved in exact lowercase. Tailer state is kept under the metadata "
                 + "keys 'index.<id>', 'index.<id>.lock' and 'index.<id>.version', so this id "
                 + "would collide with the metadata of the tailer named '"
                 + id.substring(0, id.lastIndexOf('.')) + "'");

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -24,6 +24,7 @@ import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.queue.impl.*;
 import net.openhft.chronicle.queue.impl.single.namedtailer.IndexUpdater;
 import net.openhft.chronicle.queue.impl.single.namedtailer.IndexUpdaterFactory;
+import net.openhft.chronicle.queue.impl.table.ReadonlyTableStore;
 import net.openhft.chronicle.queue.impl.table.SingleTableStore;
 import net.openhft.chronicle.queue.internal.AnalyticsHolder;
 import net.openhft.chronicle.threads.DiskSpaceMonitor;
@@ -186,7 +187,10 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             readOnly = builder.readOnly();
             appenderListener = builder.appenderListener();
 
-            if (metaStore.readOnly()) {
+            // ReadonlyTableStore is the no-metadata fallback. A SingleTableStore can also be
+            // read-only, but still contains the persisted cycle listing that a read-only queue
+            // must retain rather than replacing with a filesystem rescan.
+            if (metaStore instanceof ReadonlyTableStore) {
                 this.directoryListing = new FileSystemDirectoryListing(path, fileNameToCycleFunction(), time);
             } else {
                 this.directoryListing = readOnly
@@ -346,6 +350,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         throwExceptionIfClosed();
 
         directoryListing.refresh(true);
+    }
+
+    @NotNull
+    DirectoryListing directoryListing() {
+        return directoryListing;
     }
 
     /**
@@ -1399,8 +1408,10 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * desynchronise replication. The case-insensitive check is deliberately as broad as the
      * historical table-store lookup that follows it. The result distinguishes this safety refusal
      * from an unknown name so operators can diagnose the outcome without duplicating Queue's
-     * metadata rules. A {@code null} name or a reserved metadata suffix is a caller error rather
-     * than an operational outcome.
+     * metadata rules. Refusal is evaluated before metadata existence, so an unregistered id with a
+     * replicated-looking prefix also returns {@link NamedTailerParkResult#REFUSED_REPLICATED}. A
+     * {@code null} name or a reserved metadata suffix is a caller error rather than an operational
+     * outcome.
      *
      * @param name the named-tailer id to park
      * @return the outcome of the parking attempt

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1296,6 +1296,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * lock and version metadata entries are excluded; replicated named tailers are returned under
      * their persisted ids. An index of {@code 0} means the tailer has never read, or has been parked,
      * and should not be interpreted as a real roll-cycle position.
+     * Legacy tailer ids ending in the now-reserved suffix {@code .lock} or {@code .version} are
+     * retained in the result when they can be distinguished from internal metadata, and a warning
+     * identifies each id that must be migrated. This is deliberately conservative for retention.
      *
      * @return a name-ordered snapshot of named-tailer id to committed index (empty if none)
      * @throws UnsupportedOperationException if the metadata store does not support locked key scans
@@ -1311,16 +1314,45 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     private static NavigableMap<String, Long> scanNamedTailerIndexes(TableStore<SCQMeta> tableStore) {
-        final NavigableMap<String, Long> result = new TreeMap<>();
-        tableStore.forEachKey(result, (acc, key, value) -> {
+        final NavigableMap<String, Long> metadataIndexes = new TreeMap<>();
+        tableStore.forEachKey(metadataIndexes, (acc, key, value) -> {
             final String k = key.toString();
-            if (k.startsWith("index.")) {
-                String namedTailer = k.substring("index.".length());
-                if (!isReservedNamedTailerId(namedTailer))
-                    acc.put(namedTailer, value.int64());
-            }
+            if (k.startsWith("index."))
+                acc.put(k.substring("index.".length()), value.int64());
+        });
+
+        final NavigableMap<String, Long> result = new TreeMap<>();
+        metadataIndexes.forEach((namedTailer, index) -> {
+            if (isInternalNamedTailerMetadata(metadataIndexes, namedTailer))
+                return;
+            result.put(namedTailer, index);
+            if (isReservedNamedTailerId(namedTailer))
+                Jvm.warn().on(SingleChronicleQueue.class,
+                        "Legacy named tailer id '" + namedTailer + "' uses the now-reserved suffix "
+                                + "'.lock' or '.version'. It remains in this snapshot for safe retention; "
+                                + "migrate its committed position to a new id before using it again.");
         });
         return result;
+    }
+
+    private static boolean isInternalNamedTailerMetadata(Map<String, Long> metadataIndexes,
+                                                          String candidate) {
+        final String suffix;
+        if (candidate.endsWith(".lock"))
+            suffix = ".lock";
+        else if (candidate.endsWith(".version"))
+            suffix = ".version";
+        else
+            return false;
+
+        final String owner = candidate.substring(0, candidate.length() - suffix.length());
+        if (!owner.startsWith(REPLICATED_NAMED_TAILER_PREFIX) || !metadataIndexes.containsKey(owner))
+            return false;
+
+        // Older releases allowed a replicated tailer whose primary id collided with this record.
+        // Its own lock and version records make that legacy registration distinguishable.
+        return !metadataIndexes.containsKey(candidate + ".lock")
+                || !metadataIndexes.containsKey(candidate + ".version");
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1287,8 +1287,10 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     /**
      * Returns a detached snapshot of committed named-tailer indexes collected by a single metadata
      * scan. The result is not live: subsequent registrations and index changes are not reflected.
-     * This method allocates and takes the metadata-store exclusive lock, so it is intended for
-     * periodic, off-critical-path maintenance or diagnostics rather than application polling.
+     * This method allocates and locks the metadata file for one scan: writable stores take an
+     * exclusive lock and read-only stores take a shared lock. It is intended for periodic,
+     * off-critical-path maintenance or diagnostics rather than application polling. A read-only
+     * queue with no metadata file has no persisted named tailers and returns an empty snapshot.
      * <p>
      * For retention, the cycle a tailer is indexed to is {@code rollCycle().toCycle(index)}. Internal
      * lock and version metadata entries are excluded; replicated named tailers are returned under
@@ -1299,18 +1301,26 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * @throws UnsupportedOperationException if the metadata store does not support locked key scans
      */
     public NavigableMap<String, Long> namedTailerIndexes() {
-        return metaStore.doWithExclusiveLock(tableStore -> {
-            final NavigableMap<String, Long> result = new TreeMap<>();
-            tableStore.forEachKey(result, (acc, key, value) -> {
-                final String k = key.toString();
-                if (k.startsWith("index.")) {
-                    String namedTailer = k.substring("index.".length());
-                    if (!isReservedNamedTailerId(namedTailer))
-                        acc.put(namedTailer, value.int64());
-                }
-            });
-            return result;
+        if (!metaStore.readOnly())
+            return metaStore.doWithExclusiveLock(SingleChronicleQueue::scanNamedTailerIndexes);
+        if (!(metaStore instanceof SingleTableStore))
+            return new TreeMap<>();
+        File metadataFile = new File(path, QUEUE_METADATA_FILE);
+        return SingleTableStore.doWithSharedLock(metadataFile,
+                SingleChronicleQueue::scanNamedTailerIndexes, () -> metaStore);
+    }
+
+    private static NavigableMap<String, Long> scanNamedTailerIndexes(TableStore<SCQMeta> tableStore) {
+        final NavigableMap<String, Long> result = new TreeMap<>();
+        tableStore.forEachKey(result, (acc, key, value) -> {
+            final String k = key.toString();
+            if (k.startsWith("index.")) {
+                String namedTailer = k.substring("index.".length());
+                if (!isReservedNamedTailerId(namedTailer))
+                    acc.put(namedTailer, value.int64());
+            }
         });
+        return result;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1296,16 +1296,18 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * @return a name-ordered map of named-tailer id to its committed index (empty if none)
      */
     public NavigableMap<String, Long> namedTailerIndexes() {
-        final NavigableMap<String, Long> result = new TreeMap<>();
-        metaStore.forEachKey(result, (acc, key, value) -> {
-            final String k = key.toString();
-            if (k.startsWith("index.")) {
-                String namedTailer = k.substring("index.".length());
-                if (!isReservedNamedTailerId(namedTailer))
-                    acc.put(namedTailer, value.int64());
-            }
+        return metaStore.doWithExclusiveLock(tableStore -> {
+            final NavigableMap<String, Long> result = new TreeMap<>();
+            tableStore.forEachKey(result, (acc, key, value) -> {
+                final String k = key.toString();
+                if (k.startsWith("index.")) {
+                    String namedTailer = k.substring("index.".length());
+                    if (!isReservedNamedTailerId(namedTailer))
+                        acc.put(namedTailer, value.int64());
+                }
+            });
+            return result;
         });
-        return result;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -712,11 +712,10 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * provided ID to track its position, and the preconditions for creating a tailer
      * are verified before initialization.
      * <p>
-     * Ids ending in {@code .lock} or {@code .version} are rejected: a named tailer keeps its state
-     * in the queue metadata under the keys {@code index.<id>}, {@code index.<id>.lock} and
-     * {@code index.<id>.version}, so a tailer named {@code a.lock} or {@code a.version} would write
-     * its position into the very keys that hold tailer {@code a}'s lock and version metadata, and
-     * the two tailers would silently corrupt each other's state.
+     * Ids ending in {@code .lock} or {@code .version}, ignoring case, are rejected. Every named
+     * tailer uses {@code index.<id>}; versioned named tailers additionally use
+     * {@code index.<id>.lock} and {@code index.<id>.version}. Reserving those suffixes prevents one
+     * tailer's primary index from overlapping another tailer's version metadata.
      * <p>
      * This is a deliberate breaking change: earlier releases accepted such ids, but the overlap in
      * the metadata key namespace made their state ambiguous, so they are now rejected to guarantee
@@ -725,15 +724,14 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      *
      * @param id the identifier for the tailer
      * @return a new ExcerptTailer
-     * @throws IllegalArgumentException         if {@code id} ends with the reserved suffix
+     * @throws IllegalArgumentException         if {@code id} ends, ignoring case, with the reserved suffix
      *                                          {@code .lock} or {@code .version}
      * @throws NamedTailerNotAvailableException if the tailer is not available due to replication locks
      */
     @NotNull
     @Override
     public ExcerptTailer createTailer(String id) {
-        if (isReservedNamedTailerId(id))
-            throw reservedNamedTailerIdException(id);
+        validateNamedTailerId(id);
         verifyTailerPreconditions(id);
         IndexUpdater indexUpdater = IndexUpdaterFactory.createIndexUpdater(id, this); // NOSONAR
 
@@ -770,10 +768,12 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      *
      * @param id the identifier for which to acquire the index
      * @return a LongValue representing the index for the given ID
+     * @throws IllegalArgumentException if the id has a reserved suffix
      */
     @Override
     @NotNull
     public LongValue indexForId(@NotNull String id) {
+        validateNamedTailerId(id);
         return this.metaStore.doWithExclusiveLock((ts) -> ts.acquireValueFor("index." + id, 0L));
     }
 
@@ -782,9 +782,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      *
      * @param id the identifier for which to acquire the version index
      * @return a LongValue representing the version index for the given ID
+     * @throws IllegalArgumentException if the id has a reserved suffix
      */
     @NotNull
     public LongValue indexVersionForId(@NotNull String id) {
+        validateNamedTailerId(id);
         return this.metaStore.doWithExclusiveLock((ts) -> ts.acquireValueFor(String.format(INDEX_VERSION_FORMAT, id), -1L));
     }
 
@@ -793,9 +795,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      *
      * @param id the identifier for which to create the write lock
      * @return a new TableStoreWriteLock for the version index
+     * @throws IllegalArgumentException if the id has a reserved suffix
      */
     @NotNull
     public TableStoreWriteLock versionIndexLockForId(@NotNull String id) {
+        validateNamedTailerId(id);
         return new TableStoreWriteLock(
                 metaStore,
                 pauserSupplier,
@@ -1294,6 +1298,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * interpreted as a real roll-cycle position.
      *
      * @return a name-ordered map of named-tailer id to its committed index (empty if none)
+     * @throws UnsupportedOperationException if the metadata store does not support locked key scans
      */
     public NavigableMap<String, Long> namedTailerIndexes() {
         return metaStore.doWithExclusiveLock(tableStore -> {
@@ -1312,10 +1317,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
     /**
      * Returns the roll file backing the given cycle, or {@code null} if that cycle is not present.
-     * The path is resolved from the cycle number alone and only the file's existence is checked, so
-     * no store is acquired and nothing is memory-mapped - a caller may safely delete the returned
-     * file (a mapping held by this process would make that fail on Windows and defer the space
-     * reclaim on Linux).
+     * The path is resolved from the cycle number alone and only the file's existence is checked; this
+     * method does not acquire or memory-map the store. The file may disappear or be opened after this
+     * method returns, so callers remain responsible for coordinating archival or deletion.
      *
      * @param cycle the roll cycle
      * @return the cycle's {@code .cq4} file, or {@code null} if absent
@@ -1330,9 +1334,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * same value a freshly created, never-read tailer has - so retention by named-tailer position
      * treats it as not pinning any roll. Use this to retire a dead or over-lagging reader when free
      * disk matters more than its unread backlog: the registration remains (there is no clean way to
-     * delete a table-store entry), but it stops blocking removal. If that consumer is ever restarted
-     * it simply resumes from the oldest roll still available - losing only what retention has since
-     * removed, never everything - which makes this a self-adjusting, minimal-loss retirement.
+     * delete a table-store entry), but it stops blocking removal. On restart the persisted index
+     * remains {@code 0}; the queue does not infer a new resume point, so the application must
+     * explicitly reinitialise that consumer.
      * <p>
      * Replicated named tailers (those whose id starts with {@link #REPLICATED_NAMED_TAILER_PREFIX})
      * are refused, returning {@code false} without change: their position is coordinated with sinks
@@ -1342,14 +1346,13 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * @param name the named-tailer id to park
      * @return {@code true} if the tailer existed and was parked; {@code false} if it is unknown or
      * {@code null}, or if it is a replicated named tailer (which is never parked)
-     * @throws IllegalArgumentException if {@code name} ends with the reserved suffix {@code .lock} or
-     *                                  {@code .version}
+     * @throws IllegalArgumentException if {@code name} ends, ignoring case, with the reserved
+     *                                  suffix {@code .lock} or {@code .version}
      */
     public boolean parkNamedTailer(String name) {
         if (name == null)
             return false;
-        if (isReservedNamedTailerId(name))
-            throw reservedNamedTailerIdException(name);
+        validateNamedTailerId(name);
         if (name.startsWith(REPLICATED_NAMED_TAILER_PREFIX))
             return false;
         try (final ScopedResource<Bytes<Void>> bytesTl = acquireBytesScoped()) {
@@ -1362,12 +1365,23 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     private static boolean isReservedNamedTailerId(String id) {
-        return id != null && (id.endsWith(".lock") || id.endsWith(".version"));
+        return endsWithIgnoreCase(id, ".lock") || endsWithIgnoreCase(id, ".version");
+    }
+
+    private static boolean endsWithIgnoreCase(String value, String suffix) {
+        return value != null
+                && value.length() >= suffix.length()
+                && value.regionMatches(true, value.length() - suffix.length(), suffix, 0, suffix.length());
+    }
+
+    private static void validateNamedTailerId(String id) {
+        if (isReservedNamedTailerId(id))
+            throw reservedNamedTailerIdException(id);
     }
 
     private static IllegalArgumentException reservedNamedTailerIdException(String id) {
         return new IllegalArgumentException("Invalid named tailer id '" + id + "': the suffixes "
-                + "'.lock' and '.version' are reserved. Tailer state is kept under the metadata "
+                + "'.lock' and '.version' are reserved regardless of case. Tailer state is kept under the metadata "
                 + "keys 'index.<id>', 'index.<id>.lock' and 'index.<id>.version', so this id "
                 + "would collide with the metadata of the tailer named '"
                 + id.substring(0, id.lastIndexOf('.')) + "'");
@@ -1419,7 +1433,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 synchronized (closers) {
                     longValue = metaStoreMap.get(keyBytes);
                     if (longValue == null || longValue.isClosed()) {
-                        longValue = metaStore.acquireOrGetValueFor(key, defaultValue, createIfAbsent);
+                        longValue = createIfAbsent
+                                ? metaStore.acquireValueFor(key, defaultValue)
+                                : metaStore.getValueFor(key);
                         if (longValue == null) {
                             return null;
                         }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1314,7 +1314,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     private static NavigableMap<String, Long> scanNamedTailerIndexes(TableStore<SCQMeta> tableStore) {
-        final NavigableMap<String, Long> metadataIndexes = new TreeMap<>();
+        final NavigableMap<String, Long> metadataIndexes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         tableStore.forEachKey(metadataIndexes, (acc, key, value) -> {
             final String k = key.toString();
             if (k.startsWith("index."))
@@ -1325,10 +1325,11 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         metadataIndexes.forEach((namedTailer, index) -> {
             if (isInternalNamedTailerMetadata(metadataIndexes, namedTailer))
                 return;
-            result.put(namedTailer, index);
-            if (isReservedNamedTailerId(namedTailer))
+            final String persistedId = persistedNamedTailerId(metadataIndexes, namedTailer);
+            result.put(persistedId, index);
+            if (isReservedNamedTailerId(persistedId))
                 Jvm.warn().on(SingleChronicleQueue.class,
-                        "Legacy named tailer id '" + namedTailer + "' uses the now-reserved suffix "
+                        "Legacy named tailer id '" + persistedId + "' uses the now-reserved suffix "
                                 + "'.lock' or '.version'. It remains in this snapshot for safe retention; "
                                 + "migrate its committed position to a new id before using it again.");
         });
@@ -1353,6 +1354,15 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         // Its own lock and version records make that legacy registration distinguishable.
         return !metadataIndexes.containsKey(candidate + ".lock")
                 || !metadataIndexes.containsKey(candidate + ".version");
+    }
+
+    private static String persistedNamedTailerId(NavigableMap<String, Long> metadataIndexes,
+                                                   String candidate) {
+        final String nestedLock = candidate + ".lock";
+        final String persistedNestedLock = metadataIndexes.ceilingKey(nestedLock);
+        if (persistedNestedLock != null && persistedNestedLock.equalsIgnoreCase(nestedLock))
+            return persistedNestedLock.substring(0, persistedNestedLock.length() - ".lock".length());
+        return candidate;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -282,10 +282,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
         mappedBytes.reserve(this);
         try {
-            mappedBytes.readPosition(0);
-            // if we set readLimit to realCapacity then we can run into DecoratedBufferUnderflowException: readLimit failed. Limit: xx > writeLimit: yy
-            // while reading from a TableStore which is being written to
-            mappedBytes.readLimit(Math.min(mappedBytes.writeLimit(), mappedBytes.realCapacity()));
+            prepareForTableScan();
             while (mappedWire.readDataHeader()) {
                 final int header = mappedBytes.readVolatileInt();
                 if (Wires.isNotComplete(header))
@@ -344,10 +341,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         mappedBytes.reserve(this);
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
             StringBuilder sb = stlSb.get();
-            mappedBytes.readPosition(0);
-            // The mapped write limit can temporarily trail realCapacity while another table-store
-            // instance appends a key. Reading only to the lower bound avoids an invalid read limit.
-            mappedBytes.readLimit(Math.min(mappedBytes.writeLimit(), mappedBytes.realCapacity()));
+            prepareForTableScan();
             while (mappedWire.readDataHeader()) {
                 final int header = mappedBytes.readVolatileInt();
                 if (Wires.isNotComplete(header))
@@ -380,5 +374,15 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     @Override
     public boolean readOnly() {
         return mappedBytes.isBackingFileReadOnly();
+    }
+
+    private void prepareForTableScan() {
+        mappedBytes.readPosition(0);
+        final long scanLimit = mappedBytes.realCapacity();
+        // writeLimit is local to this MappedBytes instance and is not updated when another
+        // table-store instance grows the file. Snapshot realCapacity() as this scan's upper
+        // bound; entries appended later are visible on a later scan.
+        mappedBytes.writeLimit(mappedBytes.capacity());
+        mappedBytes.readLimit(scanLimit);
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -125,6 +125,29 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     }
 
     /**
+     * Executes a code block with a shared structural lock, waiting for no longer than the
+     * supplied timeout. This overload is intended for off-critical-path metadata snapshots whose
+     * caller owns the timeout policy.
+     *
+     * @param file          the table-store file to lock
+     * @param timeoutMillis maximum time to wait in milliseconds; zero performs one attempt
+     * @param code          the function to execute while the lock is held
+     * @param target        supplier of the function target
+     * @param <T>           target type
+     * @param <R>           result type
+     * @return the result of applying {@code code}
+     * @throws IllegalArgumentException if {@code timeoutMillis} is negative
+     */
+    public static <T, R> R doWithSharedLock(@NotNull final File file,
+                                            final long timeoutMillis,
+                                            @NotNull final Function<T, ? extends R> code,
+                                            @NotNull final Supplier<T> target) {
+        if (timeoutMillis < 0)
+            throw new IllegalArgumentException("timeoutMillis must not be negative");
+        return doWithLock(file, code, target, true, timeoutMillis);
+    }
+
+    /**
      * Executes a code block with an exclusive lock on the specified file.
      *
      * @param file   The file to lock.
@@ -155,13 +178,22 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                                        @NotNull final Function<T, ? extends R> code,
                                        @NotNull final Supplier<T> target,
                                        final boolean shared) {
+        return doWithLock(file, code, target, shared, timeoutMS);
+    }
+
+    private static <T, R> R doWithLock(@NotNull final File file,
+                                       @NotNull final Function<T, ? extends R> code,
+                                       @NotNull final Supplier<T> target,
+                                       final boolean shared,
+                                       final long timeoutMillis) {
         final String type = shared ? "shared" : "exclusive";
         final StandardOpenOption readOrWrite = shared ? StandardOpenOption.READ : StandardOpenOption.WRITE;
 
-        final long timeoutAt = System.currentTimeMillis() + timeoutMS;
+        final long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+        final long startNanos = System.nanoTime();
         final long startMs = System.currentTimeMillis();
         try (final FileChannel channel = FileChannel.open(file.toPath(), readOrWrite)) {
-            for (int count = 1; System.currentTimeMillis() < timeoutAt; count++) {
+            for (int count = 1; ; count++) {
                 try (FileLock fileLock = channel.tryLock(EXCLUSIVE_LOCK_START, EXCLUSIVE_LOCK_SIZE, shared)) {
                     if (fileLock != null) {
                         return code.apply(target.get());
@@ -176,6 +208,8 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                         }
                     }
                 }
+                if (System.nanoTime() - startNanos >= timeoutNanos)
+                    break;
                 int delay = Math.min(250, count * count);
                 Jvm.pause(delay);
             }

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -304,7 +304,6 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             }
             if (mappedBytes.isBackingFileReadOnly())
                 throw new IllegalStateException("key " + key + " does not exist in readOnly TableStore and cannot be created");
-            restoreScanState = false;
             mappedBytes.writeLimit(mappedBytes.realCapacity());
             long start = mappedBytes.readPosition();
             mappedBytes.writePosition(start);
@@ -319,6 +318,9 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             long endOfChunk = (start + chuckSize - 1) / chuckSize * chuckSize;
             if (end >= endOfChunk + overlapSize)
                 throw new IllegalStateException("Misaligned write");
+            // Failed creation must restore the caller's scan state; only a complete entry keeps
+            // the post-write positions and limits used by subsequent acquire calls.
+            restoreScanState = false;
             return longValue;
 
         } catch (StreamCorruptedException | EOFException e) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -266,7 +266,12 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
      * @return The acquired {@link LongValue}.
      */
     @Override
-    public synchronized LongValue acquireValueFor(CharSequence key, final long defaultValue) {
+    public LongValue acquireValueFor(CharSequence key, final long defaultValue) {
+        return acquireOrGetValueFor(key, defaultValue, true);
+    }
+
+    @Override
+    public synchronized LongValue acquireOrGetValueFor(CharSequence key, final long defaultValue, boolean createIfAbsent) {
 
         if (mappedBytes.isClosed())
             throw new ClosedIllegalStateException("Closed");
@@ -288,6 +293,9 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                     return valueIn.int64ForBinding(null);
                 }
                 mappedBytes.readPosition(readPosition + length);
+            }
+            if (!createIfAbsent) {
+                return null;
             }
             if (mappedBytes.isBackingFileReadOnly())
                 throw new IllegalStateException("key " + key + " does not exist in readOnly TableStore and cannot be created");

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -345,7 +345,9 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
             StringBuilder sb = stlSb.get();
             mappedBytes.readPosition(0);
-            mappedBytes.readLimit(mappedBytes.realCapacity());
+            // The mapped write limit can temporarily trail realCapacity while another table-store
+            // instance appends a key. Reading only to the lower bound avoids an invalid read limit.
+            mappedBytes.readLimit(Math.min(mappedBytes.writeLimit(), mappedBytes.realCapacity()));
             while (mappedWire.readDataHeader()) {
                 final int header = mappedBytes.readVolatileInt();
                 if (Wires.isNotComplete(header))

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -266,12 +266,16 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
      * @return The acquired {@link LongValue}.
      */
     @Override
-    public LongValue acquireValueFor(CharSequence key, final long defaultValue) {
+    public synchronized LongValue acquireValueFor(CharSequence key, final long defaultValue) {
         return acquireOrGetValueFor(key, defaultValue, true);
     }
 
     @Override
-    public synchronized LongValue acquireOrGetValueFor(CharSequence key, final long defaultValue, boolean createIfAbsent) {
+    public synchronized LongValue getValueFor(CharSequence key) {
+        return acquireOrGetValueFor(key, 0, false);
+    }
+
+    private LongValue acquireOrGetValueFor(CharSequence key, final long defaultValue, boolean createIfAbsent) {
 
         if (mappedBytes.isClosed())
             throw new ClosedIllegalStateException("Closed");

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -281,6 +281,10 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             throw new ClosedIllegalStateException("Closed");
 
         mappedBytes.reserve(this);
+        final long previousReadPosition = mappedBytes.readPosition();
+        final long previousReadLimit = mappedBytes.readLimit();
+        final long previousWriteLimit = mappedBytes.writeLimit();
+        boolean restoreScanState = true;
         try {
             prepareForTableScan();
             while (mappedWire.readDataHeader()) {
@@ -300,6 +304,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             }
             if (mappedBytes.isBackingFileReadOnly())
                 throw new IllegalStateException("key " + key + " does not exist in readOnly TableStore and cannot be created");
+            restoreScanState = false;
             mappedBytes.writeLimit(mappedBytes.realCapacity());
             long start = mappedBytes.readPosition();
             mappedBytes.writePosition(start);
@@ -320,6 +325,8 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             throw new IORuntimeException(e);
 
         } finally {
+            if (restoreScanState)
+                restoreAfterTableScan(previousReadPosition, previousReadLimit, previousWriteLimit);
             mappedBytes.release(this);
         }
     }
@@ -339,6 +346,9 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     @Override
     public synchronized <T> void forEachKey(T accumulator, TableStoreIterator<T> tsIterator) {
         mappedBytes.reserve(this);
+        final long previousReadPosition = mappedBytes.readPosition();
+        final long previousReadLimit = mappedBytes.readLimit();
+        final long previousWriteLimit = mappedBytes.writeLimit();
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
             StringBuilder sb = stlSb.get();
             prepareForTableScan();
@@ -357,6 +367,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             throw new IORuntimeException(e);
 
         } finally {
+            restoreAfterTableScan(previousReadPosition, previousReadLimit, previousWriteLimit);
             mappedBytes.release(this);
         }
     }
@@ -384,5 +395,12 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         // bound; entries appended later are visible on a later scan.
         mappedBytes.writeLimit(mappedBytes.capacity());
         mappedBytes.readLimit(scanLimit);
+    }
+
+    private void restoreAfterTableScan(long readPosition, long readLimit, long writeLimit) {
+        mappedBytes.readPosition(0);
+        mappedBytes.readLimit(readLimit);
+        mappedBytes.writeLimit(writeLimit);
+        mappedBytes.readPosition(readPosition);
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -376,4 +376,9 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     public T metadata() {
         return metadata;
     }
+
+    @Override
+    public boolean readOnly() {
+        return mappedBytes.isBackingFileReadOnly();
+    }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -267,6 +267,15 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
      */
     @Override
     public synchronized LongValue acquireValueFor(CharSequence key, final long defaultValue) {
+        return acquireOrGetValueFor(key, defaultValue, true);
+    }
+
+    @Override
+    public synchronized LongValue getValueFor(CharSequence key) {
+        return acquireOrGetValueFor(key, 0, false);
+    }
+
+    private LongValue acquireOrGetValueFor(CharSequence key, final long defaultValue, boolean createIfAbsent) {
 
         if (mappedBytes.isClosed())
             throw new ClosedIllegalStateException("Closed");
@@ -288,6 +297,9 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                     return valueIn.int64ForBinding(null);
                 }
                 mappedBytes.readPosition(readPosition + length);
+            }
+            if (!createIfAbsent) {
+                return null;
             }
             if (mappedBytes.isBackingFileReadOnly())
                 throw new IllegalStateException("key " + key + " does not exist in readOnly TableStore and cannot be created");

--- a/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
@@ -7,7 +7,6 @@ import net.openhft.chronicle.bytes.PageUtil;
 import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.table.Metadata;
-import net.openhft.chronicle.queue.impl.table.ReadonlyTableStore;
 import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
 import net.openhft.chronicle.queue.impl.table.SingleTableStore;
 import net.openhft.chronicle.wire.WireType;
@@ -17,7 +16,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static net.openhft.chronicle.queue.DirectoryUtils.tempDir;
 import static org.junit.Assert.*;
@@ -79,24 +77,20 @@ public class TableStoreTest extends QueueTestCommon {
     }
 
     @Test
-    public void defaultAcquireOrGetDelegatesToAcquireWhenCreating() {
-        AtomicInteger calls = new AtomicInteger();
-        TableStore<Metadata.NoMeta> table = new ReadonlyTableStore<Metadata.NoMeta>(Metadata.NoMeta.INSTANCE) {
-            @Override
-            public LongValue acquireValueFor(CharSequence key, long defaultValue) {
-                calls.incrementAndGet();
-                assertEquals(17L, defaultValue);
-                assertEquals("k", key.toString());
-                return null;
+    public void getValueForDoesNotCreateMissingKey() throws IOException {
+        final File dir = tempDir("table-store-get");
+        dir.mkdir();
+        final File tableFile = Files.createTempFile(dir.toPath(), "table", SingleTableStore.SUFFIX).toFile();
+
+        try (TableStore<Metadata.NoMeta> table = SingleTableBuilder.binary(tableFile, Metadata.NoMeta.INSTANCE).build()) {
+            assertNull(table.getValueFor("missing"));
+            try (LongValue value = table.acquireValueFor("missing", 17L)) {
+                assertEquals(17L, value.getValue());
             }
-        };
-        try {
-            assertNull(table.acquireOrGetValueFor("k", 17L, true));
-            assertEquals("the default must preserve acquire/create compatibility", 1, calls.get());
-            assertThrows(UnsupportedOperationException.class,
-                    () -> table.acquireOrGetValueFor("k", 17L, false));
-        } finally {
-            table.close();
+            try (LongValue value = table.getValueFor("missing")) {
+                assertNotNull(value);
+                assertEquals(17L, value.getValue());
+            }
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
@@ -7,6 +7,7 @@ import net.openhft.chronicle.bytes.PageUtil;
 import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.table.Metadata;
+import net.openhft.chronicle.queue.impl.table.ReadonlyTableStore;
 import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
 import net.openhft.chronicle.queue.impl.table.SingleTableStore;
 import net.openhft.chronicle.wire.WireType;
@@ -16,6 +17,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static net.openhft.chronicle.queue.DirectoryUtils.tempDir;
 import static org.junit.Assert.*;
@@ -77,6 +79,28 @@ public class TableStoreTest extends QueueTestCommon {
     }
 
     @Test
+    public void defaultAcquireOrGetDelegatesToAcquireWhenCreating() {
+        AtomicInteger calls = new AtomicInteger();
+        TableStore<Metadata.NoMeta> table = new ReadonlyTableStore<Metadata.NoMeta>(Metadata.NoMeta.INSTANCE) {
+            @Override
+            public LongValue acquireValueFor(CharSequence key, long defaultValue) {
+                calls.incrementAndGet();
+                assertEquals(17L, defaultValue);
+                assertEquals("k", key.toString());
+                return null;
+            }
+        };
+        try {
+            assertNull(table.acquireOrGetValueFor("k", 17L, true));
+            assertEquals("the default must preserve acquire/create compatibility", 1, calls.get());
+            assertThrows(UnsupportedOperationException.class,
+                    () -> table.acquireOrGetValueFor("k", 17L, false));
+        } finally {
+            table.close();
+        }
+    }
+
+    @Test
     public void acquireValueForReadOnly() throws IOException {
 
         final File file = tempDir("table");
@@ -96,4 +120,5 @@ public class TableStoreTest extends QueueTestCommon {
             assertThrows(IllegalStateException.class, () -> table.acquireValueFor("d"));
         }
     }
+
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/TableStoreTest.java
@@ -77,6 +77,24 @@ public class TableStoreTest extends QueueTestCommon {
     }
 
     @Test
+    public void getValueForDoesNotCreateMissingKey() throws IOException {
+        final File dir = tempDir("table-store-get");
+        dir.mkdir();
+        final File tableFile = Files.createTempFile(dir.toPath(), "table", SingleTableStore.SUFFIX).toFile();
+
+        try (TableStore<Metadata.NoMeta> table = SingleTableBuilder.binary(tableFile, Metadata.NoMeta.INSTANCE).build()) {
+            assertNull(table.getValueFor("missing"));
+            try (LongValue value = table.acquireValueFor("missing", 17L)) {
+                assertEquals(17L, value.getValue());
+            }
+            try (LongValue value = table.getValueFor("missing")) {
+                assertNotNull(value);
+                assertEquals(17L, value.getValue());
+            }
+        }
+    }
+
+    @Test
     public void acquireValueForReadOnly() throws IOException {
 
         final File file = tempDir("table");
@@ -96,4 +114,5 @@ public class TableStoreTest extends QueueTestCommon {
             assertThrows(IllegalStateException.class, () -> table.acquireValueFor("d"));
         }
     }
+
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ParkNamedTailerResumeBehaviourTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ParkNamedTailerResumeBehaviourTest.java
@@ -90,7 +90,7 @@ public class ParkNamedTailerResumeBehaviourTest extends QueueTestCommon {
             assertNotNull(stored);
             assertTrue(stored > 0);
 
-            assertTrue(q.parkNamedTailer("consumer"));
+            assertEquals(NamedTailerParkResult.PARKED, q.parkNamedTailer("consumer"));
             assertEquals(Long.valueOf(0L), q.namedTailerIndexes().get("consumer"));
         }
 
@@ -116,7 +116,7 @@ public class ParkNamedTailerResumeBehaviourTest extends QueueTestCommon {
             try (ExcerptTailer consumer = q.createTailer("consumer")) {
                 assertEquals(0, readNext(consumer, q.firstIndex()));
             }
-            assertTrue(q.parkNamedTailer("consumer"));
+            assertEquals(NamedTailerParkResult.PARKED, q.parkNamedTailer("consumer"));
         }
 
         try (SingleChronicleQueue q = builder(dir).build();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ParkNamedTailerResumeBehaviourTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ParkNamedTailerResumeBehaviourTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.core.time.SystemTimeProvider;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
+import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+/**
+ * Pins the resume semantics documented on {@link SingleChronicleQueue#parkNamedTailer(String)}:
+ * a parked named tailer (stored index {@code 0}) resumes from {@code firstIndex()} at its next
+ * read - the oldest surviving roll - exactly as a freshly created, never-read tailer does, so
+ * rolls deleted below that floor are never replayed to it.
+ */
+public class ParkNamedTailerResumeBehaviourTest extends QueueTestCommon {
+
+    private final SetTimeProvider timeProvider = new SetTimeProvider();
+
+    @Before
+    public void useDeterministicSystemTimeProvider() {
+        SystemTimeProvider.CLOCK = timeProvider;
+    }
+
+    @After
+    public void resetSystemTimeProvider() {
+        SystemTimeProvider.CLOCK = SystemTimeProvider.INSTANCE;
+    }
+
+    private SingleChronicleQueueBuilder builder(File dir) {
+        return SingleChronicleQueueBuilder.single(dir)
+                .rollCycle(TestRollCycles.TEST_DAILY)
+                .timeProvider(timeProvider);
+    }
+
+    private void writeDailyExcerpts(File dir, int days) {
+        try (ChronicleQueue queue = builder(dir).build();
+             ExcerptAppender appender = queue.createAppender()) {
+            for (int d = 0; d < days; d++) {
+                try (DocumentContext dc = appender.writingDocument()) {
+                    dc.wire().write("n").int32(d);
+                }
+                timeProvider.advanceMillis(TimeUnit.DAYS.toMillis(1));
+            }
+        }
+    }
+
+    private static int readNext(ExcerptTailer tailer, long expectedIndex) {
+        try (DocumentContext dc = tailer.readingDocument()) {
+            assertTrue(dc.isPresent());
+            assertEquals(expectedIndex, dc.index());
+            return dc.wire().read("n").int32();
+        }
+    }
+
+    private static void deleteAllButNewestRollFile(File dir) {
+        File[] rolls = dir.listFiles((d, name) -> name.endsWith(SingleChronicleQueue.SUFFIX));
+        assertNotNull(rolls);
+        Arrays.sort(rolls);
+        assertTrue(rolls.length > 1);
+        for (int i = 0; i < rolls.length - 1; i++)
+            assertTrue(rolls[i].delete());
+    }
+
+    @Test
+    public void parkedTailerResumesFromOldestSurvivingRollAfterRestart() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(70_000));
+        writeDailyExcerpts(dir, 3);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            try (ExcerptTailer consumer = q.createTailer("consumer")) {
+                assertEquals(0, readNext(consumer, q.firstIndex()));
+            }
+            Long stored = q.namedTailerIndexes().get("consumer");
+            assertNotNull(stored);
+            assertTrue(stored > 0);
+
+            assertTrue(q.parkNamedTailer("consumer"));
+            assertEquals(Long.valueOf(0L), q.namedTailerIndexes().get("consumer"));
+        }
+
+        deleteAllButNewestRollFile(dir);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            long firstIndex = q.firstIndex();
+            assertEquals(q.lastCycle(), q.rollCycle().toCycle(firstIndex));
+            try (ExcerptTailer consumer = q.createTailer("consumer")) {
+                assertEquals(0, consumer.index());
+                assertEquals(2, readNext(consumer, firstIndex));
+            }
+        }
+    }
+
+    @Test
+    public void parkedTailerReadsSameFirstEntryAsNeverReadTailer() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(75_000));
+        writeDailyExcerpts(dir, 3);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            try (ExcerptTailer consumer = q.createTailer("consumer")) {
+                assertEquals(0, readNext(consumer, q.firstIndex()));
+            }
+            assertTrue(q.parkNamedTailer("consumer"));
+        }
+
+        try (SingleChronicleQueue q = builder(dir).build();
+             ExcerptTailer parked = q.createTailer("consumer");
+             ExcerptTailer fresh = q.createTailer("fresh")) {
+            long firstIndex = q.firstIndex();
+            assertEquals(0, parked.index());
+            assertEquals(0, fresh.index());
+
+            assertEquals(0, readNext(parked, firstIndex));
+            assertEquals(0, readNext(fresh, firstIndex));
+            assertEquals(parked.lastReadIndex(), fresh.lastReadIndex());
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ReadonlyNamedTailerIndexesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ReadonlyNamedTailerIndexesTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.NavigableMap;
+import java.util.Set;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+public class ReadonlyNamedTailerIndexesTest extends QueueTestCommon {
+
+    @Test
+    public void readOnlyQueueWithoutMetadataHasNoNamedTailers() {
+        assumeFalse(OS.isWindows());
+        File directory = getTmpDir();
+        Path metadata = directory.toPath().resolve(SingleChronicleQueue.QUEUE_METADATA_FILE);
+        assertFalse(Files.exists(metadata));
+        expectException("Failback to readonly tablestore");
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(directory)
+                .readOnly(true)
+                .build()) {
+            assertTrue(queue.metaStore().readOnly());
+            assertTrue(queue.namedTailerIndexes().isEmpty());
+        }
+
+        assertFalse(Files.exists(metadata));
+    }
+
+    @Test
+    public void readsNamedTailersWithoutWriteAccessOrMetadataMutation() throws Exception {
+        assumeFalse(OS.isWindows());
+        File directory = getTmpDir();
+        long index;
+        try (ChronicleQueue queue = ChronicleQueue.singleBuilder(directory).build();
+             ExcerptTailer tailer = queue.createTailer("readonly-consumer")) {
+            queue.createAppender().writeText("one");
+            assertTrue(tailer.readText().equals("one"));
+            index = tailer.index();
+        }
+
+        Path metadata = directory.toPath().resolve(SingleChronicleQueue.QUEUE_METADATA_FILE);
+        byte[] before = Files.readAllBytes(metadata);
+        Set<PosixFilePermission> original = Files.getPosixFilePermissions(metadata);
+        Set<PosixFilePermission> readOnly = EnumSet.copyOf(original);
+        readOnly.remove(PosixFilePermission.OWNER_WRITE);
+        readOnly.remove(PosixFilePermission.GROUP_WRITE);
+        readOnly.remove(PosixFilePermission.OTHERS_WRITE);
+        Files.setPosixFilePermissions(metadata, readOnly);
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(directory)
+                .readOnly(true)
+                .build()) {
+            assertTrue(queue.metaStore().readOnly());
+            NavigableMap<String, Long> indexes = queue.namedTailerIndexes();
+            assertEquals(Long.valueOf(index), indexes.get("readonly-consumer"));
+        } finally {
+            Files.setPosixFilePermissions(metadata, original);
+        }
+        assertArrayEquals(before, Files.readAllBytes(metadata));
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ReadonlyNamedTailerIndexesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ReadonlyNamedTailerIndexesTest.java
@@ -37,10 +37,26 @@ public class ReadonlyNamedTailerIndexesTest extends QueueTestCommon {
                 .readOnly(true)
                 .build()) {
             assertTrue(queue.metaStore().readOnly());
+            assertTrue(queue.directoryListing() instanceof FileSystemDirectoryListing);
             assertTrue(queue.namedTailerIndexes().isEmpty());
         }
 
         assertFalse(Files.exists(metadata));
+    }
+
+    @Test
+    public void readOnlyQueueWithMetadataUsesPersistedDirectoryListing() {
+        File directory = getTmpDir();
+        try (ChronicleQueue queue = ChronicleQueue.singleBuilder(directory).build()) {
+            queue.createAppender().writeText("one");
+        }
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(directory)
+                .readOnly(true)
+                .build()) {
+            assertTrue(queue.metaStore().readOnly());
+            assertTrue(queue.directoryListing() instanceof TableDirectoryListingReadOnly);
+        }
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SCQMetaRollMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SCQMetaRollMetadataTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
+import org.junit.Test;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+import static org.junit.Assert.assertEquals;
+
+public class SCQMetaRollMetadataTest {
+
+    @Test
+    public void exposesPersistedRollMetadataWithoutExposingSCQRoll() {
+        LocalTime rollTime = LocalTime.of(6, 30);
+        ZoneId rollTimeZone = ZoneId.of("Europe/London");
+        long epoch = 12_345L;
+        SCQMeta metadata = new SCQMeta(new SCQRoll(
+                TestRollCycles.TEST_DAILY, epoch, rollTime, rollTimeZone), 7);
+
+        assertEquals(TestRollCycles.TEST_DAILY.lengthInMillis(),
+                metadata.rollLengthInMillis());
+        assertEquals(TestRollCycles.TEST_DAILY.format(), metadata.rollFormat());
+        assertEquals(epoch, metadata.rollEpoch());
+        assertEquals(rollTime, metadata.rollTime());
+        assertEquals(rollTimeZone, metadata.rollTimeZone());
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -82,6 +82,34 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     }
 
     @Test
+    public void namedTailerIndexesReturnsDetachedSnapshot() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(15_000));
+        writeDailyExcerpts(dir, 2);
+
+        try (SingleChronicleQueue q = builder(dir).build();
+             ExcerptTailer existing = q.createTailer("existing")) {
+            long firstIndex = q.rollCycle().toIndex(q.firstCycle(), 0);
+            long lastIndex = q.rollCycle().toIndex(q.lastCycle(), 0);
+            assertTrue(existing.moveToIndex(firstIndex));
+
+            NavigableMap<String, Long> snapshot = q.namedTailerIndexes();
+
+            assertTrue(existing.moveToIndex(lastIndex));
+            try (ExcerptTailer later = q.createTailer("later")) {
+                assertTrue(later.moveToIndex(lastIndex));
+            }
+
+            assertEquals(Long.valueOf(firstIndex), snapshot.get("existing"));
+            assertFalse(snapshot.containsKey("later"));
+
+            NavigableMap<String, Long> current = q.namedTailerIndexes();
+            assertEquals(Long.valueOf(lastIndex), current.get("existing"));
+            assertEquals(Long.valueOf(lastIndex), current.get("later"));
+        }
+    }
+
+    @Test
     public void parkNamedTailerResetsExistingNonReplicatedTailer() {
         File dir = getTmpDir();
         timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(20_000));

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.core.time.SystemTimeProvider;
+import net.openhft.chronicle.core.values.LongValue;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
+import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.NavigableMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon {
+
+    private final SetTimeProvider timeProvider = new SetTimeProvider();
+
+    @Before
+    public void useDeterministicSystemTimeProvider() {
+        SystemTimeProvider.CLOCK = timeProvider;
+    }
+
+    @After
+    public void resetSystemTimeProvider() {
+        SystemTimeProvider.CLOCK = SystemTimeProvider.INSTANCE;
+    }
+
+    private static SingleChronicleQueueBuilder builder(File dir) {
+        return SingleChronicleQueueBuilder.single(dir)
+                .rollCycle(TestRollCycles.TEST_DAILY);
+    }
+
+    private void writeDailyExcerpts(File dir, int days) {
+        try (ChronicleQueue queue = builder(dir).build();
+             ExcerptAppender appender = queue.createAppender()) {
+            for (int d = 0; d < days; d++) {
+                try (DocumentContext dc = appender.writingDocument()) {
+                    dc.wire().write("n").int32(d);
+                }
+                timeProvider.advanceMillis(TimeUnit.DAYS.toMillis(1));
+            }
+        }
+    }
+
+    @Test
+    public void namedTailerIndexesReturnsCommittedTailerPositionsOnly() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(10_000));
+        writeDailyExcerpts(dir, 2);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            long gatewayIndex = q.rollCycle().toIndex(q.firstCycle(), 0);
+            try (ExcerptTailer gateway = q.createTailer("gateway")) {
+                assertTrue(gateway.moveToIndex(gatewayIndex));
+            }
+
+            String replicated = SingleChronicleQueue.REPLICATED_NAMED_TAILER_PREFIX + "sink";
+            try (ExcerptTailer sink = q.createTailer(replicated)) {
+                assertTrue(sink.moveToIndex(q.rollCycle().toIndex(q.lastCycle(), 0)));
+            }
+
+            NavigableMap<String, Long> indexes = q.namedTailerIndexes();
+            assertEquals(Long.valueOf(gatewayIndex), indexes.get("gateway"));
+            assertEquals(Long.valueOf(q.rollCycle().toIndex(q.lastCycle(), 0)), indexes.get(replicated));
+            assertTrue(indexes.keySet().stream().noneMatch(k -> k.endsWith(".lock") || k.endsWith(".version")));
+        }
+    }
+
+    @Test
+    public void parkNamedTailerResetsExistingNonReplicatedTailer() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(20_000));
+        writeDailyExcerpts(dir, 3);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            long pinned = q.rollCycle().toIndex(q.firstCycle(), 0);
+            try (ExcerptTailer dead = q.createTailer("dead")) {
+                assertTrue(dead.moveToIndex(pinned));
+            }
+
+            assertTrue(q.parkNamedTailer("dead"));
+            assertEquals(Long.valueOf(0L), q.namedTailerIndexes().get("dead"));
+        }
+    }
+
+    @Test
+    public void parkNamedTailerDoesNotCreateMissingTailer() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(30_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            assertFalse(q.parkNamedTailer("missing"));
+            assertFalse(q.namedTailerIndexes().containsKey("missing"));
+        }
+    }
+
+    @Test
+    public void parkNamedTailerRejectsReservedSuffixesWithoutMutatingMetadata() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(40_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue q = builder(dir).build();
+             LongValue version = q.indexVersionForId("gateway");
+             TableStoreWriteLock lock = q.versionIndexLockForId("gateway")) {
+            version.setValue(42L);
+            lock.lock();
+            try {
+                long lockBefore = q.tableStoreGet("index.gateway.lock");
+
+                assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.version"));
+                assertEquals(42L, version.getValue());
+
+                assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.lock"));
+                assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.LOCK"));
+                assertEquals(lockBefore, q.tableStoreGet("index.gateway.lock"));
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    @Test
+    public void replicatedNamedTailersCannotBeParked() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(50_000));
+        writeDailyExcerpts(dir, 2);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            String name = SingleChronicleQueue.REPLICATED_NAMED_TAILER_PREFIX + "sink";
+            long pinned = q.rollCycle().toIndex(q.firstCycle(), 0);
+            try (ExcerptTailer sink = q.createTailer(name)) {
+                assertTrue(sink.moveToIndex(pinned));
+            }
+            try (LongValue version = q.indexVersionForId(name)) {
+                long versionBefore = version.getValue();
+
+                assertFalse(q.parkNamedTailer(name));
+                assertEquals(Long.valueOf(pinned), q.namedTailerIndexes().get(name));
+                assertEquals(versionBefore, version.getValue());
+            }
+        }
+    }
+
+    @Test
+    public void createTailerRejectsLockAndVersionSuffixes() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(60_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            for (String name : new String[]{"gateway.lock", "gateway.LOCK", "gateway.version", "gateway.Version"})
+                assertThrows(IllegalArgumentException.class, () -> q.createTailer(name));
+        }
+    }
+
+    @Test
+    public void fileForCycleReturnsExistingRollFileOnly() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(70_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            File first = q.fileForCycle(q.firstCycle());
+            assertNotNull(first);
+            assertTrue(first.exists());
+            assertNull(q.fileForCycle(q.firstCycle() - 1));
+        }
+    }
+
+    @Test
+    public void namedTailerMetadataApisRejectReservedSuffixes() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(80_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            assertThrows(IllegalArgumentException.class, () -> q.indexForId("gateway.LOCK"));
+            assertThrows(IllegalArgumentException.class, () -> q.indexVersionForId("gateway.version"));
+            assertThrows(IllegalArgumentException.class, () -> q.versionIndexLockForId("gateway.Version"));
+        }
+    }
+
+    @Test
+    public void namedTailerIndexesSupportsConcurrentRegistration() throws Exception {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(90_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue registeringQueue = builder(dir).build();
+             SingleChronicleQueue scanningQueue = builder(dir).build()) {
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            CountDownLatch start = new CountDownLatch(1);
+            try {
+                Future<?> registrations = executor.submit(() -> {
+                    await(start);
+                    for (int i = 0; i < 32; i++) {
+                        try (ExcerptTailer tailer = registeringQueue.createTailer("concurrent-" + i)) {
+                            assertEquals(0, tailer.index());
+                        }
+                    }
+                });
+                Future<?> scans = executor.submit(() -> {
+                    await(start);
+                    for (int i = 0; i < 64; i++)
+                        scanningQueue.namedTailerIndexes();
+                });
+
+                start.countDown();
+                registrations.get(30, TimeUnit.SECONDS);
+                scans.get(30, TimeUnit.SECONDS);
+            } finally {
+                executor.shutdownNow();
+                assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            }
+
+            NavigableMap<String, Long> indexes = scanningQueue.namedTailerIndexes();
+            for (int i = 0; i < 32; i++)
+                assertEquals(Long.valueOf(0), indexes.get("concurrent-" + i));
+        }
+    }
+
+    @Test
+    public void parkedNamedTailerRemainsParkedAfterQueueRestart() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(100_000));
+        writeDailyExcerpts(dir, 3);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            long firstIndex = q.rollCycle().toIndex(q.firstCycle(), 0);
+            try (ExcerptTailer tailer = q.createTailer("parked")) {
+                assertTrue(tailer.moveToIndex(firstIndex));
+            }
+            assertTrue(q.parkNamedTailer("parked"));
+        }
+
+        try (SingleChronicleQueue q = builder(dir).build();
+             ExcerptTailer tailer = q.createTailer("parked")) {
+            assertEquals(0, tailer.index());
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.NavigableMap;
+import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -88,6 +89,19 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             assertEquals(Long.valueOf(q.rollCycle().toIndex(q.lastCycle(), 0)), indexes.get(replicated));
             assertTrue(indexes.keySet().stream().noneMatch(k -> k.endsWith(".lock") || k.endsWith(".version")));
         }
+    }
+
+    @Test
+    public void namedTailerIndexesKeepCaseVariantIdsSeparate() {
+        NavigableMap<String, Long> metadataIndexes = new TreeMap<>();
+        metadataIndexes.put("Gateway", 1L);
+        metadataIndexes.put("gateway", 2L);
+
+        NavigableMap<String, Long> indexes = SingleChronicleQueue.selectNamedTailerIndexes(metadataIndexes);
+
+        assertEquals(2, indexes.size());
+        assertEquals(Long.valueOf(1L), indexes.get("Gateway"));
+        assertEquals(Long.valueOf(2L), indexes.get("gateway"));
     }
 
     @Test
@@ -179,7 +193,7 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
 
         try (SingleChronicleQueue q = builder(dir).build()) {
             assertEquals(NamedTailerParkResult.NOT_FOUND, q.parkNamedTailer("missing"));
-            assertEquals(NamedTailerParkResult.INVALID_NAME, q.parkNamedTailer(null));
+            assertThrows(NullPointerException.class, () -> q.parkNamedTailer(null));
             assertFalse(q.namedTailerIndexes().containsKey("missing"));
         }
     }
@@ -198,10 +212,14 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             try {
                 long lockBefore = q.tableStoreGet("index.gateway.lock");
 
-                assertEquals(NamedTailerParkResult.INVALID_NAME, q.parkNamedTailer("gateway.version"));
+                IllegalArgumentException versionException = assertThrows(IllegalArgumentException.class,
+                        () -> q.parkNamedTailer("gateway.version"));
+                assertTrue(versionException.getMessage().contains("would collide with the metadata"));
                 assertEquals(42L, version.getValue());
 
-                assertEquals(NamedTailerParkResult.INVALID_NAME, q.parkNamedTailer("gateway.lock"));
+                IllegalArgumentException lockException = assertThrows(IllegalArgumentException.class,
+                        () -> q.parkNamedTailer("gateway.lock"));
+                assertTrue(lockException.getMessage().contains("would collide with the metadata"));
                 assertEquals(lockBefore, q.tableStoreGet("index.gateway.lock"));
             } finally {
                 lock.unlock();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -44,16 +44,23 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
 
     private static SingleChronicleQueueBuilder builder(File dir) {
         return SingleChronicleQueueBuilder.single(dir)
-                .rollCycle(TestRollCycles.TEST_DAILY);
+                .rollCycle(TestRollCycles.TEST_DAILY)
+                .timeProvider(SystemTimeProvider.CLOCK);
     }
 
     private void writeDailyExcerpts(File dir, int days) {
         try (ChronicleQueue queue = builder(dir).build();
              ExcerptAppender appender = queue.createAppender()) {
+            int firstCycle = Integer.MIN_VALUE;
             for (int d = 0; d < days; d++) {
                 try (DocumentContext dc = appender.writingDocument()) {
                     dc.wire().write("n").int32(d);
                 }
+                int cycle = queue.rollCycle().toCycle(appender.lastIndexAppended());
+                if (d == 0)
+                    firstCycle = cycle;
+                assertEquals("each simulated day must use a distinct roll cycle",
+                        firstCycle + d, cycle);
                 timeProvider.advanceMillis(TimeUnit.DAYS.toMillis(1));
             }
         }
@@ -253,7 +260,7 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     @Test
     public void namedTailerMetadataApisRejectReservedSuffixes() {
         File dir = getTmpDir();
-        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(80_000));
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(62_000));
         writeDailyExcerpts(dir, 1);
 
         try (SingleChronicleQueue q = builder(dir).build()) {
@@ -276,7 +283,7 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     @Test
     public void namedTailerIndexesSupportsConcurrentRegistration() throws Exception {
         File dir = getTmpDir();
-        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(90_000));
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(68_000));
         writeDailyExcerpts(dir, 1);
 
         try (SingleChronicleQueue registeringQueue = builder(dir).build();
@@ -315,7 +322,7 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     @Test
     public void parkedNamedTailerRemainsParkedAfterQueueRestart() {
         File dir = getTmpDir();
-        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(100_000));
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(72_000));
         writeDailyExcerpts(dir, 3);
 
         try (SingleChronicleQueue q = builder(dir).build()) {
@@ -343,7 +350,7 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
 
     private void assertNamedTailerRegistrationWaitsForMetadataLock(boolean shared) throws Exception {
         File dir = getTmpDir();
-        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(shared ? 85_000 : 84_000));
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(shared ? 66_000 : 65_000));
         writeDailyExcerpts(dir, 1);
 
         File metadataFile = new File(dir, SingleChronicleQueue.QUEUE_METADATA_FILE);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -96,12 +96,15 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
         NavigableMap<String, Long> metadataIndexes = new TreeMap<>();
         metadataIndexes.put("Gateway", 1L);
         metadataIndexes.put("gateway", 2L);
+        metadataIndexes.put("gateway.lock", 3L);
 
+        expectException("Named tailer id 'gateway.lock'");
         NavigableMap<String, Long> indexes = SingleChronicleQueue.selectNamedTailerIndexes(metadataIndexes);
 
-        assertEquals(2, indexes.size());
+        assertEquals(3, indexes.size());
         assertEquals(Long.valueOf(1L), indexes.get("Gateway"));
         assertEquals(Long.valueOf(2L), indexes.get("gateway"));
+        assertEquals(Long.valueOf(3L), indexes.get("gateway.lock"));
     }
 
     @Test
@@ -126,13 +129,13 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             q.tableStorePut("index." + replicated + ".Version.version", 1);
 
             expectException("Named tailer id 'gateway.LOCK'");
-            expectException("Named tailer id '" + replicated + ".LOCK'");
-            expectException("Named tailer id '" + replicated + ".Version'");
+            expectException("Named tailer id '" + replicated + ".lock'");
+            expectException("Named tailer id '" + replicated + ".version'");
             NavigableMap<String, Long> indexes = q.namedTailerIndexes();
 
             assertEquals(Long.valueOf(index), indexes.get("gateway.LOCK"));
-            assertEquals(Long.valueOf(index), indexes.get(replicated + ".LOCK"));
-            assertEquals(Long.valueOf(index), indexes.get(replicated + ".Version"));
+            assertEquals(Long.valueOf(index), indexes.get(replicated + ".lock"));
+            assertEquals(Long.valueOf(index), indexes.get(replicated + ".version"));
             assertFalse(indexes.containsKey(replicated + ".LOCK.lock"));
             assertFalse(indexes.containsKey(replicated + ".LOCK.version"));
             assertFalse(indexes.containsKey(replicated + ".Version.lock"));
@@ -241,45 +244,74 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             }
             try (LongValue version = q.indexVersionForId(name)) {
                 long versionBefore = version.getValue();
+                long lockBefore = q.tableStoreGet("index." + name + ".lock");
+                NavigableMap<String, Long> indexesBefore = q.namedTailerIndexes();
 
                 assertEquals(NamedTailerParkResult.REFUSED_REPLICATED, q.parkNamedTailer(name));
+                assertEquals(NamedTailerParkResult.REFUSED_REPLICATED,
+                        q.parkNamedTailer("Replicated:sink"));
                 assertEquals(Long.valueOf(pinned), q.namedTailerIndexes().get(name));
                 assertEquals(versionBefore, version.getValue());
+                assertEquals(lockBefore, q.tableStoreGet("index." + name + ".lock"));
+                assertEquals(indexesBefore, q.namedTailerIndexes());
             }
         }
     }
 
     @Test
-    public void createTailerRejectsExactLowercaseReservedSuffixesOnly() {
+    public void createTailerRejectsReservedSuffixesCaseInsensitively() {
         File dir = getTmpDir();
         timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(60_000));
         writeDailyExcerpts(dir, 1);
 
         try (SingleChronicleQueue q = builder(dir).build()) {
-            for (String name : new String[]{"gateway.lock", "gateway.version"})
+            for (String name : new String[]{"gateway.lock", "gateway.LOCK",
+                    "gateway.version", "gateway.Version"})
                 assertThrows(IllegalArgumentException.class, () -> q.createTailer(name));
-            try (ExcerptTailer lock = q.createTailer("gateway.LOCK");
-                 ExcerptTailer version = q.createTailer("gateway.Version")) {
-                assertEquals(0, lock.index());
-                assertEquals(0, version.index());
+        }
+    }
+
+    @Test
+    public void mixedCaseReservedSuffixCannotBindReplicatedLockMetadata() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(60_500));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            String replicated = SingleChronicleQueue.REPLICATED_NAMED_TAILER_PREFIX + "sink";
+            try (ExcerptTailer tailer = q.createTailer(replicated)) {
+                assertEquals(0, tailer.index());
+            }
+            try (LongValue version = q.indexVersionForId(replicated)) {
+                long lockBefore = q.tableStoreGet("index." + replicated + ".lock");
+                long versionBefore = version.getValue();
+                NavigableMap<String, Long> indexesBefore = q.namedTailerIndexes();
+
+                assertThrows(IllegalArgumentException.class,
+                        () -> q.createTailer(replicated + ".LOCK"));
+
+                assertEquals(lockBefore, q.tableStoreGet("index." + replicated + ".lock"));
+                assertEquals(versionBefore, version.getValue());
+                assertEquals(indexesBefore, q.namedTailerIndexes());
             }
         }
     }
 
     @Test
-    public void parkNamedTailerAcceptsExistingMixedCaseSuffix() {
+    public void parkNamedTailerRejectsExistingMixedCaseSuffixWithoutMutation() {
         File dir = getTmpDir();
         timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(61_000));
         writeDailyExcerpts(dir, 1);
 
         try (SingleChronicleQueue q = builder(dir).build()) {
             final long index = q.rollCycle().toIndex(q.firstCycle(), 0);
-            try (ExcerptTailer tailer = q.createTailer("gateway.LOCK")) {
-                assertTrue(tailer.moveToIndex(index));
-            }
-            assertEquals(NamedTailerParkResult.PARKED, q.parkNamedTailer("gateway.LOCK"));
+            q.tableStorePut("index.gateway.LOCK", index);
+
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> q.parkNamedTailer("gateway.LOCK"));
+            assertTrue(exception.getMessage().contains("would collide with the metadata"));
             expectException("Named tailer id 'gateway.LOCK'");
-            assertEquals(Long.valueOf(0), q.namedTailerIndexes().get("gateway.LOCK"));
+            assertEquals(Long.valueOf(index), q.namedTailerIndexes().get("gateway.LOCK"));
         }
     }
 
@@ -298,20 +330,17 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     }
 
     @Test
-    public void namedTailerMetadataApisRejectExactLowercaseReservedSuffixesOnly() {
+    public void namedTailerMetadataApisRejectReservedSuffixesCaseInsensitively() {
         File dir = getTmpDir();
         timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(62_000));
         writeDailyExcerpts(dir, 1);
 
         try (SingleChronicleQueue q = builder(dir).build()) {
-            assertThrows(IllegalArgumentException.class, () -> q.indexForId("gateway.lock"));
-            assertThrows(IllegalArgumentException.class, () -> q.indexVersionForId("gateway.version"));
-            try (LongValue index = q.indexForId("gateway.LOCK");
-                 LongValue version = q.indexVersionForId("gateway.Version");
-                 TableStoreWriteLock lock = q.versionIndexLockForId("gateway.Version")) {
-                assertNotNull(index);
-                assertNotNull(version);
-                assertNotNull(lock);
+            for (String name : new String[]{"gateway.lock", "gateway.LOCK",
+                    "gateway.version", "gateway.Version"}) {
+                assertThrows(IllegalArgumentException.class, () -> q.indexForId(name));
+                assertThrows(IllegalArgumentException.class, () -> q.indexVersionForId(name));
+                assertThrows(IllegalArgumentException.class, () -> q.versionIndexLockForId(name));
             }
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -10,6 +10,7 @@ import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.impl.table.SingleTableStore;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.junit.After;
@@ -23,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.*;
 
@@ -78,6 +80,35 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             assertEquals(Long.valueOf(gatewayIndex), indexes.get("gateway"));
             assertEquals(Long.valueOf(q.rollCycle().toIndex(q.lastCycle(), 0)), indexes.get(replicated));
             assertTrue(indexes.keySet().stream().noneMatch(k -> k.endsWith(".lock") || k.endsWith(".version")));
+        }
+    }
+
+    @Test
+    public void namedTailerIndexesRetainsDistinguishableLegacyReservedIds() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(12_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            long index = q.firstIndex();
+            String replicated = SingleChronicleQueue.REPLICATED_NAMED_TAILER_PREFIX + "sink";
+            try (ExcerptTailer tailer = q.createTailer(replicated)) {
+                assertEquals(0, tailer.index());
+            }
+
+            q.tableStorePut("index.gateway.LOCK", index);
+            q.tableStorePut("index." + replicated + ".lock", index);
+            q.tableStorePut("index." + replicated + ".lock.lock", Long.MIN_VALUE);
+            q.tableStorePut("index." + replicated + ".lock.version", 1);
+
+            expectException("Legacy named tailer id 'gateway.LOCK'");
+            expectException("Legacy named tailer id '" + replicated + ".lock'");
+            NavigableMap<String, Long> indexes = q.namedTailerIndexes();
+
+            assertEquals(Long.valueOf(index), indexes.get("gateway.LOCK"));
+            assertEquals(Long.valueOf(index), indexes.get(replicated + ".lock"));
+            assertFalse(indexes.containsKey(replicated + ".lock.lock"));
+            assertFalse(indexes.containsKey(replicated + ".lock.version"));
         }
     }
 
@@ -226,6 +257,16 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     }
 
     @Test
+    public void namedTailerRegistrationWaitsForExclusiveMetadataLock() throws Exception {
+        assertNamedTailerRegistrationWaitsForMetadataLock(false);
+    }
+
+    @Test
+    public void namedTailerRegistrationWaitsForSharedMetadataLock() throws Exception {
+        assertNamedTailerRegistrationWaitsForMetadataLock(true);
+    }
+
+    @Test
     public void namedTailerIndexesSupportsConcurrentRegistration() throws Exception {
         File dir = getTmpDir();
         timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(90_000));
@@ -291,5 +332,51 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             Thread.currentThread().interrupt();
             throw new AssertionError(e);
         }
+    }
+
+    private void assertNamedTailerRegistrationWaitsForMetadataLock(boolean shared) throws Exception {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(shared ? 85_000 : 84_000));
+        writeDailyExcerpts(dir, 1);
+
+        File metadataFile = new File(dir, SingleChronicleQueue.QUEUE_METADATA_FILE);
+        CountDownLatch lockAcquired = new CountDownLatch(1);
+        CountDownLatch releaseLock = new CountDownLatch(1);
+        CountDownLatch registrationStarted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try (SingleChronicleQueue queue = builder(dir).build()) {
+            Future<?> lockHolder = executor.submit(() -> {
+                if (shared)
+                    return SingleTableStore.doWithSharedLock(metadataFile,
+                            ignored -> holdLock(lockAcquired, releaseLock), Object::new);
+                return SingleTableStore.doWithExclusiveLock(metadataFile,
+                        ignored -> holdLock(lockAcquired, releaseLock), Object::new);
+            });
+            assertTrue(lockAcquired.await(5, TimeUnit.SECONDS));
+
+            Future<?> registration = executor.submit(() -> {
+                registrationStarted.countDown();
+                try (ExcerptTailer tailer = queue.createTailer("blocked-registration")) {
+                    assertEquals(0, tailer.index());
+                }
+            });
+            assertTrue(registrationStarted.await(5, TimeUnit.SECONDS));
+            assertThrows(TimeoutException.class, () -> registration.get(100, TimeUnit.MILLISECONDS));
+
+            releaseLock.countDown();
+            registration.get(5, TimeUnit.SECONDS);
+            lockHolder.get(5, TimeUnit.SECONDS);
+            assertTrue(queue.namedTailerIndexes().containsKey("blocked-registration"));
+        } finally {
+            releaseLock.countDown();
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    private static Object holdLock(CountDownLatch lockAcquired, CountDownLatch releaseLock) {
+        lockAcquired.countDown();
+        await(releaseLock);
+        return null;
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -111,9 +111,9 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             q.tableStorePut("index." + replicated + ".Version.lock", Long.MIN_VALUE);
             q.tableStorePut("index." + replicated + ".Version.version", 1);
 
-            expectException("Legacy named tailer id 'gateway.LOCK'");
-            expectException("Legacy named tailer id '" + replicated + ".LOCK'");
-            expectException("Legacy named tailer id '" + replicated + ".Version'");
+            expectException("Named tailer id 'gateway.LOCK'");
+            expectException("Named tailer id '" + replicated + ".LOCK'");
+            expectException("Named tailer id '" + replicated + ".Version'");
             NavigableMap<String, Long> indexes = q.namedTailerIndexes();
 
             assertEquals(Long.valueOf(index), indexes.get("gateway.LOCK"));
@@ -202,7 +202,6 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
                 assertEquals(42L, version.getValue());
 
                 assertEquals(NamedTailerParkResult.INVALID_NAME, q.parkNamedTailer("gateway.lock"));
-                assertEquals(NamedTailerParkResult.INVALID_NAME, q.parkNamedTailer("gateway.LOCK"));
                 assertEquals(lockBefore, q.tableStoreGet("index.gateway.lock"));
             } finally {
                 lock.unlock();
@@ -233,14 +232,36 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     }
 
     @Test
-    public void createTailerRejectsLockAndVersionSuffixes() {
+    public void createTailerRejectsExactLowercaseReservedSuffixesOnly() {
         File dir = getTmpDir();
         timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(60_000));
         writeDailyExcerpts(dir, 1);
 
         try (SingleChronicleQueue q = builder(dir).build()) {
-            for (String name : new String[]{"gateway.lock", "gateway.LOCK", "gateway.version", "gateway.Version"})
+            for (String name : new String[]{"gateway.lock", "gateway.version"})
                 assertThrows(IllegalArgumentException.class, () -> q.createTailer(name));
+            try (ExcerptTailer lock = q.createTailer("gateway.LOCK");
+                 ExcerptTailer version = q.createTailer("gateway.Version")) {
+                assertEquals(0, lock.index());
+                assertEquals(0, version.index());
+            }
+        }
+    }
+
+    @Test
+    public void parkNamedTailerAcceptsExistingMixedCaseSuffix() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(61_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            final long index = q.rollCycle().toIndex(q.firstCycle(), 0);
+            try (ExcerptTailer tailer = q.createTailer("gateway.LOCK")) {
+                assertTrue(tailer.moveToIndex(index));
+            }
+            assertEquals(NamedTailerParkResult.PARKED, q.parkNamedTailer("gateway.LOCK"));
+            expectException("Named tailer id 'gateway.LOCK'");
+            assertEquals(Long.valueOf(0), q.namedTailerIndexes().get("gateway.LOCK"));
         }
     }
 
@@ -259,15 +280,21 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     }
 
     @Test
-    public void namedTailerMetadataApisRejectReservedSuffixes() {
+    public void namedTailerMetadataApisRejectExactLowercaseReservedSuffixesOnly() {
         File dir = getTmpDir();
         timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(62_000));
         writeDailyExcerpts(dir, 1);
 
         try (SingleChronicleQueue q = builder(dir).build()) {
-            assertThrows(IllegalArgumentException.class, () -> q.indexForId("gateway.LOCK"));
+            assertThrows(IllegalArgumentException.class, () -> q.indexForId("gateway.lock"));
             assertThrows(IllegalArgumentException.class, () -> q.indexVersionForId("gateway.version"));
-            assertThrows(IllegalArgumentException.class, () -> q.versionIndexLockForId("gateway.Version"));
+            try (LongValue index = q.indexForId("gateway.LOCK");
+                 LongValue version = q.indexVersionForId("gateway.Version");
+                 TableStoreWriteLock lock = q.versionIndexLockForId("gateway.Version")) {
+                assertNotNull(index);
+                assertNotNull(version);
+                assertNotNull(lock);
+            }
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -166,7 +166,7 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
                 assertTrue(dead.moveToIndex(pinned));
             }
 
-            assertTrue(q.parkNamedTailer("dead"));
+            assertEquals(NamedTailerParkResult.PARKED, q.parkNamedTailer("dead"));
             assertEquals(Long.valueOf(0L), q.namedTailerIndexes().get("dead"));
         }
     }
@@ -178,7 +178,8 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
         writeDailyExcerpts(dir, 1);
 
         try (SingleChronicleQueue q = builder(dir).build()) {
-            assertFalse(q.parkNamedTailer("missing"));
+            assertEquals(NamedTailerParkResult.NOT_FOUND, q.parkNamedTailer("missing"));
+            assertEquals(NamedTailerParkResult.INVALID_NAME, q.parkNamedTailer(null));
             assertFalse(q.namedTailerIndexes().containsKey("missing"));
         }
     }
@@ -197,11 +198,11 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             try {
                 long lockBefore = q.tableStoreGet("index.gateway.lock");
 
-                assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.version"));
+                assertEquals(NamedTailerParkResult.INVALID_NAME, q.parkNamedTailer("gateway.version"));
                 assertEquals(42L, version.getValue());
 
-                assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.lock"));
-                assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.LOCK"));
+                assertEquals(NamedTailerParkResult.INVALID_NAME, q.parkNamedTailer("gateway.lock"));
+                assertEquals(NamedTailerParkResult.INVALID_NAME, q.parkNamedTailer("gateway.LOCK"));
                 assertEquals(lockBefore, q.tableStoreGet("index.gateway.lock"));
             } finally {
                 lock.unlock();
@@ -224,7 +225,7 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             try (LongValue version = q.indexVersionForId(name)) {
                 long versionBefore = version.getValue();
 
-                assertFalse(q.parkNamedTailer(name));
+                assertEquals(NamedTailerParkResult.REFUSED_REPLICATED, q.parkNamedTailer(name));
                 assertEquals(Long.valueOf(pinned), q.namedTailerIndexes().get(name));
                 assertEquals(versionBefore, version.getValue());
             }
@@ -330,7 +331,7 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
             try (ExcerptTailer tailer = q.createTailer("parked")) {
                 assertTrue(tailer.moveToIndex(firstIndex));
             }
-            assertTrue(q.parkNamedTailer("parked"));
+            assertEquals(NamedTailerParkResult.PARKED, q.parkNamedTailer("parked"));
         }
 
         try (SingleChronicleQueue q = builder(dir).build();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -4,6 +4,7 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.core.time.SystemTimeProvider;
 import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
@@ -11,30 +12,47 @@ import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.NavigableMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
 public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon {
 
-    private static SingleChronicleQueueBuilder builder(File dir, SetTimeProvider time) {
-        return SingleChronicleQueueBuilder.single(dir)
-                .rollCycle(TestRollCycles.TEST_DAILY)
-                .timeProvider(time);
+    private final SetTimeProvider timeProvider = new SetTimeProvider();
+
+    @Before
+    public void useDeterministicSystemTimeProvider() {
+        SystemTimeProvider.CLOCK = timeProvider;
     }
 
-    private static void writeDailyExcerpts(File dir, SetTimeProvider time, int days) {
-        try (ChronicleQueue queue = builder(dir, time).build();
+    @After
+    public void resetSystemTimeProvider() {
+        SystemTimeProvider.CLOCK = SystemTimeProvider.INSTANCE;
+    }
+
+    private static SingleChronicleQueueBuilder builder(File dir) {
+        return SingleChronicleQueueBuilder.single(dir)
+                .rollCycle(TestRollCycles.TEST_DAILY);
+    }
+
+    private void writeDailyExcerpts(File dir, int days) {
+        try (ChronicleQueue queue = builder(dir).build();
              ExcerptAppender appender = queue.createAppender()) {
             for (int d = 0; d < days; d++) {
                 try (DocumentContext dc = appender.writingDocument()) {
                     dc.wire().write("n").int32(d);
                 }
-                time.advanceMillis(TimeUnit.DAYS.toMillis(1));
+                timeProvider.advanceMillis(TimeUnit.DAYS.toMillis(1));
             }
         }
     }
@@ -42,10 +60,10 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     @Test
     public void namedTailerIndexesReturnsCommittedTailerPositionsOnly() {
         File dir = getTmpDir();
-        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(10_000));
-        writeDailyExcerpts(dir, time, 2);
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(10_000));
+        writeDailyExcerpts(dir, 2);
 
-        try (SingleChronicleQueue q = builder(dir, time).build()) {
+        try (SingleChronicleQueue q = builder(dir).build()) {
             long gatewayIndex = q.rollCycle().toIndex(q.firstCycle(), 0);
             try (ExcerptTailer gateway = q.createTailer("gateway")) {
                 assertTrue(gateway.moveToIndex(gatewayIndex));
@@ -66,10 +84,10 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     @Test
     public void parkNamedTailerResetsExistingNonReplicatedTailer() {
         File dir = getTmpDir();
-        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(20_000));
-        writeDailyExcerpts(dir, time, 3);
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(20_000));
+        writeDailyExcerpts(dir, 3);
 
-        try (SingleChronicleQueue q = builder(dir, time).build()) {
+        try (SingleChronicleQueue q = builder(dir).build()) {
             long pinned = q.rollCycle().toIndex(q.firstCycle(), 0);
             try (ExcerptTailer dead = q.createTailer("dead")) {
                 assertTrue(dead.moveToIndex(pinned));
@@ -83,10 +101,10 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     @Test
     public void parkNamedTailerDoesNotCreateMissingTailer() {
         File dir = getTmpDir();
-        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(30_000));
-        writeDailyExcerpts(dir, time, 1);
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(30_000));
+        writeDailyExcerpts(dir, 1);
 
-        try (SingleChronicleQueue q = builder(dir, time).build()) {
+        try (SingleChronicleQueue q = builder(dir).build()) {
             assertFalse(q.parkNamedTailer("missing"));
             assertFalse(q.namedTailerIndexes().containsKey("missing"));
         }
@@ -95,10 +113,10 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     @Test
     public void parkNamedTailerRejectsReservedSuffixesWithoutMutatingMetadata() {
         File dir = getTmpDir();
-        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(40_000));
-        writeDailyExcerpts(dir, time, 1);
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(40_000));
+        writeDailyExcerpts(dir, 1);
 
-        try (SingleChronicleQueue q = builder(dir, time).build();
+        try (SingleChronicleQueue q = builder(dir).build();
              LongValue version = q.indexVersionForId("gateway");
              TableStoreWriteLock lock = q.versionIndexLockForId("gateway")) {
             version.setValue(42L);
@@ -110,6 +128,7 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
                 assertEquals(42L, version.getValue());
 
                 assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.lock"));
+                assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.LOCK"));
                 assertEquals(lockBefore, q.tableStoreGet("index.gateway.lock"));
             } finally {
                 lock.unlock();
@@ -120,10 +139,10 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     @Test
     public void replicatedNamedTailersCannotBeParked() {
         File dir = getTmpDir();
-        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(50_000));
-        writeDailyExcerpts(dir, time, 2);
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(50_000));
+        writeDailyExcerpts(dir, 2);
 
-        try (SingleChronicleQueue q = builder(dir, time).build()) {
+        try (SingleChronicleQueue q = builder(dir).build()) {
             String name = SingleChronicleQueue.REPLICATED_NAMED_TAILER_PREFIX + "sink";
             long pinned = q.rollCycle().toIndex(q.firstCycle(), 0);
             try (ExcerptTailer sink = q.createTailer(name)) {
@@ -142,26 +161,107 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
     @Test
     public void createTailerRejectsLockAndVersionSuffixes() {
         File dir = getTmpDir();
-        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(60_000));
-        writeDailyExcerpts(dir, time, 1);
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(60_000));
+        writeDailyExcerpts(dir, 1);
 
-        try (SingleChronicleQueue q = builder(dir, time).build()) {
-            assertThrows(IllegalArgumentException.class, () -> q.createTailer("gateway.lock"));
-            assertThrows(IllegalArgumentException.class, () -> q.createTailer("gateway.version"));
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            for (String name : new String[]{"gateway.lock", "gateway.LOCK", "gateway.version", "gateway.Version"})
+                assertThrows(IllegalArgumentException.class, () -> q.createTailer(name));
         }
     }
 
     @Test
     public void fileForCycleReturnsExistingRollFileOnly() {
         File dir = getTmpDir();
-        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(70_000));
-        writeDailyExcerpts(dir, time, 1);
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(70_000));
+        writeDailyExcerpts(dir, 1);
 
-        try (SingleChronicleQueue q = builder(dir, time).build()) {
+        try (SingleChronicleQueue q = builder(dir).build()) {
             File first = q.fileForCycle(q.firstCycle());
             assertNotNull(first);
             assertTrue(first.exists());
             assertNull(q.fileForCycle(q.firstCycle() - 1));
+        }
+    }
+
+    @Test
+    public void namedTailerMetadataApisRejectReservedSuffixes() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(80_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            assertThrows(IllegalArgumentException.class, () -> q.indexForId("gateway.LOCK"));
+            assertThrows(IllegalArgumentException.class, () -> q.indexVersionForId("gateway.version"));
+            assertThrows(IllegalArgumentException.class, () -> q.versionIndexLockForId("gateway.Version"));
+        }
+    }
+
+    @Test
+    public void namedTailerIndexesSupportsConcurrentRegistration() throws Exception {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(90_000));
+        writeDailyExcerpts(dir, 1);
+
+        try (SingleChronicleQueue registeringQueue = builder(dir).build();
+             SingleChronicleQueue scanningQueue = builder(dir).build()) {
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            CountDownLatch start = new CountDownLatch(1);
+            try {
+                Future<?> registrations = executor.submit(() -> {
+                    await(start);
+                    for (int i = 0; i < 32; i++) {
+                        try (ExcerptTailer tailer = registeringQueue.createTailer("concurrent-" + i)) {
+                            assertEquals(0, tailer.index());
+                        }
+                    }
+                });
+                Future<?> scans = executor.submit(() -> {
+                    await(start);
+                    for (int i = 0; i < 64; i++)
+                        scanningQueue.namedTailerIndexes();
+                });
+
+                start.countDown();
+                registrations.get(30, TimeUnit.SECONDS);
+                scans.get(30, TimeUnit.SECONDS);
+            } finally {
+                executor.shutdownNow();
+                assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            }
+
+            NavigableMap<String, Long> indexes = scanningQueue.namedTailerIndexes();
+            for (int i = 0; i < 32; i++)
+                assertEquals(Long.valueOf(0), indexes.get("concurrent-" + i));
+        }
+    }
+
+    @Test
+    public void parkedNamedTailerRemainsParkedAfterQueueRestart() {
+        File dir = getTmpDir();
+        timeProvider.currentTimeNanos(TimeUnit.DAYS.toNanos(100_000));
+        writeDailyExcerpts(dir, 3);
+
+        try (SingleChronicleQueue q = builder(dir).build()) {
+            long firstIndex = q.rollCycle().toIndex(q.firstCycle(), 0);
+            try (ExcerptTailer tailer = q.createTailer("parked")) {
+                assertTrue(tailer.moveToIndex(firstIndex));
+            }
+            assertTrue(q.parkNamedTailer("parked"));
+        }
+
+        try (SingleChronicleQueue q = builder(dir).build();
+             ExcerptTailer tailer = q.createTailer("parked")) {
+            assertEquals(0, tailer.index());
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.core.values.LongValue;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
+import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.NavigableMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon {
+
+    private static SingleChronicleQueueBuilder builder(File dir, SetTimeProvider time) {
+        return SingleChronicleQueueBuilder.single(dir)
+                .rollCycle(TestRollCycles.TEST_DAILY)
+                .timeProvider(time);
+    }
+
+    private static void writeDailyExcerpts(File dir, SetTimeProvider time, int days) {
+        try (ChronicleQueue queue = builder(dir, time).build();
+             ExcerptAppender appender = queue.createAppender()) {
+            for (int d = 0; d < days; d++) {
+                try (DocumentContext dc = appender.writingDocument()) {
+                    dc.wire().write("n").int32(d);
+                }
+                time.advanceMillis(TimeUnit.DAYS.toMillis(1));
+            }
+        }
+    }
+
+    @Test
+    public void namedTailerIndexesReturnsCommittedTailerPositionsOnly() {
+        File dir = getTmpDir();
+        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(10_000));
+        writeDailyExcerpts(dir, time, 2);
+
+        try (SingleChronicleQueue q = builder(dir, time).build()) {
+            long gatewayIndex = q.rollCycle().toIndex(q.firstCycle(), 0);
+            try (ExcerptTailer gateway = q.createTailer("gateway")) {
+                assertTrue(gateway.moveToIndex(gatewayIndex));
+            }
+
+            String replicated = SingleChronicleQueue.REPLICATED_NAMED_TAILER_PREFIX + "sink";
+            try (ExcerptTailer sink = q.createTailer(replicated)) {
+                assertTrue(sink.moveToIndex(q.rollCycle().toIndex(q.lastCycle(), 0)));
+            }
+
+            NavigableMap<String, Long> indexes = q.namedTailerIndexes();
+            assertEquals(Long.valueOf(gatewayIndex), indexes.get("gateway"));
+            assertEquals(Long.valueOf(q.rollCycle().toIndex(q.lastCycle(), 0)), indexes.get(replicated));
+            assertTrue(indexes.keySet().stream().noneMatch(k -> k.endsWith(".lock") || k.endsWith(".version")));
+        }
+    }
+
+    @Test
+    public void parkNamedTailerResetsExistingNonReplicatedTailer() {
+        File dir = getTmpDir();
+        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(20_000));
+        writeDailyExcerpts(dir, time, 3);
+
+        try (SingleChronicleQueue q = builder(dir, time).build()) {
+            long pinned = q.rollCycle().toIndex(q.firstCycle(), 0);
+            try (ExcerptTailer dead = q.createTailer("dead")) {
+                assertTrue(dead.moveToIndex(pinned));
+            }
+
+            assertTrue(q.parkNamedTailer("dead"));
+            assertEquals(Long.valueOf(0L), q.namedTailerIndexes().get("dead"));
+        }
+    }
+
+    @Test
+    public void parkNamedTailerDoesNotCreateMissingTailer() {
+        File dir = getTmpDir();
+        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(30_000));
+        writeDailyExcerpts(dir, time, 1);
+
+        try (SingleChronicleQueue q = builder(dir, time).build()) {
+            assertFalse(q.parkNamedTailer("missing"));
+            assertFalse(q.namedTailerIndexes().containsKey("missing"));
+        }
+    }
+
+    @Test
+    public void parkNamedTailerRejectsReservedSuffixesWithoutMutatingMetadata() {
+        File dir = getTmpDir();
+        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(40_000));
+        writeDailyExcerpts(dir, time, 1);
+
+        try (SingleChronicleQueue q = builder(dir, time).build();
+             LongValue version = q.indexVersionForId("gateway");
+             TableStoreWriteLock lock = q.versionIndexLockForId("gateway")) {
+            version.setValue(42L);
+            lock.lock();
+            try {
+                long lockBefore = q.tableStoreGet("index.gateway.lock");
+
+                assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.version"));
+                assertEquals(42L, version.getValue());
+
+                assertThrows(IllegalArgumentException.class, () -> q.parkNamedTailer("gateway.lock"));
+                assertEquals(lockBefore, q.tableStoreGet("index.gateway.lock"));
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    @Test
+    public void replicatedNamedTailersCannotBeParked() {
+        File dir = getTmpDir();
+        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(50_000));
+        writeDailyExcerpts(dir, time, 2);
+
+        try (SingleChronicleQueue q = builder(dir, time).build()) {
+            String name = SingleChronicleQueue.REPLICATED_NAMED_TAILER_PREFIX + "sink";
+            long pinned = q.rollCycle().toIndex(q.firstCycle(), 0);
+            try (ExcerptTailer sink = q.createTailer(name)) {
+                assertTrue(sink.moveToIndex(pinned));
+            }
+            try (LongValue version = q.indexVersionForId(name)) {
+                long versionBefore = version.getValue();
+
+                assertFalse(q.parkNamedTailer(name));
+                assertEquals(Long.valueOf(pinned), q.namedTailerIndexes().get(name));
+                assertEquals(versionBefore, version.getValue());
+            }
+        }
+    }
+
+    @Test
+    public void createTailerRejectsLockAndVersionSuffixes() {
+        File dir = getTmpDir();
+        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(60_000));
+        writeDailyExcerpts(dir, time, 1);
+
+        try (SingleChronicleQueue q = builder(dir, time).build()) {
+            assertThrows(IllegalArgumentException.class, () -> q.createTailer("gateway.lock"));
+            assertThrows(IllegalArgumentException.class, () -> q.createTailer("gateway.version"));
+        }
+    }
+
+    @Test
+    public void fileForCycleReturnsExistingRollFileOnly() {
+        File dir = getTmpDir();
+        SetTimeProvider time = new SetTimeProvider(TimeUnit.DAYS.toNanos(70_000));
+        writeDailyExcerpts(dir, time, 1);
+
+        try (SingleChronicleQueue q = builder(dir, time).build()) {
+            File first = q.fileForCycle(q.firstCycle());
+            assertNotNull(first);
+            assertTrue(first.exists());
+            assertNull(q.fileForCycle(q.firstCycle() - 1));
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueNamedTailerMetadataTest.java
@@ -98,17 +98,24 @@ public class SingleChronicleQueueNamedTailerMetadataTest extends QueueTestCommon
 
             q.tableStorePut("index.gateway.LOCK", index);
             q.tableStorePut("index." + replicated + ".lock", index);
-            q.tableStorePut("index." + replicated + ".lock.lock", Long.MIN_VALUE);
-            q.tableStorePut("index." + replicated + ".lock.version", 1);
+            q.tableStorePut("index." + replicated + ".LOCK.lock", Long.MIN_VALUE);
+            q.tableStorePut("index." + replicated + ".LOCK.version", 1);
+            q.tableStorePut("index." + replicated + ".Version", index);
+            q.tableStorePut("index." + replicated + ".Version.lock", Long.MIN_VALUE);
+            q.tableStorePut("index." + replicated + ".Version.version", 1);
 
             expectException("Legacy named tailer id 'gateway.LOCK'");
-            expectException("Legacy named tailer id '" + replicated + ".lock'");
+            expectException("Legacy named tailer id '" + replicated + ".LOCK'");
+            expectException("Legacy named tailer id '" + replicated + ".Version'");
             NavigableMap<String, Long> indexes = q.namedTailerIndexes();
 
             assertEquals(Long.valueOf(index), indexes.get("gateway.LOCK"));
-            assertEquals(Long.valueOf(index), indexes.get(replicated + ".lock"));
-            assertFalse(indexes.containsKey(replicated + ".lock.lock"));
-            assertFalse(indexes.containsKey(replicated + ".lock.version"));
+            assertEquals(Long.valueOf(index), indexes.get(replicated + ".LOCK"));
+            assertEquals(Long.valueOf(index), indexes.get(replicated + ".Version"));
+            assertFalse(indexes.containsKey(replicated + ".LOCK.lock"));
+            assertFalse(indexes.containsKey(replicated + ".LOCK.version"));
+            assertFalse(indexes.containsKey(replicated + ".Version.lock"));
+            assertFalse(indexes.containsKey(replicated + ".Version.version"));
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreForEachKeyGuardTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreForEachKeyGuardTest.java
@@ -3,9 +3,13 @@
  */
 package net.openhft.chronicle.queue.impl.table;
 
+import net.openhft.chronicle.bytes.Byteable;
+import net.openhft.chronicle.bytes.MappedBytes;
+import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.TableStore;
+import net.openhft.chronicle.wire.WireType;
 import org.junit.Test;
 
 import java.io.File;
@@ -20,9 +24,58 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class SingleTableStoreForEachKeyGuardTest extends QueueTestCommon {
+
+    @Test
+    public void laterScanSeesEntriesAppendedByAnotherStore() throws Exception {
+        File directory = getTmpDir();
+        assertTrue(directory.mkdirs());
+        File tableFile = Files.createTempFile(directory.toPath(), "table", SingleTableStore.SUFFIX).toFile();
+
+        try (TableStore<Metadata.NoMeta> writer =
+                     SingleTableBuilder.binary(tableFile, Metadata.NoMeta.INSTANCE).build()) {
+            try (LongValue initial = writer.acquireValueFor("initial-key", 1)) {
+                assertEquals(1, initial.getValue());
+            }
+
+            MappedBytes scannerBytes = MappedBytes.mappedBytes(
+                    tableFile, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, false);
+            scannerBytes.singleThreadedCheckDisabled(true);
+
+            try (SingleTableStore<Metadata.NoMeta> scanner = new SingleTableStore<>(
+                    WireType.BINARY_LIGHT, scannerBytes, Metadata.NoMeta.INSTANCE)) {
+                final String latestKey = "later-key";
+                final long latestOffset;
+                try (LongValue value = writer.acquireValueFor(latestKey, 2)) {
+                    assertEquals(2, value.getValue());
+                    latestOffset = ((Byteable) value).offset();
+                }
+                assertTrue(latestOffset > 0);
+
+                // Model a local limit captured while another store was still appending the entry.
+                final long staleWriteLimit = latestOffset - 1;
+                scannerBytes.writePosition(staleWriteLimit);
+                scannerBytes.writeLimit(staleWriteLimit);
+
+                try (LongValue value = scanner.getValueFor(latestKey)) {
+                    assertNotNull(value);
+                    assertEquals(2, value.getValue());
+                }
+
+                scannerBytes.writePosition(staleWriteLimit);
+                scannerBytes.writeLimit(staleWriteLimit);
+                Set<String> keys = new HashSet<>();
+                scanner.forEachKey(keys, (result, key, value) -> {
+                    result.add(key.toString());
+                    value.int64();
+                });
+                assertTrue(keys.contains(latestKey));
+            }
+        }
+    }
 
     @Test
     public void scansWhileAnotherStoreAppendsKeys() throws Exception {

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreForEachKeyGuardTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreForEachKeyGuardTest.java
@@ -64,6 +64,7 @@ public class SingleTableStoreForEachKeyGuardTest extends QueueTestCommon {
                     assertNotNull(value);
                     assertEquals(2, value.getValue());
                 }
+                assertEquals(staleWriteLimit, scannerBytes.writeLimit());
 
                 scannerBytes.writePosition(staleWriteLimit);
                 scannerBytes.writeLimit(staleWriteLimit);
@@ -73,6 +74,7 @@ public class SingleTableStoreForEachKeyGuardTest extends QueueTestCommon {
                     value.int64();
                 });
                 assertTrue(keys.contains(latestKey));
+                assertEquals(staleWriteLimit, scannerBytes.writeLimit());
             }
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreForEachKeyGuardTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreForEachKeyGuardTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.table;
+
+import net.openhft.chronicle.core.values.LongValue;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.impl.TableStore;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SingleTableStoreForEachKeyGuardTest extends QueueTestCommon {
+
+    @Test
+    public void scansWhileAnotherStoreAppendsKeys() throws Exception {
+        File directory = getTmpDir();
+        assertTrue(directory.mkdirs());
+        File tableFile = Files.createTempFile(directory.toPath(), "table", SingleTableStore.SUFFIX).toFile();
+
+        try (TableStore<Metadata.NoMeta> writer =
+                     SingleTableBuilder.binary(tableFile, Metadata.NoMeta.INSTANCE).build();
+             TableStore<Metadata.NoMeta> scanner =
+                     SingleTableBuilder.binary(tableFile, Metadata.NoMeta.INSTANCE).build()) {
+            int keyCount = 2_000;
+            CountDownLatch start = new CountDownLatch(1);
+            AtomicBoolean writing = new AtomicBoolean(true);
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            try {
+                Future<?> writes = executor.submit(() -> {
+                    await(start);
+                    try {
+                        for (int i = 0; i < keyCount; i++) {
+                            try (LongValue value = writer.acquireValueFor("key-" + i, i)) {
+                                assertEquals(i, value.getValue());
+                            }
+                        }
+                    } finally {
+                        writing.set(false);
+                    }
+                });
+                Future<?> scans = executor.submit(() -> {
+                    await(start);
+                    int scanCount = 0;
+                    do {
+                        scanner.forEachKey(new HashSet<>(), (keys, key, value) -> {
+                            keys.add(key.toString());
+                            value.int64();
+                        });
+                        scanCount++;
+                    } while (writing.get() || scanCount < 1_000);
+                });
+
+                start.countDown();
+                writes.get(30, TimeUnit.SECONDS);
+                scans.get(30, TimeUnit.SECONDS);
+            } finally {
+                executor.shutdownNow();
+                assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            }
+
+            Set<String> keys = new HashSet<>();
+            scanner.forEachKey(keys, (result, key, value) -> {
+                result.add(key.toString());
+                value.int64();
+            });
+            assertEquals(keyCount, keys.size());
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreSharedLockTimeoutTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreSharedLockTimeoutTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.table;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileLock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SingleTableStoreSharedLockTimeoutTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void callerCanSupplySharedLockTimeout() throws Exception {
+        File file = temporaryFolder.newFile("metadata.cq4t");
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw")) {
+            randomAccessFile.setLength(1);
+        }
+
+        String value = SingleTableStore.doWithSharedLock(file, 0,
+                ignored -> "locked", () -> null);
+
+        assertEquals("locked", value);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeSharedLockTimeoutIsRejected() throws Exception {
+        File file = temporaryFolder.newFile("metadata.cq4t");
+        SingleTableStore.doWithSharedLock(file, -1,
+                ignored -> "unreachable", () -> null);
+    }
+
+    @Test
+    public void zeroTimeoutPerformsOneAttemptWhenTheStructuralLockIsHeld() throws Exception {
+        File file = temporaryFolder.newFile("locked-metadata.cq4t");
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw")) {
+            randomAccessFile.setLength(1);
+            try (FileLock lock = randomAccessFile.getChannel()
+                    .lock(Long.MAX_VALUE - 1, 1, false)) {
+                assertTrue(lock.isValid());
+                try {
+                    SingleTableStore.doWithSharedLock(file, 0,
+                            value -> "unreachable", () -> null);
+                    fail("shared lock should not have been acquired");
+                } catch (IllegalStateException expected) {
+                    // A zero timeout still performs one non-blocking attempt.
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The delivery owner is #1745 on #1741. This older branch is retained as source/reference, including the dependencies of source-only #1716 and the older listener line. Do not create a competing maintenance stack from it.

Reconcile these review decisions into the modern delivery:

- Non-creating table lookup and scans of current capacity, with all caller-visible cursor/limit restoration.
- Truthful `SingleTableStore.readOnly()` paired with `SingleChronicleQueue` choosing the metadata-backed listing for a read-only mapped table; only the no-metadata `ReadonlyTableStore` fallback uses filesystem listing.
- Persisted geometry, existing-roll lookup and detached raw-name snapshots, preserving case variants and distinguishable legacy names.
- Parking and public naming restrictions, including replicated-name refusal, every validating entry point, quiescence, backlog-loss and resume guidance.

Modern #1745 preserves `getValueFor` as non-creating access alongside legacy acquisition semantics. Its later cursor/limit restoration must not be overwritten by the older extraction. Old #1731 deletion scenarios need mapping to the authoritative-current-roll policy, rather than copying old all-deleted expectations.

Retained source `dd06188703757dbac0172569e0b821fb967f02f2` includes current develop. It passed full verification during the refresh, but that does not qualify a second modern delivery. #1745 remains the single maintenance owner, followed by #1746 for listeners.
