### PR TITLE
Dropped: QUEUE-144 named tailer context recovery

### DIFF
--- a/docs/named-tailer-context-recovery.adoc
+++ b/docs/named-tailer-context-recovery.adoc
@@ -1,0 +1,144 @@
+= Named Tailer Context Recovery
+:toc:
+:toclevels: 3
+:css-signature: demo
+
+Named tailers persist their read position.
+After a restart, a named tailer may resume in the middle of a roll cycle.
+If records earlier in that same cycle carried context required by later records, a freshly started application needs a way to rebuild that context before it continues processing live data.
+
+`TailerContextRecovery` provides that pattern without advancing the named tailer.
+
+== When to use it
+
+Use this pattern when all of the following are true:
+
+* the queue contains normal method-writer records;
+* some records define context used by later records in the same roll cycle;
+* the reader uses a named tailer and can restart mid-cycle;
+* the application can rebuild the context by replaying records from the start of the current cycle.
+
+Typical examples include:
+
+* instrument definitions before market-data events that reference instruments by id;
+* static dictionaries before compact event records;
+* schema or routing context before small event messages;
+* roll-level snapshots written by `MarshallableOut.ContextListener`.
+
+Do not use this for raw fixed-format queues unless the replay handler understands every record format it may see.
+
+== Restart pattern
+
+On restart:
+
+. Open the real named tailer.
+. Capture its persisted resume index by calling `index()`.
+. Use `TailerContextRecovery.replayCurrentCycleContext(...)` with a context-only handler.
+. Continue normal processing with the named tailer.
+
+[source,java]
+----
+try (ExcerptTailer namedTailer = queue.createTailer("risk-engine")) {
+    MarketProjection projection = new MarketProjection();
+
+    TailerContextRecovery.ReplayResult result =
+            TailerContextRecovery.replayCurrentCycleContext(namedTailer, projection);
+
+    if (!result.complete())
+        throw new IllegalStateException("Unable to rebuild context: " + result);
+
+    MethodReader reader = namedTailer.methodReader(new MarketEventHandler(projection));
+    while (reader.readOne()) {
+        // normal processing
+    }
+}
+----
+
+The helper opens a temporary unnamed tailer, moves it to the start of the named tailer's current cycle, replays records strictly before the named tailer's resume index, and closes the temporary tailer.
+The named tailer's persisted position is not changed.
+
+== Context-only handlers
+
+The replay handler must not perform business side effects.
+It should either implement only the context methods or implement data methods as projection-only no-ops.
+
+For example, a queue may contain both context and data methods:
+
+[source,java]
+----
+interface MarketContext {
+    void instrument(int symbolId, String name);
+}
+
+interface MarketEvents extends MarketContext {
+    void trade(int symbolId, long quantity);
+}
+----
+
+The recovery replay can use a projection that only accepts `instrument(...)`:
+
+[source,java]
+----
+final class MarketProjection implements MarketContext {
+    private final Map<Integer, String> symbolNames = new HashMap<>();
+
+    @Override
+    public void instrument(int symbolId, String name) {
+        symbolNames.put(symbolId, name);
+    }
+
+    String symbolName(int symbolId) {
+        return symbolNames.get(symbolId);
+    }
+}
+----
+
+Normal processing can then use a handler that depends on that projection:
+
+[source,java]
+----
+final class MarketEventHandler implements MarketEvents {
+    private final MarketProjection projection;
+
+    MarketEventHandler(MarketProjection projection) {
+        this.projection = projection;
+    }
+
+    @Override
+    public void instrument(int symbolId, String name) {
+        projection.instrument(symbolId, name);
+    }
+
+    @Override
+    public void trade(int symbolId, long quantity) {
+        String symbolName = projection.symbolName(symbolId);
+        if (symbolName == null)
+            throw new IllegalStateException("Missing instrument context for " + symbolId);
+        // process the trade
+    }
+}
+----
+
+== Result statuses
+
+`ReplayResult.status()` can return:
+
+* `NO_NAMED_POSITION`: the named tailer has no real committed index. Fresh and parked named tailers use index `0`.
+* `NAMED_INDEX_AT_CYCLE_START`: the named tailer is already at sequence `0`; there are no earlier same-cycle records to replay.
+* `REPLAYED_TO_NAMED_INDEX`: replay reached the named tailer's resume index.
+* `CYCLE_NOT_AVAILABLE`: the roll cycle containing the named tailer's resume index could not be opened.
+* `STOPPED_BEFORE_NAMED_INDEX`: replay stopped before reaching the named tailer's resume index.
+
+Treat `CYCLE_NOT_AVAILABLE` and `STOPPED_BEFORE_NAMED_INDEX` as recovery failures when the application requires context before continuing.
+
+== Limits
+
+The utility reconstructs context from records in the current roll cycle only.
+It does not replay earlier cycles.
+Applications that require a longer-lived context should write enough context at roll boundaries, use progressive resend with `DocumentContext.contextCount()`, or load durable state from a separate store before reading.
+
+The replay is side-effect safe only if the supplied handlers are side-effect safe.
+Do not pass the normal business handler unless reprocessing earlier records is acceptable.
+
+The helper is intended for method-writer streams.
+It is not a framing adapter for raw binary queues.

