### PR TITLE
QUEUE-143: Make deleted-cycle recovery deterministic

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -34,6 +36,7 @@ import java.util.stream.IntStream;
 
 import static java.lang.Long.toHexString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 @SuppressWarnings("this-escape")
@@ -209,6 +212,19 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     @Test
     public void tailingThroughDeletedCyclesWillRefreshThenRetry_ReadOnly() throws IOException {
         tailingThroughDeletedCyclesWillRefreshThenRetry(qwcd -> SingleChronicleQueueBuilder.binary(qwcd.queue.fileAbsolutePath())
+                .rollCycle(RollCycles.FAST_DAILY)
+                .readOnly(true)
+                .build());
+    }
+
+    @Test
+    public void tailingThroughDeletedCyclesWillRecoverToLaterCycle_Writable() throws IOException {
+        tailingThroughDeletedCyclesWillRecoverToLaterCycle(qwcd -> qwcd.queue);
+    }
+
+    @Test
+    public void tailingThroughDeletedCyclesWillRecoverToLaterCycle_ReadOnly() throws IOException {
+        tailingThroughDeletedCyclesWillRecoverToLaterCycle(qwcd -> SingleChronicleQueueBuilder.binary(qwcd.queue.fileAbsolutePath())
                 .rollCycle(RollCycles.FAST_DAILY)
                 .readOnly(true)
                 .build());
@@ -495,6 +511,54 @@ public class TestDeleteQueueFile extends QueueTestCommon {
                 }
             }
             assertEquals(10, counter); // we still get 10 because the current store is in memory
+        }
+    }
+
+    private void tailingThroughDeletedCyclesWillRecoverToLaterCycle(Function<QueueWithCycleDetails, SingleChronicleQueue> queueCreator) throws IOException {
+        assumeFalse(OS.isWindows());
+        expectException("The current cycle seems to have been deleted from under the queue, scanning to find the next remaining cycle");
+
+        try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(3, null);
+             SingleChronicleQueue queue = queueCreator.apply(queueWithCycleDetails)
+        ) {
+            RollCycleDetails firstCycle = queueWithCycleDetails.rollCycles.get(0);
+            RollCycleDetails secondCycle = queueWithCycleDetails.rollCycles.get(1);
+            RollCycleDetails thirdCycle = queueWithCycleDetails.rollCycles.get(2);
+
+            List<String> observedText = new ArrayList<>();
+            List<Long> observedIndexes = new ArrayList<>();
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                String firstText = tailer.readText();
+                assertEquals("test1", firstText);
+                observedText.add(firstText);
+                observedIndexes.add(tailer.lastReadIndex());
+
+                // Delete the mapped current cycle and the next cycle. The third cycle remains on disk,
+                // so recovery must scan past both deleted files and continue from that later cycle.
+                Files.delete(Paths.get(firstCycle.filename));
+                Files.delete(Paths.get(secondCycle.filename));
+
+                String text;
+                while ((text = tailer.readText()) != null) {
+                    observedText.add(text);
+                    observedIndexes.add(tailer.lastReadIndex());
+                }
+
+                assertEquals(thirdCycle.lastIndex, tailer.lastReadIndex());
+            }
+
+            List<String> expectedText = new ArrayList<>();
+            expectedText.addAll(Collections.nCopies(NUM_REPEATS, "test1"));
+            expectedText.addAll(Collections.nCopies(NUM_REPEATS, "test3"));
+            assertEquals(expectedText, observedText);
+            assertEquals(NUM_REPEATS * 2, observedIndexes.size());
+            assertTrue(observedIndexes.stream()
+                    .noneMatch(index -> queue.rollCycle().toCycle(index) == secondCycle.rollCycle));
+            for (int i = 1; i < observedIndexes.size(); i++)
+                assertTrue("indexes must increase: " + observedIndexes,
+                        observedIndexes.get(i) > observedIndexes.get(i - 1));
+            assertEquals(thirdCycle.lastIndex,
+                    observedIndexes.get(observedIndexes.size() - 1).longValue());
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
@@ -36,6 +36,7 @@ import java.util.stream.IntStream;
 
 import static java.lang.Long.toHexString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
