### PR TITLE
QUEUE-144: Recover named-tailer context after restart

### DIFF
--- a/docs/context-listeners.adoc
+++ b/docs/context-listeners.adoc
@@ -60,6 +60,9 @@ cycle and will not reread context stored earlier in that cycle. A context listen
 the reader's in-memory state.
 
 Applications that require this state must either persist it separately or replay the current cycle
-up to the named tailer's saved index with a temporary unnamed tailer. Replay handlers must rebuild
-context without business side effects, and the temporary tailer must not advance the named tailer.
+up to the named tailer's saved index with a temporary unnamed tailer. Replay handlers must collectively
+cover the method stream, rebuild context without business side effects, and leave the named tailer unchanged.
 If the required roll file has already been removed, recovery needs another durable source.
+
+See link:named-tailer-context-recovery.adoc[Named Tailer Context Recovery] for the public replay
+helper, its result statuses and the restart pattern.

--- a/docs/named-tailer-context-recovery.adoc
+++ b/docs/named-tailer-context-recovery.adoc
@@ -1,0 +1,171 @@
+= Named Tailer Context Recovery
+:toc:
+:toclevels: 3
+:css-signature: demo
+
+Named tailers persist their read position.
+After a restart, a named tailer may resume in the middle of a roll cycle.
+If records earlier in that same cycle carried context required by later records, a freshly started application needs a way to rebuild that context before it continues processing live data.
+
+`TailerContextRecovery` provides that pattern without advancing the named tailer.
+
+== When to use it
+
+Use this pattern when all of the following are true:
+
+* the queue contains normal method-writer records;
+* some records define context used by later records in the same roll cycle;
+* the reader uses a named tailer and can restart mid-cycle;
+* the application can rebuild the context by replaying records from the start of the current cycle.
+
+Typical examples include:
+
+* instrument definitions before market-data events that reference instruments by id;
+* static dictionaries before compact event records;
+* schema or routing context before small event messages;
+* roll-level snapshots written by `MarshallableOut.ContextListener`.
+
+Do not use this for raw fixed-format queues unless the replay handler understands every record format it may see.
+
+== Restart pattern
+
+On restart:
+
+. Open the real named tailer.
+. Capture its persisted resume index by calling `index()`.
+. Use `TailerContextRecovery.replayCurrentCycleContext(...)` with replay handlers that collectively cover the method stream.
+. Continue normal processing with the named tailer.
+
+[source,java]
+----
+try (ExcerptTailer namedTailer = queue.createTailer("risk-engine")) {
+    MarketProjection projection = new MarketProjection();
+
+    TailerContextRecovery.ReplayResult result =
+            TailerContextRecovery.replayCurrentCycleContext(
+                    namedTailer, projection, new NoOpMarketDataHandler());
+
+    if (!result.complete())
+        throw new IllegalStateException("Unable to rebuild context: " + result);
+
+    MethodReader reader = namedTailer.methodReader(new MarketEventHandler(projection));
+    while (reader.readOne()) {
+        // normal processing
+    }
+}
+----
+
+The helper opens a temporary unnamed tailer, moves it to the start of the named tailer's current cycle, replays records strictly before the named tailer's resume index, and closes the temporary tailer.
+It checks the actual document index again before invoking a replay handler, so recovery into a later available cycle cannot dispatch a later-cycle method.
+The named tailer's persisted position is not changed.
+
+== Replay handlers
+
+The replay handlers must collectively implement every method that may occur in the stream.
+Context methods should update the reconstructed projection, while ordinary data methods must be side-effect-free no-ops.
+The helper fails immediately on an unknown method, preventing a missing context handler from being reported as a successful replay.
+
+For example, a queue may contain both context and data methods:
+
+[source,java]
+----
+interface MarketContext {
+    void instrument(int symbolId, String name);
+}
+
+interface MarketData {
+    void trade(int symbolId, long quantity);
+}
+
+interface MarketEvents extends MarketContext, MarketData {
+}
+----
+
+The recovery replay can combine a context projection with a no-op data handler:
+
+[source,java]
+----
+final class MarketProjection implements MarketContext {
+    private final Map<Integer, String> symbolNames = new HashMap<>();
+
+    @Override
+    public void instrument(int symbolId, String name) {
+        symbolNames.put(symbolId, name);
+    }
+
+    String symbolName(int symbolId) {
+        return symbolNames.get(symbolId);
+    }
+}
+
+final class NoOpMarketDataHandler implements MarketData {
+    @Override
+    public void trade(int symbolId, long quantity) {
+        // Consume the method without repeating its business effect.
+    }
+}
+----
+
+Normal processing can then use a handler that depends on that projection:
+
+[source,java]
+----
+final class MarketEventHandler implements MarketEvents {
+    private final MarketProjection projection;
+
+    MarketEventHandler(MarketProjection projection) {
+        this.projection = projection;
+    }
+
+    @Override
+    public void instrument(int symbolId, String name) {
+        projection.instrument(symbolId, name);
+    }
+
+    @Override
+    public void trade(int symbolId, long quantity) {
+        String symbolName = projection.symbolName(symbolId);
+        if (symbolName == null)
+            throw new IllegalStateException("Missing instrument context for " + symbolId);
+        // process the trade
+    }
+}
+----
+
+== Result statuses
+
+`ReplayResult.status()` can return:
+
+* `NO_RESUME_POSITION`: the resume tailer has no real committed index. Fresh and parked named tailers use index `0`.
+* `RESUME_INDEX_AT_CYCLE_START`: the resume tailer is already at sequence `0`; there are no earlier same-cycle records to replay.
+* `REPLAYED_TO_RESUME_INDEX`: replay reached the resume index exactly.
+* `CYCLE_NOT_AVAILABLE`: the roll cycle containing the resume index could not be opened.
+* `REPLAY_INCOMPLETE`: replay stopped without reaching the resume index exactly, including when recovery encountered a document in another cycle.
+
+Treat `CYCLE_NOT_AVAILABLE` and `REPLAY_INCOMPLETE` as recovery failures when the application requires context before continuing.
+
+== Limits
+
+The utility reconstructs context from records in the current roll cycle only.
+It does not replay earlier cycles.
+Applications that require a longer-lived context should write enough context at roll boundaries, use progressive resend with `DocumentContext.contextCount()`, or load durable state from a separate store before reading.
+
+The replay is side-effect safe only if the supplied handlers are side-effect safe.
+Do not pass the normal business handler unless reprocessing earlier records is acceptable.
+
+The API accepts any forward tailer positioned at a trusted resume index.
+A restarted named tailer supplies that position in the normal use case, but the helper does not attempt to prove that the position was persisted.
+Backward tailers are rejected.
+For a read-only queue, a caller can obtain the persisted index separately and use the overload that accepts the queue and resume index directly:
+
+[source,java]
+----
+TailerContextRecovery.ReplayResult result =
+        TailerContextRecovery.replayCurrentCycleContext(
+                readOnlyQueue, persistedResumeIndex, replayHandlers);
+----
+
+The tailer overload does not mutate the supplied tailer.
+
+The helper is intended for method-writer streams.
+It is not a framing adapter for raw binary queues.

