### PR TITLE
QUEUE-144: Use the configurable system clock by default

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -1264,13 +1264,11 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     }
 
     /**
-     * Returns the {@link TimeProvider} for the queue. If not explicitly set, it defaults to the
-     * {@link SystemTimeProvider#INSTANCE}.
-     *
-     * @return the time provider used by the queue
+     * Returns the explicit time provider, or the current {@link SystemTimeProvider#CLOCK}.
+     * A queue captures this value when it is built.
      */
     public TimeProvider timeProvider() {
-        return timeProvider == null ? SystemTimeProvider.INSTANCE : timeProvider;
+        return timeProvider == null ? SystemTimeProvider.CLOCK : timeProvider;
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -6,6 +6,9 @@ package net.openhft.chronicle.queue.impl.single;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.scoped.ScopedResource;
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.core.time.SystemTimeProvider;
+import net.openhft.chronicle.core.time.TimeProvider;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
@@ -200,6 +203,28 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
     public void drainerPriorityIsSetByDefault() {
         SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.single();
         assertNotNull(builder.drainerPriority()); // priority may change from CONCURRENT in future
+    }
+
+    @Test
+    public void defaultTimeProviderUsesCurrentSystemClockAtBuildTime() {
+        TimeProvider previous = SystemTimeProvider.CLOCK;
+        SetTimeProvider clockAtBuild = new SetTimeProvider(1_000L);
+        SetTimeProvider replacementClock = new SetTimeProvider(2_000L);
+        try {
+            SystemTimeProvider.CLOCK = clockAtBuild;
+            SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.single(getTmpDir())
+                    .testBlockSize();
+
+            try (SingleChronicleQueue queue = builder.build()) {
+                assertSame(clockAtBuild, queue.time());
+
+                SystemTimeProvider.CLOCK = replacementClock;
+                assertSame(replacementClock, builder.timeProvider());
+                assertSame(clockAtBuild, queue.time());
+            }
+        } finally {
+            SystemTimeProvider.CLOCK = previous;
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Default `SingleChronicleQueueBuilder.timeProvider()` to the current `SystemTimeProvider.CLOCK` instead of the fixed `SystemTimeProvider.INSTANCE`.
- Document that a queue captures the resolved provider when it is built.
- Add focused coverage for global-clock replacement and build-time capture.

## Why
This is a process-wide behavioral change for every queue built without an explicit time provider. Extracting it from the context-listener implementation makes that impact visible and independently reviewable.

Tests can set `SystemTimeProvider.CLOCK` once to control roll timing without passing a provider through every builder. Queues with an explicit provider are unaffected, and changing the global clock does not alter queues that have already been built.

## Order
Depends on OpenHFT/Chronicle-Queue#1724. OpenHFT/Chronicle-Queue#1725 is based on this branch and therefore depends on this PR.

## Validation
- `mvn -o -Dtest=SingleChronicleQueueBuilderTest test`
- `mvn -o verify` (1,126 tests, 0 failures, 0 errors, 52 skipped)
- `git diff --check`