--- a/src/main/java/net/openhft/chronicle/queue/TailerContextRecovery.java
+++ b/src/main/java/net/openhft/chronicle/queue/TailerContextRecovery.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.bytes.MethodReader;
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Reconstructs same-cycle context before a restarted named tailer resumes normal processing.
+ * <p>
+ * A named tailer can restart in the middle of a roll cycle. If earlier records in the same cycle
+ * carried context required by later records, the restarted application can rebuild that context by
+ * replaying the current cycle with a temporary unnamed tailer up to, but not including, the named
+ * tailer's saved index.
+ * <p>
+ * The handlers supplied to this class must be context-only projections. They should either implement
+ * only context methods or handle data methods without external side effects. This utility never
+ * advances the supplied named tailer.
+ */
+public final class TailerContextRecovery {
+
+    private TailerContextRecovery() {
+    }
+
+    /**
+     * Replays non-metadata documents from the start of the named tailer's current cycle up to the
+     * named tailer's current index.
+     *
+     * @param namedTailer         the restarted named tailer, positioned at its persisted resume index
+     * @param contextOnlyHandlers method-reader targets that rebuild context without business side effects
+     * @return a result describing whether and how far replay proceeded
+     */
+    @NotNull
+    public static ReplayResult replayCurrentCycleContext(@NotNull ExcerptTailer namedTailer,
+                                                         @NotNull Object... contextOnlyHandlers) {
+        requireNonNull(namedTailer);
+        requireContextHandlers(contextOnlyHandlers);
+
+        final long resumeIndex = namedTailer.index();
+        if (resumeIndex <= 0)
+            return ReplayResult.noNamedPosition(resumeIndex);
+
+        final RollCycle rollCycle = namedTailer.queue().rollCycle();
+        final int cycle = rollCycle.toCycle(resumeIndex);
+        if (rollCycle.toSequenceNumber(resumeIndex) == 0)
+            return ReplayResult.atCycleStart(cycle, resumeIndex);
+
+        try (ExcerptTailer replayTailer = namedTailer.queue().createTailer()) {
+            if (!replayTailer.moveToCycle(cycle))
+                return ReplayResult.cycleNotAvailable(cycle, resumeIndex);
+
+            long documentsScanned = 0;
+            long lastScannedIndex = -1;
+            final MethodReader reader = replayTailer.methodReaderBuilder()
+                    .predicate(ignored -> isBeforeResumeIndex(replayTailer, rollCycle, cycle, resumeIndex))
+                    .build(contextOnlyHandlers);
+
+            while (reader.readOne()) {
+                documentsScanned++;
+                lastScannedIndex = replayTailer.lastReadIndex();
+            }
+
+            return replayTailer.index() >= resumeIndex
+                    ? ReplayResult.replayed(cycle, resumeIndex, documentsScanned, lastScannedIndex)
+                    : ReplayResult.stoppedBeforeNamedIndex(cycle, resumeIndex, documentsScanned, lastScannedIndex);
+        }
+    }
+
+    private static boolean isBeforeResumeIndex(ExcerptTailer replayTailer, RollCycle rollCycle, int cycle, long resumeIndex) {
+        final long nextIndex = replayTailer.index();
+        return nextIndex >= 0 && nextIndex < resumeIndex && rollCycle.toCycle(nextIndex) == cycle;
+    }
+
+    private static void requireContextHandlers(Object[] contextOnlyHandlers) {
+        requireNonNull(contextOnlyHandlers);
+        if (contextOnlyHandlers.length == 0)
+            throw new IllegalArgumentException("At least one context-only handler is required");
+        for (Object handler : contextOnlyHandlers)
+            requireNonNull(handler);
+    }
+
+    /**
+     * Outcome of a current-cycle context replay attempt.
+     */
+    public static final class ReplayResult {
+        private final Status status;
+        private final int cycle;
+        private final long resumeIndex;
+        private final long documentsScanned;
+        private final long lastScannedIndex;
+
+        private ReplayResult(Status status, int cycle, long resumeIndex, long documentsScanned, long lastScannedIndex) {
+            this.status = status;
+            this.cycle = cycle;
+            this.resumeIndex = resumeIndex;
+            this.documentsScanned = documentsScanned;
+            this.lastScannedIndex = lastScannedIndex;
+        }
+
+        private static ReplayResult noNamedPosition(long resumeIndex) {
+            return new ReplayResult(Status.NO_NAMED_POSITION, Integer.MIN_VALUE, resumeIndex, 0, -1);
+        }
+
+        private static ReplayResult atCycleStart(int cycle, long resumeIndex) {
+            return new ReplayResult(Status.NAMED_INDEX_AT_CYCLE_START, cycle, resumeIndex, 0, -1);
+        }
+
+        private static ReplayResult cycleNotAvailable(int cycle, long resumeIndex) {
+            return new ReplayResult(Status.CYCLE_NOT_AVAILABLE, cycle, resumeIndex, 0, -1);
+        }
+
+        private static ReplayResult replayed(int cycle, long resumeIndex, long documentsScanned, long lastScannedIndex) {
+            return new ReplayResult(Status.REPLAYED_TO_NAMED_INDEX, cycle, resumeIndex, documentsScanned, lastScannedIndex);
+        }
+
+        private static ReplayResult stoppedBeforeNamedIndex(int cycle, long resumeIndex, long documentsScanned, long lastScannedIndex) {
+            return new ReplayResult(Status.STOPPED_BEFORE_NAMED_INDEX, cycle, resumeIndex, documentsScanned, lastScannedIndex);
+        }
+
+        /**
+         * @return the replay status
+         */
+        public Status status() {
+            return status;
+        }
+
+        /**
+         * @return the cycle containing the named tailer's resume index, or {@link Integer#MIN_VALUE} if unknown
+         */
+        public int cycle() {
+            return cycle;
+        }
+
+        /**
+         * @return the named tailer's resume index captured before replay began
+         */
+        public long resumeIndex() {
+            return resumeIndex;
+        }
+
+        /**
+         * @return the number of documents scanned by the context replay tailer
+         */
+        public long documentsScanned() {
+            return documentsScanned;
+        }
+
+        /**
+         * @return the last document index scanned, or {@code -1} when no document was scanned
+         */
+        public long lastScannedIndex() {
+            return lastScannedIndex;
+        }
+
+        /**
+         * @return {@code true} when replay reached the named tailer's resume point or no replay was needed
+         */
+        public boolean complete() {
+            return status != Status.CYCLE_NOT_AVAILABLE && status != Status.STOPPED_BEFORE_NAMED_INDEX;
+        }
+
+        @Override
+        public String toString() {
+            return "ReplayResult{" +
+                    "status=" + status +
+                    ", cycle=" + cycle +
+                    ", resumeIndex=" + resumeIndex +
+                    ", documentsScanned=" + documentsScanned +
+                    ", lastScannedIndex=" + lastScannedIndex +
+                    '}';
+        }
+    }
+
+    /**
+     * Status for current-cycle context replay.
+     */
+    public enum Status {
+        /**
+         * The named tailer had no real committed position. Fresh and parked named tailers use index {@code 0}.
+         */
+        NO_NAMED_POSITION,
+
+        /**
+         * The named tailer is positioned at sequence {@code 0}, so there are no earlier same-cycle records to replay.
+         */
+        NAMED_INDEX_AT_CYCLE_START,
+
+        /**
+         * Replay reached the named tailer's resume index.
+         */
+        REPLAYED_TO_NAMED_INDEX,
+
+        /**
+         * The roll cycle containing the named tailer's resume index is not available.
+         */
+        CYCLE_NOT_AVAILABLE,
+
+        /**
+         * Replay stopped before reaching the named tailer's resume index.
+         */
+        STOPPED_BEFORE_NAMED_INDEX
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/TailerContextRecoveryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerContextRecoveryTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.bytes.MethodReader;
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static net.openhft.chronicle.queue.TailerContextRecovery.Status.NO_NAMED_POSITION;
+import static net.openhft.chronicle.queue.TailerContextRecovery.Status.REPLAYED_TO_NAMED_INDEX;
+import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
+import static org.junit.Assert.*;
+
+public class TailerContextRecoveryTest extends QueueTestCommon {
+
+    @Test
+    public void restartedNamedTailerRebuildsCurrentCycleContextBeforeContinuing() {
+        File path = getTmpDir();
+        SetTimeProvider timeProvider = new SetTimeProvider(1_000_000_000L);
+
+        long resumeIndex;
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(path)
+                .rollCycle(TEST_SECONDLY)
+                .timeProvider(timeProvider)
+                .contextListener(MarketContext.class, context -> context.instrument(17, "EUR/USD"))
+                .build()) {
+            MarketEvents writer = queue.createAppender().methodWriter(MarketEvents.class);
+            writer.trade(17, 10);
+            writer.trade(17, 20);
+
+            MarketProjection firstRunProjection = new MarketProjection();
+            MarketEventHandler firstRunHandler = new MarketEventHandler(firstRunProjection);
+            try (ExcerptTailer namedTailer = queue.createTailer("risk-engine")) {
+                MethodReader reader = namedTailer.methodReader(firstRunHandler);
+                assertTrue(reader.readOne());
+                assertTrue(reader.readOne());
+                resumeIndex = namedTailer.index();
+            }
+            assertEquals(Collections.singletonList("EUR/USD:10"), firstRunHandler.trades);
+
+            MarketProjection restartedProjection = new MarketProjection();
+            try (ExcerptTailer restartedTailer = queue.createTailer("risk-engine")) {
+                assertEquals(resumeIndex, restartedTailer.index());
+
+                TailerContextRecovery.ReplayResult result =
+                        TailerContextRecovery.replayCurrentCycleContext(restartedTailer, restartedProjection);
+
+                assertEquals(REPLAYED_TO_NAMED_INDEX, result.status());
+                assertTrue(result.complete());
+                assertEquals(2, result.documentsScanned());
+                assertEquals("EUR/USD", restartedProjection.symbolName(17));
+                assertEquals("context replay must not advance the named tailer",
+                        resumeIndex, restartedTailer.index());
+
+                MarketEventHandler restartedHandler = new MarketEventHandler(restartedProjection);
+                MethodReader reader = restartedTailer.methodReader(restartedHandler);
+                assertTrue(reader.readOne());
+                assertEquals(Collections.singletonList("EUR/USD:20"), restartedHandler.trades);
+                assertFalse(reader.readOne());
+            }
+        }
+    }
+
+    @Test
+    public void freshNamedTailerHasNoContextToReplay() {
+        File path = getTmpDir();
+
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(path)
+                .rollCycle(TEST_SECONDLY)
+                .build()) {
+            try (ExcerptTailer namedTailer = queue.createTailer("fresh")) {
+                TailerContextRecovery.ReplayResult result =
+                        TailerContextRecovery.replayCurrentCycleContext(namedTailer, new MarketProjection());
+
+                assertEquals(NO_NAMED_POSITION, result.status());
+                assertTrue(result.complete());
+                assertEquals(0, result.documentsScanned());
+                assertEquals(0, namedTailer.index());
+            }
+        }
+    }
+
+    public interface MarketContext {
+        void instrument(int symbolId, String name);
+    }
+
+    public interface MarketEvents extends MarketContext {
+        void trade(int symbolId, long quantity);
+    }
+
+    public static final class MarketProjection implements MarketContext {
+        private final Map<Integer, String> symbolNames = new HashMap<>();
+
+        @Override
+        public void instrument(int symbolId, String name) {
+            symbolNames.put(symbolId, name);
+        }
+
+        private String symbolName(int symbolId) {
+            return symbolNames.get(symbolId);
+        }
+    }
+
+    public static final class MarketEventHandler implements MarketEvents {
+        private final MarketProjection projection;
+        private final List<String> trades = new ArrayList<>();
+
+        private MarketEventHandler(MarketProjection projection) {
+            this.projection = projection;
+        }
+
+        @Override
+        public void instrument(int symbolId, String name) {
+            projection.instrument(symbolId, name);
+        }
+
+        @Override
+        public void trade(int symbolId, long quantity) {
+            String symbolName = projection.symbolName(symbolId);
+            if (symbolName == null)
+                throw new IllegalStateException("Missing instrument context for " + symbolId);
+            trades.add(symbolName + ":" + quantity);
+        }
+    }
+}


### PR DESCRIPTION
## Status

Closed because the public named-tailer recovery utility is not part of the agreed QUEUE-144 scope. Do not merge this branch.

OpenHFT/Chronicle-Queue#1725 documents the named-tailer restart limitation and the application-level replay pattern. The `TailerContextRecovery` API in this branch is not required by the known consumers, depends on a superseded implementation branch, and has not been reconciled with Queue Enterprise roll-file retention and archive facilities.

If a public recovery utility becomes a concrete requirement, it should be proposed as a new PR based on the final #1725 implementation.