@@ -538,11 +539,11 @@ public class TestDeleteQueueFile extends QueueTestCommon {
                 Files.delete(Paths.get(firstCycle.filename));
                 Files.delete(Paths.get(secondCycle.filename));
 
-                String text;
-                while ((text = tailer.readText()) != null) {
-                    observedText.add(text);
+                for (int i = 1; i < NUM_REPEATS * 2; i++) {
+                    observedText.add(tailer.readText());
                     observedIndexes.add(tailer.lastReadIndex());
                 }
+                assertNull("recovery must end after the surviving messages", tailer.readText());
 
                 assertEquals(thirdCycle.lastIndex, tailer.lastReadIndex());
             }
@@ -551,14 +552,12 @@ public class TestDeleteQueueFile extends QueueTestCommon {
             expectedText.addAll(Collections.nCopies(NUM_REPEATS, "test1"));
             expectedText.addAll(Collections.nCopies(NUM_REPEATS, "test3"));
             assertEquals(expectedText, observedText);
-            assertEquals(NUM_REPEATS * 2, observedIndexes.size());
-            assertTrue(observedIndexes.stream()
-                    .noneMatch(index -> queue.rollCycle().toCycle(index) == secondCycle.rollCycle));
-            for (int i = 1; i < observedIndexes.size(); i++)
-                assertTrue("indexes must increase: " + observedIndexes,
-                        observedIndexes.get(i) > observedIndexes.get(i - 1));
-            assertEquals(thirdCycle.lastIndex,
-                    observedIndexes.get(observedIndexes.size() - 1).longValue());
+            List<Long> expectedIndexes = new ArrayList<>();
+            for (RollCycleDetails cycle : new RollCycleDetails[]{firstCycle, thirdCycle}) {
+                for (long index = cycle.firstIndex; index <= cycle.lastIndex; index++)
+                    expectedIndexes.add(index);
+            }
+            assertEquals(expectedIndexes, observedIndexes);
         }
     }
 


### PR DESCRIPTION
Add independent regressions for recovery when a tailer has mapped its current cycle, that cycle and the next cycle are deleted, and a later cycle remains. Retain the original all-cycles-deleted regressions unchanged; they exercise a different recovery path.

Both writable and read-only variants read the first payload before deletion, drain exactly the expected number of remaining messages, explicitly assert end of queue, and compare every recovered payload and index with the fixture's first/third-cycle sequence. The tailer is explicitly closed. A repeating recovery path now fails at the bounded end assertion, while missing/incorrect intermediate indexes fail the exact list comparison.

Validation on 12 September 2026: full serial `mvn -o clean verify` on Linux x86-64/OpenJDK 21 passes 1,116 reported tests, 52 skips, zero failures/errors/retries. The original and added writable/read-only variants execute. `git diff --check` passes.

The unlink-while-mapped scenarios explicitly skip Windows, so Windows CI does not exercise these particular paths. Current-head platform CI and repository review checks remain outstanding.

This is independent additive test coverage against develop, with no production-code or RollFileCleanup changes. Queue #1724 owns its separate directory-listing correction.

<!-- teamcity-repair-batch10-20260912 -->

### Authenticated Zing crash and deletion-fixture audit — 12 September 2026

At head `194eee19ab440a1fb6a205c6be23f77ce5432e50`, Zing Java 8 [build 1357335](https://teamcity.chronicle.software/buildConfiguration/Chronicle_ChronicleQueue_SnapshotZing8/1357335), configuration `Chronicle_ChronicleQueue_SnapshotZing8`, ran on agent 1181 / Dev02b-Docker. The first native failure is SIGSEGV at 17:23:59 UTC while `RollCycleTest` is running; the log records a core dump at 17:24:04 and Surefire exits 134, naming that class. Native diagnostics/Surefire dumpstream are not in the ordinary or hidden artifact listing. The exact crashing instruction and repair destination remain unclassified; the Queue/Zing CI maintainers own retrieval from that agent and a pinned comparison.

The deletion chaos test's disk assertion separately fails at 17:24:03 with a 2.1650390625 GiB filesystem free-space decrease. It is muted at the time of the build and passes its second invocation. The core dump is a possible contributor, not a demonstrated explanation. The global free-space measurement cannot attribute those bytes to this test.

Source inspection and an observation-only Java 8 control establish another defect on current develop `4707043f3b1f9a1676a0514ccd3e65afe7ac44ce`: the progressive deletion test constructs both reader Runnables without running them. Expected two first reads, observed zero. Shared [#1756](https://github.com/OpenHFT/Chronicle-Queue/pull/1756), now `fe3d4725e8e2ecf3daa12819de25b625ec0d927e`, makes reader execution mandatory, observes failure and waits before closing Queue. Its full class passes 13 cases with two existing skips on Java 8/21; both chaos cases and both lifecycle controls pass on 32-bit Java 17, with no retries. It also corrects the disk diagnostic without changing its threshold. Incorporate this shared repair after landing; it is not a claim that the crash or disk event is fixed.

Existing [#1739](https://github.com/OpenHFT/Chronicle-Queue/pull/1739) already changes `RollCycleTest` to close its tailer and join its observer before Queue closure. Reuse/review that existing implementation and establish a focused delivery route instead of copying another variation. Its unmerged staged feature head is not a develop control. Exact-head Zing/platform checks and review remain required.