--- a/src/main/java/net/openhft/chronicle/queue/TailerContextRecovery.java
+++ b/src/main/java/net/openhft/chronicle/queue/TailerContextRecovery.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.bytes.MethodReader;
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+import static net.openhft.chronicle.queue.TailerDirection.FORWARD;
+
+/**
+ * Reconstructs same-cycle context before a restarted tailer resumes normal processing.
+ * <p>
+ * A named tailer can restart in the middle of a roll cycle. If earlier records in the same cycle
+ * carried context required by later records, the restarted application can rebuild that context by
+ * replaying the current cycle with a temporary unnamed tailer up to, but not including, the named
+ * tailer's saved index.
+ * <p>
+ * The supplied replay handlers must collectively handle every method that may occur in the replayed
+ * stream. Context methods should update only the reconstructed projection and ordinary data methods
+ * must have no external side effects. This utility never advances the supplied resume tailer.
+ */
+public final class TailerContextRecovery {
+
+    private TailerContextRecovery() {
+    }
+
+    /**
+     * Replays non-metadata documents from the start of the resume tailer's current cycle up to the
+     * resume tailer's current index.
+     *
+     * @param resumeTailer   a forward tailer positioned at a trusted resume index; normally a restarted named tailer
+     * @param replayHandlers method-reader targets that collectively handle the replay stream without business side effects
+     * @return a result describing whether and how far replay proceeded
+     * @throws IllegalStateException if a replayed method has no matching handler
+     */
+    @NotNull
+    public static ReplayResult replayCurrentCycleContext(@NotNull ExcerptTailer resumeTailer,
+                                                         @NotNull Object... replayHandlers) {
+        requireNonNull(resumeTailer);
+        if (resumeTailer.direction() != FORWARD)
+            throw new IllegalArgumentException("The resume tailer must use FORWARD direction");
+
+        return replayCurrentCycleContext(resumeTailer.queue(), resumeTailer.index(), replayHandlers);
+    }
+
+    /**
+     * Replays non-metadata documents from the start of the cycle containing {@code resumeIndex}
+     * up to that index. This overload is useful when a persisted position has been obtained
+     * separately, including when the queue is read-only.
+     *
+     * @param queue          the queue containing the records to replay
+     * @param resumeIndex    a trusted resume index in {@code queue}
+     * @param replayHandlers method-reader targets that collectively handle the replay stream without business side effects
+     * @return a result describing whether and how far replay proceeded
+     * @throws IllegalStateException if a replayed method has no matching handler
+     */
+    @NotNull
+    public static ReplayResult replayCurrentCycleContext(@NotNull ChronicleQueue queue,
+                                                         long resumeIndex,
+                                                         @NotNull Object... replayHandlers) {
+        requireNonNull(queue);
+        requireReplayHandlers(replayHandlers);
+
+        if (resumeIndex <= 0)
+            return ReplayResult.noResumePosition(resumeIndex);
+
+        final RollCycle rollCycle = queue.rollCycle();
+        final int cycle = rollCycle.toCycle(resumeIndex);
+        if (rollCycle.toSequenceNumber(resumeIndex) == 0)
+            return ReplayResult.atCycleStart(cycle, resumeIndex);
+
+        try (ExcerptTailer replayTailer = queue.createTailer()) {
+            if (!replayTailer.moveToCycle(cycle))
+                return ReplayResult.cycleNotAvailable(cycle, resumeIndex);
+
+            long documentsScanned = 0;
+            long lastScannedIndex = -1;
+            final long[] rejectedDocumentIndex = {-1};
+            final MethodReader reader = replayTailer.methodReaderBuilder()
+                    .defaultParselet((methodName, valueIn) -> {
+                        throw new IllegalStateException("No replay handler for method '" + methodName + "'");
+                    })
+                    .predicate(ignored -> isBeforeResumeIndex(replayTailer, rollCycle, cycle, resumeIndex))
+                    .methodReaderInterceptorReturns((method, target, arguments, invocation) -> {
+                        final long documentIndex = replayTailer.index();
+                        if (!isReplayDocumentIndex(documentIndex, rollCycle, cycle, resumeIndex)) {
+                            rejectedDocumentIndex[0] = documentIndex;
+                            return null;
+                        }
+                        return invocation.invoke(method, target, arguments);
+                    })
+                    .build(replayHandlers);
+
+            while (reader.readOne()) {
+                documentsScanned++;
+                lastScannedIndex = replayTailer.lastReadIndex();
+                if (!isReplayDocumentIndex(lastScannedIndex, rollCycle, cycle, resumeIndex)) {
+                    rejectedDocumentIndex[0] = lastScannedIndex;
+                    break;
+                }
+            }
+
+            return rejectedDocumentIndex[0] < 0 && replayTailer.index() == resumeIndex
+                    ? ReplayResult.replayed(cycle, resumeIndex, documentsScanned, lastScannedIndex)
+                    : ReplayResult.replayIncomplete(cycle, resumeIndex, documentsScanned, lastScannedIndex);
+        }
+    }
+
+    private static boolean isBeforeResumeIndex(ExcerptTailer replayTailer, RollCycle rollCycle, int cycle, long resumeIndex) {
+        final long nextIndex = replayTailer.index();
+        return isReplayDocumentIndex(nextIndex, rollCycle, cycle, resumeIndex);
+    }
+
+    private static boolean isReplayDocumentIndex(long documentIndex, RollCycle rollCycle, int cycle, long resumeIndex) {
+        return documentIndex >= 0 && documentIndex < resumeIndex && rollCycle.toCycle(documentIndex) == cycle;
+    }
+
+    private static void requireReplayHandlers(Object[] replayHandlers) {
+        requireNonNull(replayHandlers);
+        if (replayHandlers.length == 0)
+            throw new IllegalArgumentException("At least one replay handler is required");
+        for (Object handler : replayHandlers)
+            requireNonNull(handler);
+    }
+
+    /**
+     * Outcome of a current-cycle context replay attempt.
+     */
+    public static final class ReplayResult {
+        private final Status status;
+        private final int cycle;
+        private final long resumeIndex;
+        private final long documentsScanned;
+        private final long lastScannedIndex;
+
+        private ReplayResult(Status status, int cycle, long resumeIndex, long documentsScanned, long lastScannedIndex) {
+            this.status = status;
+            this.cycle = cycle;
+            this.resumeIndex = resumeIndex;
+            this.documentsScanned = documentsScanned;
+            this.lastScannedIndex = lastScannedIndex;
+        }
+
+        private static ReplayResult noResumePosition(long resumeIndex) {
+            return new ReplayResult(Status.NO_RESUME_POSITION, Integer.MIN_VALUE, resumeIndex, 0, -1);
+        }
+
+        private static ReplayResult atCycleStart(int cycle, long resumeIndex) {
+            return new ReplayResult(Status.RESUME_INDEX_AT_CYCLE_START, cycle, resumeIndex, 0, -1);
+        }
+
+        private static ReplayResult cycleNotAvailable(int cycle, long resumeIndex) {
+            return new ReplayResult(Status.CYCLE_NOT_AVAILABLE, cycle, resumeIndex, 0, -1);
+        }
+
+        private static ReplayResult replayed(int cycle, long resumeIndex, long documentsScanned, long lastScannedIndex) {
+            return new ReplayResult(Status.REPLAYED_TO_RESUME_INDEX, cycle, resumeIndex, documentsScanned, lastScannedIndex);
+        }
+
+        private static ReplayResult replayIncomplete(int cycle, long resumeIndex, long documentsScanned, long lastScannedIndex) {
+            return new ReplayResult(Status.REPLAY_INCOMPLETE, cycle, resumeIndex, documentsScanned, lastScannedIndex);
+        }
+
+        /**
+         * @return the replay status
+         */
+        public Status status() {
+            return status;
+        }
+
+        /**
+         * @return the cycle containing the resume index, or {@link Integer#MIN_VALUE} if unknown
+         */
+        public int cycle() {
+            return cycle;
+        }
+
+        /**
+         * @return the trusted resume index captured before replay began
+         */
+        public long resumeIndex() {
+            return resumeIndex;
+        }
+
+        /**
+         * @return the number of documents scanned by the context replay tailer
+         */
+        public long documentsScanned() {
+            return documentsScanned;
+        }
+
+        /**
+         * @return the last document index scanned, or {@code -1} when no document was scanned
+         */
+        public long lastScannedIndex() {
+            return lastScannedIndex;
+        }
+
+        /**
+         * @return {@code true} when replay reached the resume point or no replay was needed
+         */
+        public boolean complete() {
+            switch (status) {
+                case NO_RESUME_POSITION:
+                case RESUME_INDEX_AT_CYCLE_START:
+                case REPLAYED_TO_RESUME_INDEX:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "ReplayResult{" +
+                    "status=" + status +
+                    ", cycle=" + cycle +
+                    ", resumeIndex=" + resumeIndex +
+                    ", documentsScanned=" + documentsScanned +
+                    ", lastScannedIndex=" + lastScannedIndex +
+                    '}';
+        }
+    }
+
+    /**
+     * Status for current-cycle context replay.
+     */
+    public enum Status {
+        /**
+         * The resume tailer had no real committed position. Fresh and parked named tailers use index {@code 0}.
+         */
+        NO_RESUME_POSITION,
+
+        /**
+         * The resume tailer is positioned at sequence {@code 0}, so there are no earlier same-cycle records to replay.
+         */
+        RESUME_INDEX_AT_CYCLE_START,
+
+        /**
+         * Replay reached the resume tailer's index.
+         */
+        REPLAYED_TO_RESUME_INDEX,
+
+        /**
+         * The roll cycle containing the resume index is not available.
+         */
+        CYCLE_NOT_AVAILABLE,
+
+        /**
+         * Replay did not reach the resume index exactly.
+         */
+        REPLAY_INCOMPLETE
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/TailerContextRecoveryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/TailerContextRecoveryTest.java
@@ -1,0 +1,584 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue;
+
+import net.openhft.chronicle.bytes.MethodReader;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
+import net.openhft.chronicle.wire.AbstractGeneratedMethodReader;
+import net.openhft.chronicle.wire.VanillaMethodReader;
+import net.openhft.chronicle.wire.VanillaMethodReaderBuilder;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static net.openhft.chronicle.queue.TailerContextRecovery.Status.CYCLE_NOT_AVAILABLE;
+import static net.openhft.chronicle.queue.TailerContextRecovery.Status.NO_RESUME_POSITION;
+import static net.openhft.chronicle.queue.TailerContextRecovery.Status.REPLAYED_TO_RESUME_INDEX;
+import static net.openhft.chronicle.queue.TailerContextRecovery.Status.RESUME_INDEX_AT_CYCLE_START;
+import static net.openhft.chronicle.queue.TailerContextRecovery.Status.REPLAY_INCOMPLETE;
+import static net.openhft.chronicle.queue.TailerDirection.BACKWARD;
+import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
+import static net.openhft.chronicle.wire.VanillaMethodReaderBuilder.DISABLE_READER_PROXY_CODEGEN;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+
+public class TailerContextRecoveryTest extends QueueTestCommon {
+
+    private static final long INITIAL_TIME_NANOS = 1_000_000_000L;
+
+    @Test
+    public void requiresForwardTailerAndReplayHandlers() {
+        assertThrows(NullPointerException.class,
+                () -> TailerContextRecovery.replayCurrentCycleContext(
+                        (ExcerptTailer) null, new RecordingReplayHandler()));
+
+        File path = getTmpDir();
+        try (ChronicleQueue queue = queueBuilder(path, new SetTimeProvider(INITIAL_TIME_NANOS)).build();
+             ExcerptTailer tailer = queue.createTailer()) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> TailerContextRecovery.replayCurrentCycleContext(tailer));
+            assertThrows(NullPointerException.class,
+                    () -> TailerContextRecovery.replayCurrentCycleContext(tailer, (Object) null));
+
+            tailer.direction(BACKWARD);
+            assertThrows(IllegalArgumentException.class,
+                    () -> TailerContextRecovery.replayCurrentCycleContext(tailer, new RecordingReplayHandler()));
+        }
+
+        assertThrows(NullPointerException.class,
+                () -> TailerContextRecovery.replayCurrentCycleContext(
+                        (ChronicleQueue) null, 1, new RecordingReplayHandler()));
+    }
+
+    @Test
+    public void restartedNamedTailerRebuildsCurrentCycleContextBeforeContinuing() {
+        File path = getTmpDir();
+        SetTimeProvider timeProvider = new SetTimeProvider(INITIAL_TIME_NANOS);
+
+        long resumeIndex;
+        try (ChronicleQueue queue = marketQueueBuilder(path, timeProvider).build()) {
+            try (ExcerptAppender appender = queue.createAppender()) {
+                MarketEvents writer = appender.methodWriter(MarketEvents.class);
+                writer.trade(17, 10);
+                writer.trade(17, 20);
+            }
+
+            MarketProjection firstRunProjection = new MarketProjection();
+            MarketEventHandler firstRunHandler = new MarketEventHandler(firstRunProjection);
+            try (ExcerptTailer namedTailer = queue.createTailer("risk-engine")) {
+                MethodReader reader = namedTailer.methodReader(firstRunHandler);
+                assertTrue(reader.readOne());
+                assertTrue(reader.readOne());
+                resumeIndex = namedTailer.index();
+            }
+            assertEquals(Collections.singletonList("EUR/USD:10"), firstRunHandler.trades);
+        }
+
+        MarketProjection restartedProjection = new MarketProjection();
+        try (ChronicleQueue queue = marketQueueBuilder(path, timeProvider).build();
+             ExcerptTailer restartedTailer = queue.createTailer("risk-engine")) {
+            assertEquals(resumeIndex, restartedTailer.index());
+
+            TailerContextRecovery.ReplayResult result =
+                    TailerContextRecovery.replayCurrentCycleContext(
+                            restartedTailer, restartedProjection, new NoOpMarketDataHandler());
+
+            assertEquals(REPLAYED_TO_RESUME_INDEX, result.status());
+            assertTrue(result.complete());
+            assertEquals(2, result.documentsScanned());
+            assertEquals("EUR/USD", restartedProjection.symbolName(17));
+            assertEquals("context replay must not advance the resume tailer",
+                    resumeIndex, restartedTailer.index());
+
+            MarketEventHandler restartedHandler = new MarketEventHandler(restartedProjection);
+            MethodReader reader = restartedTailer.methodReader(restartedHandler);
+            assertTrue(reader.readOne());
+            assertEquals(Collections.singletonList("EUR/USD:20"), restartedHandler.trades);
+            assertFalse(reader.readOne());
+        }
+    }
+
+    @Test
+    public void freshTailerHasNoResumePosition() {
+        File path = getTmpDir();
+
+        try (ChronicleQueue queue = queueBuilder(path, new SetTimeProvider(INITIAL_TIME_NANOS)).build();
+             ExcerptTailer tailer = queue.createTailer("fresh")) {
+            TailerContextRecovery.ReplayResult result =
+                    TailerContextRecovery.replayCurrentCycleContext(tailer, new RecordingReplayHandler());
+
+            assertEquals(NO_RESUME_POSITION, result.status());
+            assertTrue(result.complete());
+            assertEquals(0, result.documentsScanned());
+            assertEquals(0, tailer.index());
+        }
+    }
+
+    @Test
+    public void resumeIndexAtCycleStartNeedsNoReplayAndSupportsUnnamedTailer() {
+        File path = getTmpDir();
+        SetTimeProvider timeProvider = new SetTimeProvider(INITIAL_TIME_NANOS);
+
+        try (ChronicleQueue queue = queueBuilder(path, timeProvider).build()) {
+            writeReplayEvents(queue, "first", "second");
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                long resumeIndex = tailer.index();
+                assertEquals(0, queue.rollCycle().toSequenceNumber(resumeIndex));
+
+                TailerContextRecovery.ReplayResult result =
+                        TailerContextRecovery.replayCurrentCycleContext(tailer, new RecordingReplayHandler());
+
+                assertEquals(RESUME_INDEX_AT_CYCLE_START, result.status());
+                assertTrue(result.complete());
+                assertEquals(0, result.documentsScanned());
+                assertEquals(resumeIndex, tailer.index());
+            }
+        }
+    }
+
+    @Test
+    public void unavailableResumeCycleIsReported() throws IOException {
+        File path = getTmpDir();
+        SetTimeProvider timeProvider = new SetTimeProvider(INITIAL_TIME_NANOS);
+        long resumeIndex;
+
+        try (ChronicleQueue queue = queueBuilder(path, timeProvider).build()) {
+            writeReplayEvents(queue, "one", "two", "three");
+            resumeIndex = persistAfterReading(queue, "missing-cycle", 2);
+        }
+
+        File[] cycleFiles = cycleFiles(path);
+        assertEquals(1, cycleFiles.length);
+        Files.delete(cycleFiles[0].toPath());
+
+        try (ChronicleQueue queue = queueBuilder(path, timeProvider).build();
+             ExcerptTailer tailer = queue.createTailer("missing-cycle")) {
+            assertEquals(resumeIndex, tailer.index());
+
+            TailerContextRecovery.ReplayResult result =
+                    TailerContextRecovery.replayCurrentCycleContext(tailer, new RecordingReplayHandler());
+
+            assertEquals(CYCLE_NOT_AVAILABLE, result.status());
+            assertFalse(result.complete());
+            assertEquals(0, result.documentsScanned());
+            assertEquals(resumeIndex, tailer.index());
+        }
+    }
+
+    @Test
+    public void readOnlyRestartCanReplayPersistedPosition() {
+        File path = getTmpDir();
+        SetTimeProvider timeProvider = new SetTimeProvider(INITIAL_TIME_NANOS);
+        long resumeIndex;
+
+        try (ChronicleQueue queue = queueBuilder(path, timeProvider).build()) {
+            writeReplayEvents(queue, "one", "two", "three");
+            resumeIndex = persistAfterReading(queue, "read-only", 2);
+        }
+
+        RecordingReplayHandler replayHandler = new RecordingReplayHandler();
+        try (ChronicleQueue queue = queueBuilder(path, timeProvider)
+                .readOnly(true)
+                .build()) {
+            TailerContextRecovery.ReplayResult result =
+                    TailerContextRecovery.replayCurrentCycleContext(queue, resumeIndex, replayHandler);
+
+            assertEquals(REPLAYED_TO_RESUME_INDEX, result.status());
+            assertTrue(result.complete());
+            assertEquals(Arrays.asList("one", "two"), replayHandler.values);
+        }
+    }
+
+    @Test
+    public void missingReplayMethodFailsGeneratedReader() {
+        missingReplayMethodFails(false);
+    }
+
+    @Test
+    public void missingReplayMethodFailsFallbackReader() {
+        missingReplayMethodFails(true);
+    }
+
+    @Test
+    public void shortenedCycleStopsWithoutDispatchingLaterCycle() throws IOException {
+        shortenedCycleStopsBeforeLaterCycle();
+    }
+
+    @Test
+    public void generatedReaderChecksActualDocumentBeforeDispatch() {
+        forcedReadingDocumentCrossingDoesNotDispatch(false);
+    }
+
+    @Test
+    public void fallbackReaderChecksActualDocumentBeforeDispatch() {
+        forcedReadingDocumentCrossingDoesNotDispatch(true);
+    }
+
+    private void shortenedCycleStopsBeforeLaterCycle() throws IOException {
+        assumeFalse(OS.isWindows());
+        File root = getTmpDir();
+        File primaryPath = new File(root, "primary");
+        File shortenedPath = new File(root, "shortened");
+        SetTimeProvider primaryTime = new SetTimeProvider(INITIAL_TIME_NANOS);
+        long resumeIndex;
+
+        try (ChronicleQueue queue = queueBuilder(primaryPath, primaryTime).build()) {
+            writeReplayEvents(queue, "long-0", "long-1", "long-2", "long-3", "long-4", "long-5");
+            resumeIndex = persistAfterReading(queue, "shortened-cycle", 5);
+
+            primaryTime.advanceMillis(1_000);
+            writeReplayEvents(queue, "deleted-following-cycle");
+            primaryTime.advanceMillis(1_000);
+            writeReplayEvents(queue, "later-cycle");
+        }
+
+        try (ChronicleQueue shortenedQueue = queueBuilder(
+                shortenedPath, new SetTimeProvider(INITIAL_TIME_NANOS)).build()) {
+            writeReplayEvents(shortenedQueue, "short-0", "short-1");
+        }
+
+        File[] shortenedCycleFiles = cycleFiles(shortenedPath);
+        assertEquals(1, shortenedCycleFiles.length);
+        File replacement = new File(primaryPath, shortenedCycleFiles[0].getName());
+        assertTrue("expected the original resume cycle", replacement.isFile());
+        Files.copy(shortenedCycleFiles[0].toPath(), replacement.toPath(), REPLACE_EXISTING);
+
+        File[] primaryCycleFiles = cycleFiles(primaryPath);
+        assertEquals(3, primaryCycleFiles.length);
+        DeletingRecordingReplayHandler replayHandler =
+                new DeletingRecordingReplayHandler(primaryCycleFiles[0], primaryCycleFiles[1]);
+        try (ChronicleQueue queue = queueBuilder(primaryPath, primaryTime).build();
+             ExcerptTailer tailer = queue.createTailer("shortened-cycle")) {
+            assertEquals(resumeIndex, tailer.index());
+            int resumeCycle = queue.rollCycle().toCycle(resumeIndex);
+
+            TailerContextRecovery.ReplayResult result =
+                    TailerContextRecovery.replayCurrentCycleContext(tailer, replayHandler);
+
+            assertEquals(REPLAY_INCOMPLETE, result.status());
+            assertFalse(result.complete());
+            assertEquals(Arrays.asList("short-0", "short-1"), replayHandler.values);
+            assertEquals("the resume tailer must remain unchanged", resumeIndex, tailer.index());
+            assertEquals(resumeCycle, queue.rollCycle().toCycle(result.lastScannedIndex()));
+        }
+    }
+
+    private void forcedReadingDocumentCrossingDoesNotDispatch(boolean disableCodegen) {
+        // MethodReader evaluates its predicate before readingDocument(). These delegating views
+        // deterministically make readingDocument() select a later-cycle record after that predicate,
+        // so the test exercises the dispatch-time guard rather than only the pre-read optimisation.
+        String previousCodegenSetting = System.getProperty(DISABLE_READER_PROXY_CODEGEN);
+        System.setProperty(DISABLE_READER_PROXY_CODEGEN, Boolean.toString(disableCodegen));
+        try {
+            File path = getTmpDir();
+            SetTimeProvider timeProvider = new SetTimeProvider(INITIAL_TIME_NANOS);
+            try (ChronicleQueue queue = queueBuilder(path, timeProvider).build();
+                 ExcerptAppender appender = queue.createAppender()) {
+                ReplayEvents writer = appender.methodWriter(ReplayEvents.class);
+                for (int i = 0; i < 6; i++)
+                    writer.context("resume-cycle-" + i);
+
+                long lastResumeCycleIndex = queue.lastIndex();
+                int resumeCycle = queue.rollCycle().toCycle(lastResumeCycleIndex);
+                long resumeIndex = queue.rollCycle().toIndex(resumeCycle, 5);
+
+                timeProvider.advanceMillis(1_000);
+                writer.context("later-cycle");
+                long laterIndex = queue.lastIndex();
+
+                try (ExcerptTailer realResumeTailer = queue.createTailer()) {
+                    assertTrue(realResumeTailer.moveToIndex(resumeIndex));
+                    ExcerptTailer realReplayTailer = queue.createTailer();
+                    AtomicReference<ExcerptTailer> replayTailerReference = new AtomicReference<>();
+                    AtomicReference<MethodReader> methodReaderReference = new AtomicReference<>();
+                    ChronicleQueue queueView = queueReturningReplayTailer(queue, replayTailerReference);
+                    ExcerptTailer crossingReplayTailer = crossingReplayTailer(
+                            realReplayTailer, queueView, resumeCycle, laterIndex, methodReaderReference);
+                    replayTailerReference.set(crossingReplayTailer);
+                    ExcerptTailer resumeTailerView = tailerWithQueue(realResumeTailer, queueView);
+                    RecordingReplayHandler replayHandler = new RecordingReplayHandler();
+
+                    TailerContextRecovery.ReplayResult result =
+                            TailerContextRecovery.replayCurrentCycleContext(resumeTailerView, replayHandler);
+
+                    assertEquals(REPLAY_INCOMPLETE, result.status());
+                    assertFalse(result.complete());
+                    assertTrue("the later-cycle handler must not be invoked", replayHandler.values.isEmpty());
+                    assertEquals(laterIndex, result.lastScannedIndex());
+                    assertEquals(resumeIndex, realResumeTailer.index());
+                    if (disableCodegen)
+                        assertTrue(methodReaderReference.get() instanceof VanillaMethodReader);
+                    else
+                        assertTrue(methodReaderReference.get() instanceof AbstractGeneratedMethodReader);
+                }
+            }
+        } finally {
+            restoreProperty(DISABLE_READER_PROXY_CODEGEN, previousCodegenSetting);
+        }
+    }
+
+    private static ChronicleQueue queueReturningReplayTailer(
+            ChronicleQueue delegate, AtomicReference<ExcerptTailer> replayTailerReference) {
+        return (ChronicleQueue) Proxy.newProxyInstance(
+                ChronicleQueue.class.getClassLoader(),
+                new Class<?>[]{ChronicleQueue.class},
+                (proxy, method, arguments) -> {
+                    if ("createTailer".equals(method.getName()) &&
+                            (arguments == null || arguments.length == 0))
+                        return replayTailerReference.get();
+                    return invokeDelegate(method, delegate, arguments);
+                });
+    }
+
+    private static ExcerptTailer tailerWithQueue(ExcerptTailer delegate, ChronicleQueue queueView) {
+        return (ExcerptTailer) Proxy.newProxyInstance(
+                ExcerptTailer.class.getClassLoader(),
+                new Class<?>[]{ExcerptTailer.class},
+                (proxy, method, arguments) -> "queue".equals(method.getName())
+                        ? queueView
+                        : invokeDelegate(method, delegate, arguments));
+    }
+
+    private static ExcerptTailer crossingReplayTailer(
+            ExcerptTailer delegate,
+            ChronicleQueue queueView,
+            int resumeCycle,
+            long laterIndex,
+            AtomicReference<MethodReader> methodReaderReference) {
+        AtomicReference<ExcerptTailer> proxyReference = new AtomicReference<>();
+        boolean[] beforeRead = {true};
+        ExcerptTailer proxy = (ExcerptTailer) Proxy.newProxyInstance(
+                ExcerptTailer.class.getClassLoader(),
+                new Class<?>[]{ExcerptTailer.class},
+                (ignored, method, arguments) -> {
+                    switch (method.getName()) {
+                        case "queue":
+                            return queueView;
+                        case "moveToCycle":
+                            beforeRead[0] = true;
+                            return ((Integer) arguments[0]) == resumeCycle;
+                        case "index":
+                            return beforeRead[0]
+                                    ? queueView.rollCycle().toIndex(resumeCycle, 0)
+                                    : delegate.index();
+                        case "methodReaderBuilder":
+                            return new CapturingMethodReaderBuilder(
+                                    proxyReference.get(), methodReaderReference);
+                        case "readingDocument":
+                            beforeRead[0] = false;
+                            assertTrue(delegate.moveToIndex(laterIndex));
+                            return arguments == null || arguments.length == 0
+                                    ? delegate.readingDocument()
+                                    : delegate.readingDocument((Boolean) arguments[0]);
+                        default:
+                            return invokeDelegate(method, delegate, arguments);
+                    }
+                });
+        proxyReference.set(proxy);
+        return proxy;
+    }
+
+    private void missingReplayMethodFails(boolean disableCodegen) {
+        String previousCodegenSetting = System.getProperty(DISABLE_READER_PROXY_CODEGEN);
+        System.setProperty(DISABLE_READER_PROXY_CODEGEN, Boolean.toString(disableCodegen));
+        try {
+            File path = getTmpDir();
+            SetTimeProvider timeProvider = new SetTimeProvider(INITIAL_TIME_NANOS);
+            try (ChronicleQueue queue = marketQueueBuilder(path, timeProvider).build()) {
+                try (ExcerptAppender appender = queue.createAppender()) {
+                    MarketEvents writer = appender.methodWriter(MarketEvents.class);
+                    writer.trade(17, 10);
+                }
+                long resumeIndex = persistAfterReading(queue, "missing-handler", 1);
+
+                try (ExcerptTailer tailer = queue.createTailer()) {
+                    assertTrue(tailer.moveToIndex(resumeIndex));
+                    IllegalStateException exception = assertThrows(IllegalStateException.class,
+                            () -> TailerContextRecovery.replayCurrentCycleContext(
+                                    tailer, new NoOpMarketDataHandler()));
+                    assertTrue(exception.getMessage(), exception.getMessage().contains("instrument"));
+                    assertEquals(resumeIndex, tailer.index());
+                }
+            }
+        } finally {
+            restoreProperty(DISABLE_READER_PROXY_CODEGEN, previousCodegenSetting);
+        }
+    }
+
+    private static final class CapturingMethodReaderBuilder extends VanillaMethodReaderBuilder {
+        private final AtomicReference<MethodReader> methodReaderReference;
+
+        private CapturingMethodReaderBuilder(
+                ExcerptTailer tailer, AtomicReference<MethodReader> methodReaderReference) {
+            super(tailer);
+            this.methodReaderReference = methodReaderReference;
+        }
+
+        @Override
+        public MethodReader build(Object... implementations) {
+            MethodReader methodReader = super.build(implementations);
+            methodReaderReference.set(methodReader);
+            return methodReader;
+        }
+    }
+
+    private static Object invokeDelegate(Method method, Object delegate, Object[] arguments) throws Throwable {
+        try {
+            return method.invoke(delegate, arguments);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    private static SingleChronicleQueueBuilder queueBuilder(File path, SetTimeProvider timeProvider) {
+        return SingleChronicleQueueBuilder.binary(path)
+                .rollCycle(TEST_SECONDLY)
+                .timeProvider(timeProvider);
+    }
+
+    private static SingleChronicleQueueBuilder marketQueueBuilder(File path, SetTimeProvider timeProvider) {
+        return queueBuilder(path, timeProvider)
+                .contextListener(MarketContext.class, context -> context.instrument(17, "EUR/USD"));
+    }
+
+    private static void writeReplayEvents(ChronicleQueue queue, String... values) {
+        try (ExcerptAppender appender = queue.createAppender()) {
+            ReplayEvents writer = appender.methodWriter(ReplayEvents.class);
+            for (String value : values)
+                writer.context(value);
+        }
+    }
+
+    private static long persistAfterReading(ChronicleQueue queue, String tailerName, int documents) {
+        RecordingReplayHandler handler = new RecordingReplayHandler();
+        try (ExcerptTailer tailer = queue.createTailer(tailerName)) {
+            MethodReader reader = tailer.methodReader(handler);
+            for (int i = 0; i < documents; i++)
+                assertTrue(reader.readOne());
+            return tailer.index();
+        }
+    }
+
+    private static File[] cycleFiles(File path) {
+        File[] files = path.listFiles((directory, name) -> name.endsWith(".cq4"));
+        assertNotNull(files);
+        Arrays.sort(files, Comparator.comparing(File::getName));
+        return files;
+    }
+
+    private static void restoreProperty(String property, String previousValue) {
+        if (previousValue == null)
+            System.clearProperty(property);
+        else
+            System.setProperty(property, previousValue);
+    }
+
+    public interface ReplayEvents {
+        void context(String value);
+    }
+
+    public static final class RecordingReplayHandler implements ReplayEvents {
+        private final List<String> values = new ArrayList<>();
+
+        @Override
+        public void context(String value) {
+            values.add(value);
+        }
+    }
+
+    public static final class DeletingRecordingReplayHandler implements ReplayEvents {
+        private final List<String> values = new ArrayList<>();
+        private final File currentCycle;
+        private final File followingCycle;
+        private boolean deleted;
+
+        private DeletingRecordingReplayHandler(File currentCycle, File followingCycle) {
+            this.currentCycle = currentCycle;
+            this.followingCycle = followingCycle;
+        }
+
+        @Override
+        public void context(String value) {
+            values.add(value);
+            if (deleted)
+                return;
+            deleted = true;
+            try {
+                Files.delete(currentCycle.toPath());
+                Files.delete(followingCycle.toPath());
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        }
+    }
+
+    public interface MarketContext {
+        void instrument(int symbolId, String name);
+    }
+
+    public interface MarketData {
+        void trade(int symbolId, long quantity);
+    }
+
+    public interface MarketEvents extends MarketContext, MarketData {
+    }
+
+    public static final class MarketProjection implements MarketContext {
+        private final Map<Integer, String> symbolNames = new HashMap<>();
+
+        @Override
+        public void instrument(int symbolId, String name) {
+            symbolNames.put(symbolId, name);
+        }
+
+        private String symbolName(int symbolId) {
+            return symbolNames.get(symbolId);
+        }
+    }
+
+    public static final class NoOpMarketDataHandler implements MarketData {
+        @Override
+        public void trade(int symbolId, long quantity) {
+            // Replay must consume ordinary data methods without repeating their business effects.
+        }
+    }
+
+    public static final class MarketEventHandler implements MarketEvents {
+        private final MarketProjection projection;
+        private final List<String> trades = new ArrayList<>();
+
+        private MarketEventHandler(MarketProjection projection) {
+            this.projection = projection;
+        }
+
+        @Override
+        public void instrument(int symbolId, String name) {
+            projection.instrument(symbolId, name);
+        }
+
+        @Override
+        public void trade(int symbolId, long quantity) {
+            String symbolName = projection.symbolName(symbolId);
+            if (symbolName == null)
+                throw new IllegalStateException("Missing instrument context for " + symbolId);
+            trades.add(symbolName + ":" + quantity);
+        }
+    }
+}


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged current #1725 parent `71c9db2f3c9f6a55a4cc5bc487802253df83930c` into the existing branch without rewriting history. Updated head: `7ed74eee9c7fd0e7f272370afc254ce183533296`. Both the declared base and develop are ancestors of this head.

Fresh Linux/OpenJDK 21 focused Maven verify and Javadocs passed: 57 recovery, context-listener and named-tailer tests, no failures, errors or skips. The branch now contains all 14 missing parent commits, including develop. Two completed default full-suite runs each reported six filesystem-wide free-space assertion failures; the single-fork diagnostic later hit an unchanged method-writer timeout and cascading resource-leak failures and was stopped. Both implicated shared test sources are byte-identical to the old head and current parent. Full-suite/platform CI remains required; no unrelated worker-cleanup or feature PR was imported to conceal these failures.

Platform CI and repository merge gates remain separate. Earlier implementation and validation details follow; their recorded results apply to the revisions stated there.

---

## Summary

- Add `TailerContextRecovery.replayCurrentCycleContext(...)` for rebuilding same-cycle context before a restarted named tailer resumes.
- Replay through a temporary unnamed tailer without advancing the supplied named tailer.
- Return an explicit status for no persisted position, cycle start, successful replay, unavailable cycles, and incomplete replay.
- Document the side-effect-free handler requirement and the restart pattern.

## Scope and dependency

Depends on #1725 and its Queue/Wire context-listener contract. This PR is independent of roll-file cleanup and does not add any cleanup analysis, retention policy or CLI to Chronicle Queue.

The implementation is mined from the source-only #1718 branch, with additional argument-contract coverage and a link from the current context-listener guide.

## Validation

- `mvn -q -o -Dtest=TailerContextRecoveryTest test` - pass (3 tests).
- `mvn -q -o -DskipTests javadoc:javadoc` - pass.
- `/usr/bin/time -p mvn -q -o clean verify` - 1,154 tests, 1 failure, 0 errors, 52 skipped; 158.83 seconds.
  - The sole failure is the pre-existing `TestDeleteQueueFile` exception-tracker race: it observes the expected “current cycle seems to have been deleted” recovery diagnostic. The same failure is documented on the underlying #1725 branch.
- `git diff --check feature/QUEUE-144-queue-context-listener-core-split-base...HEAD` - pass.
