### PR TITLE
QUEUE-146: keep ordinary appenders on the latest published cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Guidance for agents working on Chronicle Queue
+
+## Formatting
+
+* Wrap new or changed lines at 144 characters. Do not reflow unchanged lines solely to meet this limit.
+
+## Time-bounded reviewer notes
+
+`//!` has a deliberate lifecycle that differs from an ordinary `//` comment:
+
+* Keep `//` comments concise and suitable for indefinite retention. They explain only the durable invariant a maintainer still needs after the
+  change is established.
+* Use `//!` on every behavioural or compatibility change to an existing release-code file while that change is under review. Build metadata
+  needs a note when it changes what downstream users build against. A documentation-only change may need one when its reason is not apparent
+  from the changed text or surrounding behavioural change; use the corresponding comment syntax, for example `<!-- //! ... -->` in XML.
+* Do not add `//!` for import tidies, formatting, or a hunk whose only change is the reviewer note itself.
+* A `//!` note may be deliberately verbose. Explain what observable failure or compatibility risk required the change, why the simpler-looking
+  alternative is unsafe, and name the best test that fails without the change. If no test discriminates it, say so and give the specific reason
+  the change must remain; otherwise consider dropping the change.
+* After every changed hunk is covered, review large hunks again for independent logical changes. One broad `//!` must not make unrelated
+  lifecycle, ordering, compatibility, or failure-policy decisions appear covered; add a separate `//!` section beside each such decision. Do not
+  duplicate notes when the entire hunk enforces one cohesive invariant.
+* Perform the converse review as well: every changed test should be named by a relevant release-code `//!`, or have an explicit review
+  disposition explaining its broader integration or compatibility value. If no rationale claims a test and it adds no distinct evidence, drop
+  it.
+* A nearby permanent `//` comment does not replace the `//!` evidence. Both may coexist: the concise comment records the lasting rule, while the
+  reviewer note records the change-specific evidence and consequences.
+* Do not remove, shorten to an ordinary comment, or omit a relevant `//!` note during cleanup, simplification, squashing, or restacking. Remove
+  a note when its code is removed, when review establishes that no behavioural or compatibility change needs justification, or when maintainers
+  deliberately retire it after the post-merge review period.
+* `//!` notes must survive merge so end users can review them. Their eventual retirement will be selected by age with `git blame`; the retention
+  period is intentionally not fixed yet.
+
+This convention intentionally favours reviewability over short-term comment volume. Do not use `///` for these notes: on JDK 23 and later it is
+a Markdown documentation comment and can fail `-Xlint:all -Werror` when placed next to Javadoc.

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,10 @@
     </parent>
 
     <artifactId>chronicle-queue</artifactId>
-    <version>2026.7-SNAPSHOT</version>
+    <!-- //! This coordinated artifact line publishes the mapped highest-cycle contract used by the
+         //! QUEUE-146 stack; retaining 2026.7 would publish the changed Queue behaviour under the
+         //! superseded release coordinate. Maven coordinates have no Java-level discriminator. -->
+    <version>2026.10-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>OpenHFT/Chronicle Queue</name>
     <description>Java library for persisted low latency messaging (Java 8+)</description>
@@ -65,6 +68,9 @@
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-wire</artifactId>
+            <!-- //! Context-listener compilation requires Wire's new lifecycle API; remove this
+                 //! direct pin once the BOM includes the coordinated QUEUE-144 Wire artifact. -->
+            <version>2026.10-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/ChronicleQueue.java
@@ -432,14 +432,20 @@ public interface ChronicleQueue extends Closeable {
         throw new UnsupportedOperationException();
     }
 
+    //! TableDirectoryListingTest#refreshRejectsMissingPublishedMaximum demonstrates why refresh may incorporate
+    //! removal of closed historical rolls but must reject removal of the published current roll.
     /**
-     * Refreshes this ChronicleQueue's view of the directory used for storing files.
+     * Refreshes this ChronicleQueue's cached view of its roll files.
      * <p>
-     * Invoke this method if you delete file from a chronicle-queue directory
+     * Invoke this method after deleting closed historical {@code .cq4} roll files. The highest published roll
+     * (normally the current roll) must remain while Queue metadata remains; deleting it is unsupported. A writable
+     * Queue detects that inconsistency when it refreshes, opens, or transitions to the missing roll, rather than
+     * performing a filesystem lookup for every append to an already-open mapped roll.
      * <p>
-     * The problem solved by this is that we cache the structure of the queue directory in order to reduce
-     * file system adds latency. Calling this method, after deleting .cq4 files, will update the internal
-     * caches accordingly,
+     * To replace a Queue, close every instance and delete the complete Queue directory, including its metadata,
+     * before creating the replacement.
+     *
+     * @throws IllegalStateException if the highest published roll is missing while Queue metadata remains
      */
     void refreshDirectoryListing();
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/RollingChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/RollingChronicleQueue.java
@@ -42,10 +42,13 @@ public interface RollingChronicleQueue extends ChronicleQueue {
     @Nullable
     SingleChronicleQueueStore storeForCycle(int cycle, final long epoch, boolean createIfAbsent, SingleChronicleQueueStore oldStore);
 
+    //! CycleOverflowTest#maximumUInt31CycleIsNotTreatedAsEmpty documents why callers must use the maximum cycle to
+    //! distinguish an empty Queue: Integer.MAX_VALUE is both the legacy public sentinel here and a valid UInt31 cycle.
     /**
      * Finds and returns the first cycle number in the queue.
      *
-     * @return the first cycle number, or {@code Integer.MAX_VALUE} if no cycles are found.
+     * @return the first cycle number, or {@code Integer.MAX_VALUE} if no cycles are found; compare with
+     *         {@link #lastCycle()} when {@code Integer.MAX_VALUE} must be distinguished from an empty Queue
      */
     int firstCycle();
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/RollingChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/RollingChronicleQueue.java
@@ -52,10 +52,14 @@ public interface RollingChronicleQueue extends ChronicleQueue {
      */
     int firstCycle();
 
+    //! StoreAppenderTest#deletingHighestRollWithMetadataFailsClosed demonstrates why the last cycle is the published
+    //! maximum, not a physical maximum that may move backwards after unsupported deletion of the current roll.
     /**
-     * Finds and returns the last cycle number available in the queue.
+     * Finds and returns the highest cycle published by the queue.
      *
-     * @return the last cycle number, or {@code Integer.MIN_VALUE} if no cycles are found.
+     * @return the highest published cycle, or {@code Integer.MIN_VALUE} if no cycles have been published
+     * @throws IllegalStateException if a writable directory refresh finds that the published maximum is missing
+     *                               while Queue metadata remains
      */
     int lastCycle();
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/RollingResourcesCache.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/RollingResourcesCache.java
@@ -103,11 +103,22 @@ public class RollingResourcesCache {
                 if (parse.isSupported(weekFields.weekBasedYear()) && parse.isSupported(weekFields.weekOfWeekBasedYear())) {
                     int year = Math.toIntExact(parse.getLong(weekFields.weekBasedYear()));
                     int week = Math.toIntExact(parse.getLong(weekFields.weekOfWeekBasedYear()));
-                    LocalDate ld = LocalDate.now()
-                            .withYear(year)
-                            .with(weekFields.weekOfYear(), week)
-                            .with(weekFields.dayOfWeek(), 1);
-                    return Math.toIntExact(ld.toEpochDay());
+                    //! RollingResourcesCacheTest#namedWeeklyFormatRoundTripsCycle,
+                    //! #namedWeeklyFormatRoundTripsLocaleYearBoundaries fail when a week-formatted filename
+                    //! is reconstructed through the current date, calendar year, or week-of-year. Those fields can
+                    //! select another week at locale/year boundaries. Resolve the parsed week-based fields on the
+                    //! roll epoch's weekday, then apply the same length-and-epoch geometry as every other format so
+                    //! resourceFor(cycle) and parseCount(name) remain inverses.
+                    //! ChangeRollCycleTest#changeRollCycleWithReadOnlyTailer is integration evidence; its
+                    //! date-dependent fixture does not discriminate every week-year reconstruction mistake.
+                    final int rollDayOfWeek = LocalDate.ofEpochDay(epoch / ONE_DAY_IN_MILLIS)
+                            .get(weekFields.dayOfWeek());
+                    LocalDate ld = LocalDate.of(year, 7, 1)
+                            .with(weekFields.weekBasedYear(), year)
+                            .with(weekFields.weekOfWeekBasedYear(), week)
+                            .with(weekFields.dayOfWeek(), rollDayOfWeek);
+                    long epochSecond = ld.toEpochDay() * 86400;
+                    return Maths.toInt32((epochSecond - (epoch / 1000)) / (length / 1000));
                 }
                 throw new UnsupportedOperationException("Unable to parse " + name + " using format " + format);
             }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/DirectoryListing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/DirectoryListing.java
@@ -52,14 +52,16 @@ public interface DirectoryListing extends Closeable {
     /**
      * Returns the minimum cycle number created so far.
      *
-     * @return The minimum cycle number.
+     * @return the minimum UInt31 cycle, or {@link net.openhft.chronicle.wire.MarshallableOut#UNSET_CONTEXT}
+     *         if no cycle has been published
      */
     int getMinCreatedCycle();
 
     /**
      * Returns the maximum cycle number created so far.
      *
-     * @return The maximum cycle number.
+     * @return the maximum UInt31 cycle, or {@link net.openhft.chronicle.wire.MarshallableOut#UNSET_CONTEXT}
+     *         if no cycle has been published
      */
     int getMaxCreatedCycle();
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/FileSystemDirectoryListing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/FileSystemDirectoryListing.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.util.function.ToIntFunction;
 
 import static net.openhft.chronicle.queue.impl.single.TableDirectoryListing.*;
+import static net.openhft.chronicle.wire.MarshallableOut.UNSET_CONTEXT;
 
 /**
  * The {@code FileSystemDirectoryListing} class is responsible for managing the listing of files
@@ -25,7 +26,9 @@ final class FileSystemDirectoryListing extends SimpleCloseable implements Direct
     private final ToIntFunction<String> fileNameToCycleFunction;
     private final TimeProvider time;
     private int minCreatedCycle = Integer.MAX_VALUE;
-    private int maxCreatedCycle = Integer.MIN_VALUE;
+    //! fileSystemListingDistinguishesMaximumCycleFromUnset requires the same semantic sentinel as the mapped
+    //! implementation so read-only fallback and table-backed queues expose one internal cycle domain.
+    private int maxCreatedCycle = UNSET_CONTEXT;
     private long lastRefreshTimeMS;
 
     /**
@@ -66,28 +69,19 @@ final class FileSystemDirectoryListing extends SimpleCloseable implements Direct
         lastRefreshTimeMS = time.currentTimeMillis();
 
         final String[] fileNamesList = queueDir.list();
-        String minFilename = INITIAL_MIN_FILENAME;
-        String maxFilename = INITIAL_MAX_FILENAME;
+        //! DirectoryPublicationBoundaryTest#fileSystemBoundsUseLogicalCycles requires the read-only fallback to
+        //! agree with mapped refresh for extended-year names; '+' year prefixes are not chronological lexical keys.
+        int min = INITIAL_MIN_CYCLE;
+        int max = UNSET_CONTEXT;
         if (fileNamesList != null) {
             for (String fileName : fileNamesList) {
                 if (fileName.endsWith(SingleChronicleQueue.SUFFIX)) {
-                    if (minFilename.compareTo(fileName) > 0)
-                        minFilename = fileName;
-
-                    if (maxFilename.compareTo(fileName) < 0)
-                        maxFilename = fileName;
+                    int cycle = requireCycle(fileNameToCycleFunction.applyAsInt(fileName), "physical cycle");
+                    min = Math.min(min, cycle);
+                    max = Math.max(max, cycle);
                 }
             }
         }
-
-        // Update the minimum and maximum cycles based on the filenames
-        int min = UNSET_MIN_CYCLE;
-        if (!INITIAL_MIN_FILENAME.equals(minFilename))
-            min = fileNameToCycleFunction.applyAsInt(minFilename);
-
-        int max = UNSET_MAX_CYCLE;
-        if (!INITIAL_MAX_FILENAME.equals(maxFilename))
-            max = fileNameToCycleFunction.applyAsInt(maxFilename);
 
         minCreatedCycle = min;
         maxCreatedCycle = max;
@@ -110,7 +104,9 @@ final class FileSystemDirectoryListing extends SimpleCloseable implements Direct
      */
     @Override
     public int getMinCreatedCycle() {
-        return minCreatedCycle;
+        //! fileSystemListingDistinguishesMaximumCycleFromUnset requires maximum, not Integer.MAX_VALUE minimum, to
+        //! distinguish an empty listing from a listing whose only valid UInt31 cycle is Integer.MAX_VALUE.
+        return maxCreatedCycle == UNSET_CONTEXT ? UNSET_CONTEXT : minCreatedCycle;
     }
 
     /**
@@ -143,7 +139,10 @@ final class FileSystemDirectoryListing extends SimpleCloseable implements Direct
      */
     @Override
     public void onRoll(int cycle) {
-        minCreatedCycle = Math.min(minCreatedCycle, cycle);
-        maxCreatedCycle = Math.max(maxCreatedCycle, cycle);
+        //! fileSystemListingDistinguishesMaximumCycleFromUnset also requires invalid in-process cycle values to be
+        //! rejected before they can collide with the semantic unset state.
+        final int validCycle = requireCycle(cycle, "roll cycle");
+        minCreatedCycle = Math.min(minCreatedCycle, validCycle);
+        maxCreatedCycle = Math.max(maxCreatedCycle, validCycle);
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -49,6 +49,7 @@ import static java.util.Collections.singletonMap;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 import static net.openhft.chronicle.queue.TailerDirection.BACKWARD;
 import static net.openhft.chronicle.queue.TailerDirection.NONE;
+import static net.openhft.chronicle.wire.MarshallableOut.UNSET_CONTEXT;
 import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
 import static net.openhft.chronicle.wire.Wires.acquireBytesScoped;
 
@@ -338,8 +339,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     /**
-     * Refreshes the directory listing, ensuring it is up-to-date.
-     * Throws an exception if the queue has been closed.
+     * {@inheritDoc}
      */
     @Override
     public void refreshDirectoryListing() {
@@ -453,6 +453,10 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 if (commonStore != null)
                     sb.append(commonStore.dump(wireType));
             }
+            //! CycleOverflowTest#maximumUInt31CycleIsNotTreatedAsEmpty requires termination before incrementing the
+            //! highest UInt31 cycle, because int overflow would otherwise restart this loop at Integer.MIN_VALUE.
+            if (i == max)
+                break;
         }
         return sb.toString();
     }
@@ -1034,8 +1038,10 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      */
     @Override
     public long firstIndex() {
-        int cycle = firstCycle();
-        if (cycle == Integer.MAX_VALUE)
+        //! CycleOverflowTest#maximumUInt31CycleIsNotTreatedAsEmpty requires internal emptiness to use UNSET_CONTEXT
+        //! rather than the public firstCycle() sentinel, because Integer.MAX_VALUE is itself a valid UInt31 cycle.
+        final int cycle = firstPublishedCycle();
+        if (cycle == UNSET_CONTEXT)
             return Long.MAX_VALUE;
 
         return rollCycle().toIndex(cycle, 0);
@@ -1112,6 +1118,13 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      */
     @Override
     public int firstCycle() {
+        final int firstCycle = firstPublishedCycle();
+        //! SingleCQFormatTest#testEmptyDirectory preserves the established public empty-Queue sentinel while the
+        //! internal representation uses UNSET_CONTEXT and can distinguish a real Integer.MAX_VALUE cycle.
+        return firstCycle == UNSET_CONTEXT ? Integer.MAX_VALUE : firstCycle;
+    }
+
+    int firstPublishedCycle() {
         setFirstAndLastCycle();
         return directoryListing.getMinCreatedCycle();
     }
@@ -1126,15 +1139,20 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     /**
-     * Returns the last cycle available in the queue by setting the first and last cycle
-     * and then retrieving the maximum created cycle from the directory listing.
+     * Refreshes the directory listing when necessary and returns the highest cycle published by the queue. Closed
+     * historical rolls may be removed, but the published maximum cannot move backwards while Queue metadata remains.
      *
-     * @return the last cycle in the queue
+     * @return the highest published cycle, or {@code Integer.MIN_VALUE} if no cycles have been published
+     * @throws IllegalStateException if a writable directory refresh finds that the published maximum is missing
+     *                               while Queue metadata remains
      */
     @Override
     public int lastCycle() {
         setFirstAndLastCycle();
-        return directoryListing.getMaxCreatedCycle();
+        final int lastCycle = directoryListing.getMaxCreatedCycle();
+        //! SingleCQFormatTest#testEmptyDirectory preserves the established public lastCycle() sentinel even though
+        //! internal consumers and contextCount() use Wire's canonical UNSET_CONTEXT value.
+        return lastCycle == UNSET_CONTEXT ? Integer.MIN_VALUE : lastCycle;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1156,6 +1156,20 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     /**
+     * Returns the latest cycle published by a cooperating writer without the periodic filesystem
+     * refresh performed by {@link #lastCycle()}. This distinction keeps the append hot path from
+     * scanning the queue directory.
+     *
+     * @return the latest UInt31 cycle, or {@link MarshallableOut#UNSET_CONTEXT} if none is published
+     */
+    int lastPublishedCycle() {
+        //! ordinaryAppendUsesPublishedCycleWithoutRefreshingDirectoryListing and
+        //! stalledWriterSeesCyclePublishedByAnotherJvmWithoutRefreshingDirectoryListing fail if
+        //! this delegates to lastCycle(): both require the mapped maximum without a directory refresh.
+        return directoryListing.getMaxCreatedCycle();
+    }
+
+    /**
      * Returns the consumer that handles {@link BytesRingBufferStats}.
      *
      * @return the consumer for ring buffer statistics

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -571,12 +571,10 @@ class StoreAppender extends AbstractCloseable
             writeLock.lock();
 
             try {
-                int cycle = queue.cycle();
-                if (wire == null)
-                    setWireIfNull(cycle);
-
-                if (this.cycle != cycle)
-                    rollCycleTo(cycle);
+                //! writingDocumentIgnoresClockRollback and stalledWriterFollowsAnotherWriterToLaterCycle require
+                //! documents to use the same no-backward destination selector as sequential byte writes; retaining
+                //! the former local-clock selection lets the two public append paths choose different generations.
+                moveToCycleForAppend();
 
                 long safeLength = queue.overlapSize();
                 resetPosition();
@@ -685,9 +683,79 @@ class StoreAppender extends AbstractCloseable
      * @param cycle the cycle for which the wire should be set
      */
     private void setWireIfNull(final int cycle) {
+        setWireIfNull(cycle, WireStoreSupplier.CreateStrategy.CREATE);
+    }
+
+    private void setWireIfNull(final int cycle, WireStoreSupplier.CreateStrategy createStrategy) {
+        //! unusedAppenderDoesNotCreateDeletedPublishedMaximum requires a caller-selected acquisition strategy: the
+        //! unconditional CREATE here would recreate an absent generation already published in Queue metadata.
         normaliseEOFs0(cycle);
 
-        setCycle2(cycle, WireStoreSupplier.CreateStrategy.CREATE);
+        setCycle2(cycle, createStrategy);
+        if (store == null)
+            throw missingPublishedCycle(cycle);
+    }
+
+    /**
+     * Moves an ordinary append to the latest cycle known by either time, this appender, or another
+     * writer. Time-provider rollback must not move an appender back into a historical roll.
+     */
+    private void moveToCycleForAppend() {
+        //! deletingOldestHistoricalRollPreservesPublishedMaximum and
+        //! deletingWholeQueueOfflineAllowsClockSelectedInitialCycle distinguish a retained Queue with a published
+        //! high-water mark from a genuinely new Queue. The shared maximum therefore remains the ordinary-write floor
+        //! while metadata exists; only a newer target may be created.
+        final int publishedCycle = queue.lastPublishedCycle();
+        final boolean hasPublishedCycle = publishedCycle != UNSET_CONTEXT;
+        // Supported retention keeps the published maximum; taking it with time prevents clock
+        // rollback while still allowing a writer to advance normally.
+        final int targetCycle = hasPublishedCycle ? Math.max(queue.cycle(), publishedCycle) : queue.cycle();
+        final boolean publishedCycleMustExist = hasPublishedCycle && targetCycle == publishedCycle;
+        if (wire == null) {
+            //! incompletePublishedCycleIsReinitialised, stalledAppenderReinitialisesIncompletePublishedCycle and StoreTailerTest's
+            //! shouldHaltAtPartiallyInitialisedRollCycle require REINITIALIZE_EXISTING rather than READ_ONLY:
+            //! it still refuses an absent pathname, but preserves Queue's established recovery of an existing
+            //! generation whose first header never completed.
+            setWireIfNull(targetCycle, publishedCycleMustExist
+                    ? WireStoreSupplier.CreateStrategy.REINITIALIZE_EXISTING
+                    : WireStoreSupplier.CreateStrategy.CREATE);
+            return;
+        }
+
+        //! steadyStateAppenderAndTailerReusePublishedCycleStore requires the strict-forward guard: same-cycle writes
+        //! must reuse the acquired store rather than repeat store-pool and filesystem work for every document. A
+        //! missing published destination is therefore checked when an appender opens or transitions, not by adding
+        //! a pathname check to each append on an already-current mapped store.
+        if (cycle < targetCycle) {
+            if (publishedCycleMustExist)
+                requirePublishedCycle(publishedCycle);
+            rollCycleTo(targetCycle, false, publishedCycleMustExist);
+        }
+    }
+
+    private void requirePublishedCycle(int publishedCycle) {
+        //! stalledAppenderDoesNotRecreateDeletedPublishedMaximum requires a known-missing destination to fail before
+        //! rollCycleTo seals the appender's current store, so the transition needs this separate preflight.
+        //! stalledAppenderReinitialisesIncompletePublishedCycle mutation-fails if that probe merely reads the
+        //! published generation: an interrupted first header is recoverable, while REINITIALIZE_EXISTING still
+        //! returns null instead of creating a genuinely absent pathname.
+        final SingleChronicleQueueStore ignored = queue.pool.acquire(
+                publishedCycle, WireStoreSupplier.CreateStrategy.REINITIALIZE_EXISTING, null);
+        try {
+            if (ignored == null)
+                throw missingPublishedCycle(publishedCycle);
+        } finally {
+            //! AppenderInspectionLifecycleTest#publishedCycleProbePairsStoreFileEvents counts a real stalled-writer
+            //! transition. Direct close releases the mapping but omits the pool's matching onReleased event, so
+            //! retention listeners would permanently count this temporary inspection as an acquired store.
+            if (ignored != null)
+                queue.pool.closeStore(ignored);
+        }
+    }
+
+    private IllegalStateException missingPublishedCycle(int publishedCycle) {
+        return new IllegalStateException("Highest/current roll " + publishedCycle
+                + " disappeared while Queue metadata remains");
     }
 
     /**
@@ -790,12 +858,9 @@ class StoreAppender extends AbstractCloseable
         checkAppendLock();
         writeLock.lock();
         try {
-            int cycle = queue.cycle();
-            if (wire == null)
-                setWireIfNull(cycle);
-
-            if (this.cycle != cycle)
-                rollCycleTo(cycle);
+            //! sequentialWriteBytesIgnoresClockRollback fails if this entry point retains the former clock-only
+            //! selection: bytes would move backwards while writingDocument() follows the shared published maximum.
+            moveToCycleForAppend();
 
             this.positionOfHeader = writeHeader(wire, (int) queue.overlapSize()); // writeHeader sets wire.byte().writePosition
 
@@ -861,7 +926,7 @@ class StoreAppender extends AbstractCloseable
         if (wire == null)
             setWireIfNull(cycle);
 
-        /// if the header number has changed then we will have roll
+        // If the header number has changed, the appender has rolled.
         if (this.cycle != cycle)
             rollCycleTo(cycle, this.cycle > cycle);
 
@@ -999,6 +1064,10 @@ class StoreAppender extends AbstractCloseable
      * @param suppressEOF flag to suppress writing EOF markers
      */
     private void rollCycleTo(final int cycle, boolean suppressEOF) {
+        rollCycleTo(cycle, suppressEOF, false);
+    }
+
+    private void rollCycleTo(final int cycle, boolean suppressEOF, boolean existingOnly) {
 
         // only a valid check if the wire was set.
         if (this.cycle == cycle)
@@ -1009,14 +1078,30 @@ class StoreAppender extends AbstractCloseable
             store.writeEOF(wire, timeoutMS());
         }
 
-        int lastExistingCycle = queue.lastCycle();
+        //! stalledWriterSeesCyclePublishedByAnotherJvmWithoutRefreshingDirectoryListing fails if rollover calls
+        //! lastCycle(): a directory refresh can replace the cooperating writer's destination with an unrelated
+        //! unreported filename and adds filesystem I/O to the append path. testCountExcerptsWhenTheCycleIsRolled,
+        //! testRollCycle and testRead2 pin the corresponding publication and modification-count effects of using the
+        //! mapped maximum here.
+        int lastPublishedCycle = queue.lastPublishedCycle();
 
         // If we're behind the target cycle, roll forward to the last existing cycle first
-        if (lastExistingCycle < cycle && lastExistingCycle != this.cycle && lastExistingCycle >= 0) {
-            setCycle2(lastExistingCycle, WireStoreSupplier.CreateStrategy.READ_ONLY);
+        if (lastPublishedCycle != UNSET_CONTEXT
+                && lastPublishedCycle < cycle
+                && lastPublishedCycle != this.cycle) {
+            setCycle2(lastPublishedCycle, WireStoreSupplier.CreateStrategy.READ_ONLY);
+            if (store == null)
+                throw missingPublishedCycle(lastPublishedCycle);
             rollCycleTo(cycle);
         } else {
-            setCycle2(cycle, WireStoreSupplier.CreateStrategy.CREATE);
+            //! stalledAppenderDoesNotRecreateDeletedPublishedMaximum requires an equality transition to open the
+            //! published target without CREATE; otherwise a removed generation is silently replaced after the
+            //! source store has been sealed.
+            setCycle2(cycle, existingOnly
+                    ? WireStoreSupplier.CreateStrategy.READ_ONLY
+                    : WireStoreSupplier.CreateStrategy.CREATE);
+            if (existingOnly && store == null)
+                throw missingPublishedCycle(cycle);
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -535,7 +535,10 @@ class StoreAppender extends AbstractCloseable
         count++;
         try {
             return prepareAndReturnWriteContext(metaData);
-        } catch (RuntimeException e) {
+        //! DocumentAcquisitionFailureTest#acquisitionErrorReleasesLockAndRestoresCount injects before Wire header
+        //! entry without a listener. Error must restore nesting just like RuntimeException or later writes reuse
+        //! a context that never opened; the test does not simulate arbitrary partial Wire mutation.
+        } catch (RuntimeException | Error e) {
             count--;
             throw e;
         }
@@ -579,7 +582,9 @@ class StoreAppender extends AbstractCloseable
 
                 // Move readPosition to the start of the context. i.e. readRemaining() == 0
                 wire.bytes().readPosition(wire.bytes().writePosition());
-            } catch (RuntimeException e) {
+            //! DocumentAcquisitionFailureTest#acquisitionErrorReleasesLockAndRestoresCount also requires the shared
+            //! write lock to be released on Error. Counting cleanup alone leaves every subsequent appender blocked.
+            } catch (RuntimeException | Error e) {
                 writeLock.unlock();
                 throw e;
             }
@@ -1261,6 +1266,10 @@ class StoreAppender extends AbstractCloseable
         public void close(boolean unlock) {
             if (!closePreconditionsAreSatisfied()) return;
 
+            //! BufferedDocumentOwnershipTest#bufferedRollbackDoesNotUnlockAnotherAppender fails if private-buffer
+            //! rollback releases the PID-owned lock held by another appender. A buffered context owns no mapped
+            //! write lock; its eventual writeBytes call acquires/releases its own lock, including on failure.
+            unlock &= !buffered;
             try {
                 handleInterrupts();
                 if (handleRollbackOnClose()) return;
@@ -1270,8 +1279,6 @@ class StoreAppender extends AbstractCloseable
                 } else if (wire != null) {
                     if (buffered) {
                         writeBytes(wire.bytes());
-                        unlock = false;
-                        wire.clear();
                     } else {
                         writeBytesInternal(wire.bytes(), metaData);
                         wire = StoreAppender.this.wire;
@@ -1283,7 +1290,15 @@ class StoreAppender extends AbstractCloseable
             } catch (StreamCorruptedException | UnrecoverableTimeoutException e) {
                 throw new IllegalStateException(e);
             } finally {
-                closeCleanup(unlock);
+                //! BufferedDocumentOwnershipTest#failedBufferedFlushDoesNotLeakPayloadIntoNextDocument rejects a
+                //! flush before copying, then reuses the buffer. Clear even on failure: success-only clearing makes
+                //! the next document publish payload from the rejected operation. Cleanup still runs if clear fails.
+                try {
+                    if (buffered && wire != null)
+                        wire.clear();
+                } finally {
+                    closeCleanup(unlock);
+                }
             }
         }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -33,6 +33,7 @@ import java.nio.BufferOverflowException;
 import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueue.WARN_SLOW_APPENDER_MS;
+import static net.openhft.chronicle.wire.MarshallableOut.UNSET_CONTEXT;
 import static net.openhft.chronicle.wire.Wires.*;
 
 /**
@@ -98,14 +99,18 @@ class StoreAppender extends AbstractCloseable
 
         try {
             int lastExistingCycle = queue.lastCycle();
-            int firstCycle = queue.firstCycle();
+            //! CycleOverflowTest#maximumUInt31CycleIsNotTreatedAsEmpty supplies maximum-cycle integration evidence;
+            //! it does not discriminate this constructor's scan alone, since a sole maximum roll has no older roll
+            //! to seal. Retain semantic emptiness here so that valid roll still receives the constructor's normal
+            //! store inspection/reset lifecycle rather than silently bypassing it as an empty Queue.
+            int firstCycle = queue.firstPublishedCycle();
             long start = System.nanoTime();
             int scannedCycle = Integer.MIN_VALUE;
             final WriteLock writeLock = this.queue.writeLock();
             writeLock.lock();
             try {
                 // Process cycles and handle EOF markers
-                if (firstCycle != Integer.MAX_VALUE) {
+                if (firstCycle != UNSET_CONTEXT) {
                     // Backing down until EOF-ed cycle is encountered
                     for (int eofCycle = lastExistingCycle; eofCycle >= firstCycle; eofCycle--) {
                         setCycle2(eofCycle, WireStoreSupplier.CreateStrategy.READ_ONLY);

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -30,6 +30,7 @@ import java.text.ParseException;
 import static net.openhft.chronicle.queue.TailerDirection.*;
 import static net.openhft.chronicle.queue.TailerState.*;
 import static net.openhft.chronicle.queue.impl.single.ScanResult.*;
+import static net.openhft.chronicle.wire.MarshallableOut.UNSET_CONTEXT;
 import static net.openhft.chronicle.wire.NoDocumentContext.INSTANCE;
 import static net.openhft.chronicle.wire.Wires.isEndOfFile;
 
@@ -939,8 +940,10 @@ class StoreTailer extends AbstractCloseable
      */
     private ExcerptTailer doToStart() {
         assert direction != BACKWARD;
-        final int firstCycle = queue.firstCycle();
-        if (firstCycle == Integer.MAX_VALUE) {
+        //! CycleOverflowTest#maximumUInt31CycleIsNotTreatedAsEmpty requires the semantic first-cycle value here: the
+        //! public Integer.MAX_VALUE empty sentinel collides with the highest valid UInt31 cycle.
+        final int firstCycle = queue.firstPublishedCycle();
+        if (firstCycle == UNSET_CONTEXT) {
             state = UNINITIALISED;
             return this;
         }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListing.java
@@ -4,6 +4,7 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.time.TimeProvider;
@@ -16,6 +17,8 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.function.ToIntFunction;
 
+import static net.openhft.chronicle.wire.MarshallableOut.UNSET_CONTEXT;
+
 /**
  * TableDirectoryListing manages the cycle metadata for a Chronicle Queue stored in a table.
  * This class is responsible for keeping track of the minimum and maximum cycle numbers created in the queue.
@@ -27,10 +30,8 @@ class TableDirectoryListing extends AbstractCloseable implements DirectoryListin
     private static final String HIGHEST_CREATED_CYCLE = "listing.highestCycle";
     private static final String LOWEST_CREATED_CYCLE = "listing.lowestCycle";
     private static final String MOD_COUNT = "listing.modCount";
-    static final int UNSET_MAX_CYCLE = Integer.MIN_VALUE;
-    static final int UNSET_MIN_CYCLE = Integer.MAX_VALUE;
-    static final String INITIAL_MIN_FILENAME = Character.toString(Character.MAX_VALUE);
-    static final String INITIAL_MAX_FILENAME = Character.toString(Character.MIN_VALUE);
+    private static final int LEGACY_UNSET_MAX_CYCLE = Integer.MIN_VALUE;
+    static final int INITIAL_MIN_CYCLE = Integer.MAX_VALUE;
     private final TableStore<?> tableStore;
     private final Path queuePath;
     private final ToIntFunction<String> fileNameToCycleFunction;
@@ -81,7 +82,12 @@ class TableDirectoryListing extends AbstractCloseable implements DirectoryListin
 
         tableStore.doWithExclusiveLock(ts -> {
             initLongValues();
-            minCycleValue.compareAndSwapValue(Long.MIN_VALUE, UNSET_MIN_CYCLE);
+            //! freshListingReportsUnsetCycle checks both the semantic -1 and the legacy persisted empty value.
+            //! Old readers narrow this field and recognise only Integer.MIN_VALUE as empty; storing domain -1 would
+            //! send their toEnd() down the non-empty path. Use the legacy encoding here and on empty refresh, while
+            //! decoding Long.MIN_VALUE before narrowing remains necessary for readers racing this initialisation.
+            maxCycleValue.compareAndSwapValue(Long.MIN_VALUE, LEGACY_UNSET_MAX_CYCLE);
+            minCycleValue.compareAndSwapValue(Long.MIN_VALUE, INITIAL_MIN_CYCLE);
             if (modCount.getVolatileValue() == Long.MIN_VALUE) {
                 modCount.compareAndSwapValue(Long.MIN_VALUE, 0);
             }
@@ -125,52 +131,89 @@ class TableDirectoryListing extends AbstractCloseable implements DirectoryListin
             return;
         }
 
-        lastRefreshTimeMS = time.currentTimeMillis();
-
-        final long currentMin0 = minCycleValue.getVolatileValue();
-        final long currentMax0 = maxCycleValue.getVolatileValue();
-
         while (true) {
             throwExceptionIfClosed();
             tableStore.throwExceptionIfClosed();
             Jvm.safepoint();
-            final long currentMax = maxCycleValue.getVolatileValue();
+            //! refreshRetriesWhenLegacyMinimumIsPublishedAfterMaximumCas preserves a late legacy publication;
+            //! it is not an independent discriminator for every observation around the scan. Both bounds still need
+            //! CAS publication because older writers publish min, max, then modCount without taking a new lock.
+            // Writers from before QUEUE-146 do not take a table lock. Observe both legacy publication
+            // fields around the filesystem scan and retry if such a writer moves either one while the
+            // scan is in progress.
+            final long observedModCount = modCount.getVolatileValue();
+            final long observedStoredMin = minCycleValue.getVolatileValue();
+            final long observedStoredMax = maxCycleValue.getVolatileValue();
+            //! persistedCyclesOutsideDomainFailClosed requires every mapped long to be decoded and range checked
+            //! before it participates in cycle arithmetic.
+            final int observedMax = decodeMaxCycle(observedStoredMax);
+            decodeMinCycle(observedStoredMin, observedMax);
 
             final String[] fileNamesList = queuePath.toFile().list();
-            String minFilename = INITIAL_MIN_FILENAME;
-            String maxFilename = INITIAL_MAX_FILENAME;
-            if (fileNamesList != null) {
-                for (String fileName : fileNamesList) {
-                    if (fileName.endsWith(SingleChronicleQueue.SUFFIX)) {
-                        if (minFilename.compareTo(fileName) > 0)
-                            minFilename = fileName;
+            //! failedDirectoryListingDoesNotResetPublishedBounds fails if list()==null is treated as an empty Queue:
+            //! that would replace valid shared bounds with sentinels and could move ordinary writers backwards.
+            // A failed directory read is not evidence that the Queue is empty. Preserve the
+            // published bounds and leave the refresh timestamp unchanged so a later call retries.
+            if (fileNamesList == null)
+                return;
 
-                        if (maxFilename.compareTo(fileName) < 0)
-                            maxFilename = fileName;
-                    }
+            //! CycleOverflowTest#extendedYearFilesRetainLogicalBoundsAfterRefreshAndReopen requires numeric bounds:
+            //! a built-in daily/hourly filename for a large valid cycle starts with '+', which sorts before 1970.
+            //! Parse and validate every candidate before publishing either bound; lexical extrema can falsely report
+            //! the present maximum as deleted. Malformed interior names now also fail this explicit refresh.
+            int min = INITIAL_MIN_CYCLE;
+            int max = UNSET_CONTEXT;
+            for (String fileName : fileNamesList) {
+                if (fileName.endsWith(SingleChronicleQueue.SUFFIX)) {
+                    int cycle = requireCycle(fileNameToCycleFunction.applyAsInt(fileName), "physical cycle");
+                    min = Math.min(min, cycle);
+                    max = Math.max(max, cycle);
                 }
             }
 
-            int min = UNSET_MIN_CYCLE;
-            if (!INITIAL_MIN_FILENAME.equals(minFilename))
-                min = fileNameToCycleFunction.applyAsInt(minFilename);
-
-            int max = UNSET_MAX_CYCLE;
-            if (!INITIAL_MAX_FILENAME.equals(maxFilename))
-                max = fileNameToCycleFunction.applyAsInt(maxFilename);
-
-            if (currentMin0 == min && currentMax0 == max) {
-                modCount.addAtomicValue(1);
-                return;
+            if (observedModCount != modCount.getVolatileValue()
+                    || observedStoredMin != minCycleValue.getVolatileValue()
+                    || observedStoredMax != maxCycleValue.getVolatileValue()) {
+                Jvm.nanoPause();
+                continue;
             }
 
-            minCycleValue.setOrderedValue(min);
-            if (maxCycleValue.compareAndSwapValue(currentMax, max)) {
-                modCount.addAtomicValue(1);
-                break;
+            // Supported maintenance retains the highest/current roll. Losing it while metadata
+            // survives is an inconsistent Queue, not permission to move ordinary writes backward.
+            //! refreshRejectsMissingPublishedMaximum, refreshRejectsMissingLegacyPublication and
+            //! publishedCycleZeroMissingItsFileFailsClosed fail if a scan may lower the mapped maximum while
+            //! metadata survives. The explicit UNSET_CONTEXT comparison keeps published cycle zero in this check.
+            //! TestDeleteQueueFile#deletingOldFilesChaosTest is retention integration evidence, now with live
+            //! forward/backward workers and checked progress, not a discriminator for this guard. The old tests
+            //! permitting live highest-roll deletion are deliberately replaced: SingleChronicleQueueTest's
+            //! testToEndAfterOfflineQueueDeletion retains whole-Queue deletion only after all handles close.
+            if (observedMax != UNSET_CONTEXT && max < observedMax)
+                throw new IllegalStateException("Highest/current roll " + observedMax
+                        + " disappeared while Queue metadata remains");
+
+            //! DirectoryPublicationBoundaryTest#readOnlyTailerSeesMinimumBeforeRefreshedMaximum pauses after the
+            //! maximum CAS. Minimum must already be visible: publishing maximum first exposes MAX_VALUE/7 to a
+            //! read-only tailer and strands it at a fictitious first cycle. Maximum commits the non-empty state,
+            //! matching onRoll and legacy writers; each failed CAS still retries against fresh physical bounds.
+            if (!minCycleValue.compareAndSwapValue(observedStoredMin, min)) {
+                Jvm.nanoPause();
+                continue;
             }
-            Jvm.nanoPause();
+            //! freshListingReportsUnsetCycle also checks empty refresh's old-reader storage encoding. The semantic
+            //! UNSET_CONTEXT comparison above remains independent of that persisted representation.
+            final long storedMax = max == UNSET_CONTEXT ? LEGACY_UNSET_MAX_CYCLE : max;
+            if (!maxCycleValue.compareAndSwapValue(observedStoredMax, storedMax)) {
+                Jvm.nanoPause();
+                continue;
+            }
+
+            modCount.addAtomicValue(1);
+            break;
         }
+        //! failedDirectoryListingDoesNotResetPublishedBounds also requires a failed scan to remain retryable.
+        //! Assigning the refresh time only after successful publication prevents an automatic refresh from being
+        //! suppressed by a directory read that returned no listing.
+        lastRefreshTimeMS = time.currentTimeMillis();
     }
 
     /**
@@ -191,8 +234,11 @@ class TableDirectoryListing extends AbstractCloseable implements DirectoryListin
      */
     @Override
     public void onRoll(int cycle) {
-        minCycleValue.setMinValue(cycle);
-        maxCycleValue.setMaxValue(cycle);
+        //! onRollRejectsCyclesOutsideUInt31 ensures invalid in-process values cannot enter the same mapped fields
+        //! whose restart path now rejects corrupt persisted values.
+        final int validCycle = requireCycle(cycle, "roll cycle");
+        minCycleValue.setMinValue(validCycle);
+        maxCycleValue.setMaxValue(validCycle);
         modCount.addAtomicValue(1);
     }
 
@@ -259,7 +305,12 @@ class TableDirectoryListing extends AbstractCloseable implements DirectoryListin
      * @return The maximum cycle value.
      */
     private int getMaxCycleValue() {
-        return (int) maxCycleValue.getVolatileValue();
+        //! freshListingReportsUnsetCycle, readOnlyListingDecodesLegacyUnsetCycle,
+        //! readOnlyListingDecodesRawStorageSentinelAsUnset,
+        //! readOnlyListingHidesPartiallyPublishedCycleZero, unsetToCycleZeroPublicationSurvivesReopen and
+        //! persistedCyclesOutsideDomainFailClosed require storage sentinels and corrupt values to be handled before
+        //! narrowing. Writable initialisation reduces the observation window but is not a prerequisite for reads.
+        return decodeMaxCycle(maxCycleValue.getVolatileValue());
     }
 
     /**
@@ -268,6 +319,43 @@ class TableDirectoryListing extends AbstractCloseable implements DirectoryListin
      * @return The minimum cycle value.
      */
     private int getMinCycleValue() {
-        return (int) minCycleValue.getVolatileValue();
+        //! maximumCycleRoundTripsAsAValidMinimum requires the decoded maximum to carry empty/non-empty state:
+        //! Integer.MAX_VALUE remains both the legacy stored minimum sentinel and a valid UInt31 cycle.
+        //! readOnlyListingHidesPartiallyPublishedCycleZero covers empty-to-non-empty visibility, not every volatile
+        //! read interleaving here. Recheck maximum so a concurrently committed non-empty state cannot be paired with
+        //! the minimum sampled for an earlier empty state; no current test independently discriminates this retry.
+        while (true) {
+            final long storedMax = maxCycleValue.getVolatileValue();
+            final int maximum = decodeMaxCycle(storedMax);
+            final long storedMin = minCycleValue.getVolatileValue();
+            if (storedMax == maxCycleValue.getVolatileValue())
+                return decodeMinCycle(storedMin, maximum);
+            Jvm.nanoPause();
+        }
+    }
+
+    private static int decodeMaxCycle(final long storedCycle) {
+        if (storedCycle == Long.MIN_VALUE
+                || storedCycle == LEGACY_UNSET_MAX_CYCLE
+                || storedCycle == UNSET_CONTEXT)
+            return UNSET_CONTEXT;
+        return requireCycle(storedCycle, HIGHEST_CREATED_CYCLE);
+    }
+
+    private static int decodeMinCycle(final long storedCycle, final int maximumCycle) {
+        if (maximumCycle == UNSET_CONTEXT) {
+            if (storedCycle != Long.MIN_VALUE && storedCycle != UNSET_CONTEXT)
+                requireCycle(storedCycle, LOWEST_CREATED_CYCLE);
+            return UNSET_CONTEXT;
+        }
+        return requireCycle(storedCycle, LOWEST_CREATED_CYCLE);
+    }
+
+    static int requireCycle(final long cycle, final String fieldName) {
+        try {
+            return Maths.toUInt31(cycle);
+        } catch (ArithmeticException e) {
+            throw new IllegalStateException("Invalid UInt31 cycle in " + fieldName + ": " + cycle, e);
+        }
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListing.java
@@ -93,9 +93,24 @@ class TableDirectoryListing extends AbstractCloseable implements DirectoryListin
      * Acquires the necessary LongValues (maxCycle, minCycle, modCount) from the table store.
      */
     protected void initLongValues() {
-        maxCycleValue = tableStore.acquireValueFor(HIGHEST_CREATED_CYCLE);
-        minCycleValue = tableStore.acquireValueFor(LOWEST_CREATED_CYCLE);
-        modCount = tableStore.acquireValueFor(MOD_COUNT);
+        //! DirectoryPublicationBoundaryTest#readOnlyRetryClosesEveryReturnedBinding fails if a retry overwrites a
+        //! binding returned before a later acquisition failed. Acquire transactionally; callers cannot release a
+        //! partially assigned field after it has been lost. Allocation failures before return belong to ValueIn.
+        LongValue maximum = null;
+        LongValue minimum = null;
+        LongValue modifications = null;
+        try {
+            maximum = tableStore.acquireValueFor(HIGHEST_CREATED_CYCLE);
+            minimum = tableStore.acquireValueFor(LOWEST_CREATED_CYCLE);
+            modifications = tableStore.acquireValueFor(MOD_COUNT);
+        } catch (RuntimeException | Error failure) {
+            Closeable.closeQuietly(maximum, minimum, modifications);
+            throw failure;
+        }
+        Closeable.closeQuietly(maxCycleValue, minCycleValue, modCount);
+        maxCycleValue = maximum;
+        minCycleValue = minimum;
+        modCount = modifications;
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
+++ b/src/test/java/net/openhft/chronicle/queue/TestDeleteQueueFile.java
@@ -18,15 +18,21 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -34,6 +40,7 @@ import java.util.stream.IntStream;
 
 import static java.lang.Long.toHexString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 @SuppressWarnings("this-escape")
@@ -44,23 +51,23 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     private final Path tempQueueDir = getTmpDir().toPath();
 
     @Test
-    public void testRefreshDirectoryListingWillUpdateFirstAndLastIndicesCorrectly() throws IOException {
+    public void testRefreshDirectoryListingAfterHistoricalDeletion() throws IOException {
         assumeFalse(OS.isWindows());
 
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(3, null)) {
 
-            // delete the first and last files
+            // Delete only the oldest historical generation; the published maximum remains current.
             Files.delete(Paths.get(queueWithCycleDetails.rollCycles.get(0).filename));
-            Files.delete(Paths.get(queueWithCycleDetails.rollCycles.get(2).filename));
 
             final SingleChronicleQueue queue = queueWithCycleDetails.queue;
             queue.refreshDirectoryListing();
 
             RollCycleDetails secondCycle = queueWithCycleDetails.rollCycles.get(1);
+            RollCycleDetails thirdCycle = queueWithCycleDetails.rollCycles.get(2);
             assertEquals(toHexString(secondCycle.firstIndex), toHexString(queue.firstIndex()));
-            assertEquals(toHexString(secondCycle.lastIndex), toHexString(queue.lastIndex()));
+            assertEquals(toHexString(thirdCycle.lastIndex), toHexString(queue.lastIndex()));
 
-            // and create a tailer it should only read data in second file
+            // A new tailer starts at the oldest surviving historical roll.
             ExcerptTailer excerptTailer2 = queue.createTailer();
             assertEquals(toHexString(secondCycle.firstIndex), toHexString(excerptTailer2.index()));
             readText(excerptTailer2, "test2");
@@ -119,7 +126,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void tailerToEndWorksInFaceOfDeletedStoreFile() throws IOException {
+    public void tailerToEndWorksInFaceOfDeletedHistoricalStoreFile() throws IOException {
         assumeFalse(OS.isWindows());
 
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(3, null)) {
@@ -135,11 +142,11 @@ public class TestDeleteQueueFile extends QueueTestCommon {
             assertEquals(toHexString(thirdCycle.lastIndex + 1), toHexString(tailer.toEnd().index()));
             assertEquals(toHexString(firstCycle.firstIndex), toHexString(tailer.toStart().index()));
 
-            // delete the last store
-            Files.delete(Paths.get(thirdCycle.filename));
+            // Delete only the interior historical store; the current/latest store remains present.
+            Files.delete(Paths.get(secondCycle.filename));
 
             // should be at correct index
-            assertEquals(toHexString(secondCycle.lastIndex + 1), toHexString(tailer.toEnd().index()));
+            assertEquals(toHexString(thirdCycle.lastIndex + 1), toHexString(tailer.toEnd().index()));
         }
     }
 
@@ -161,11 +168,11 @@ public class TestDeleteQueueFile extends QueueTestCommon {
             assertEquals(toHexString(firstCycle.firstIndex), toHexString(tailer.toStart().index()));
             assertEquals(toHexString(thirdCycle.lastIndex + 1), toHexString(tailer.toEnd().index()));
 
-            // delete the last store
-            Files.delete(Paths.get(thirdCycle.filename));
+            // Delete only the interior historical store; the current/latest store remains present.
+            Files.delete(Paths.get(secondCycle.filename));
 
             // should be at correct index
-            assertEquals(toHexString(secondCycle.lastIndex + 1), toHexString(tailer.toEnd().index()));
+            assertEquals(toHexString(thirdCycle.lastIndex + 1), toHexString(tailer.toEnd().index()));
         }
     }
 
@@ -215,22 +222,37 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void deletingOldFilesChaosTest() throws InterruptedException {
+    public void deletingOldFilesChaosTest() throws Exception {
+        // This exercises unlinking actively mapped historical files, which Windows does not support.
+        assumeFalse(OS.isWindows());
         ignoreException("The current cycle seems to have been deleted from under the queue, scanning to find the next remaining cycle");
         final int numberOfCycles = 300;
         final AtomicBoolean running = new AtomicBoolean(true);
+        ExecutorService workers = Executors.newFixedThreadPool(3);
         try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(numberOfCycles, null)) {
-            Thread backwardTailerThread = new Thread(() -> new QueueTailer(running, queueWithCycleDetails, TailerDirection.BACKWARD));
-            Thread forwardTailerThread = new Thread(() -> new QueueTailer(running, queueWithCycleDetails, TailerDirection.FORWARD));
-            Thread deleterThread = new Thread(() -> progressivelyTruncateOldRollCycles(queueWithCycleDetails));
-
-            backwardTailerThread.start();
-            forwardTailerThread.start();
-            deleterThread.start();
-            deleterThread.join();
+            QueueTailer backward = new QueueTailer(running, queueWithCycleDetails, TailerDirection.BACKWARD);
+            QueueTailer forward = new QueueTailer(running, queueWithCycleDetails, TailerDirection.FORWARD);
+            Future<?> backwardTask = workers.submit(backward);
+            Future<?> forwardTask = workers.submit(forward);
+            try {
+                assertTrue(backward.firstRead.await(5, TimeUnit.SECONDS));
+                assertTrue(forward.firstRead.await(5, TimeUnit.SECONDS));
+                workers.submit(() -> progressivelyTruncateOldRollCycles(queueWithCycleDetails)).get(30, TimeUnit.SECONDS);
+            } finally {
+                running.set(false);
+                // Wait for both workers before Queue teardown. A five-second per-Future wait could close their
+                // mappings while a legitimate backward scan was still finishing in a busy full-suite run.
+                workers.shutdown();
+                assertTrue("tailer workers must stop before closing their Queue", workers.awaitTermination(30, TimeUnit.SECONDS));
+                backwardTask.get();
+                forwardTask.get();
+            }
+            assertTrue(backward.documentsRead.get() > 0);
+            assertTrue(forward.documentsRead.get() > 0);
+        } finally {
             running.set(false);
-            forwardTailerThread.join();
-            backwardTailerThread.join();
+            workers.shutdownNow();
+            assertTrue(workers.awaitTermination(5, TimeUnit.SECONDS));
         }
     }
 
@@ -245,8 +267,8 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     }
 
     @Test
-    public void deleteFileFromUnderTailerTest_EndOfRange() throws IOException {
-        deleteFileFromUnderTailerTest(10, 8);
+    public void deleteFileFromUnderTailerTest_EndOfHistoricalRange() throws IOException {
+        deleteFileFromUnderTailerTest(10, 7);
     }
 
     private void deleteFileFromUnderTailerTest(int numberOfCycles, int currentCycleIndex) throws IOException {
@@ -290,12 +312,13 @@ public class TestDeleteQueueFile extends QueueTestCommon {
     private void progressivelyTruncateOldRollCycles(QueueWithCycleDetails queueWithCycleDetails) {
         try {
             int deletedUpTo = 0;
-            // previously used for debug output; removed to avoid commented code smell
-            while (!queueWithCycleDetails.rollCycles.isEmpty()) {
+            // Retain the published/current roll so every refresh stays within the supported deletion contract.
+            while (queueWithCycleDetails.rollCycles.size() > 1) {
                 Jvm.startup().on(TestDeleteQueueFile.class, "Deleting from " + deletedUpTo + " to " + (deletedUpTo + CYCLES_TO_DELETE_PER_ITERATION));
-                for (int i = 0; i < CYCLES_TO_DELETE_PER_ITERATION; i++) {
+                final int cyclesThisIteration = Math.min(CYCLES_TO_DELETE_PER_ITERATION,
+                        queueWithCycleDetails.rollCycles.size() - 1);
+                for (int i = 0; i < cyclesThisIteration; i++) {
                     final RollCycleDetails rollCycleDetails = queueWithCycleDetails.rollCycles.remove(0);
-                    // debug trace removed; keep deletion behaviour unchanged
                     Files.delete(Paths.get(rollCycleDetails.filename));
                     deletedUpTo++;
                 }
@@ -312,8 +335,8 @@ public class TestDeleteQueueFile extends QueueTestCommon {
             int numberOfCycles = queueWithCycleDetails.rollCycles.size();
             int deleted = 0;
             while (queueWithCycleDetails.rollCycles.size() > 1) {
-                // Don't delete the first cycle, we can't deal with that yet
-                final int index = ThreadLocalRandom.current().nextInt(1, queueWithCycleDetails.rollCycles.size());
+                // Choose only among historical rolls; the final entry is the published/current roll.
+                final int index = ThreadLocalRandom.current().nextInt(0, queueWithCycleDetails.rollCycles.size() - 1);
                 final RollCycleDetails rollCycleDetails = queueWithCycleDetails.rollCycles.remove(index);
                 deleted++;
                 Jvm.startup().on(TestDeleteQueueFile.class, "Deleting " + rollCycleDetails.rollCycle + ": " + rollCycleDetails.filename + " (" + deleted + "/" + numberOfCycles + "), firstIndex=" + toHexString(rollCycleDetails.firstIndex) + ", lastIndex=" + toHexString(rollCycleDetails.lastIndex));
@@ -349,11 +372,38 @@ public class TestDeleteQueueFile extends QueueTestCommon {
         }
     }
 
+    @Test
+    public void stoppedDeletionReaderDoesNotReportIncompletePass() {
+        try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(2, null);
+             ExcerptTailer tailer = queueWithCycleDetails.queue.createTailer()) {
+            for (TailerDirection direction : new TailerDirection[]{TailerDirection.FORWARD, TailerDirection.BACKWARD}) {
+                QueueTailer worker = new QueueTailer(new AtomicBoolean(false), queueWithCycleDetails, direction);
+                worker.logIterationResult(direction, tailer, 0, -5);
+            }
+        }
+    }
+
+    @Test
+    public void deletionReaderCanLogAnUnresolvedStartingCycle() throws ReflectiveOperationException {
+        try (QueueWithCycleDetails queueWithCycleDetails = createQueueWithNRollCycles(0, null);
+             ExcerptTailer tailer = queueWithCycleDetails.queue.createTailer()) {
+            // Model the unresolved cursor observed when deletion races the first store acquisition.
+            assertEquals(Integer.MIN_VALUE, tailer.cycle());
+            Field index = tailer.getClass().getDeclaredField("index");
+            index.setAccessible(true);
+            index.setLong(tailer, Long.MIN_VALUE);
+            QueueTailer worker = new QueueTailer(new AtomicBoolean(true), queueWithCycleDetails, TailerDirection.FORWARD);
+            worker.logIterationStart(tailer);
+        }
+    }
+
     private static class QueueTailer implements Runnable {
 
         private final AtomicBoolean running;
         private final QueueWithCycleDetails queueWithCycleDetails;
         private final TailerDirection direction;
+        private final CountDownLatch firstRead = new CountDownLatch(1);
+        private final AtomicLong documentsRead = new AtomicLong();
 
         QueueTailer(AtomicBoolean running, QueueWithCycleDetails queueWithCycleDetails, TailerDirection direction) {
             this.running = running;
@@ -371,7 +421,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
                         } else {
                             tailer.toStart();
                         }
-                        Jvm.startup().on(TestDeleteQueueFile.class, direction + " Tailer starting at index=" + toHexString(tailer.index()) + ", cycle=" + queueWithCycleDetails.queue.rollCycle().toCycle(tailer.index()));
+                        logIterationStart(tailer);
                         int cyclesRead = 0;
                         long lastReadIndex = -5;
                         int currentCycle = -1;
@@ -382,9 +432,11 @@ public class TestDeleteQueueFile extends QueueTestCommon {
                                     break;
                                 }
                                 lastReadIndex = documentContext.index();
+                                documentsRead.incrementAndGet();
+                                firstRead.countDown();
                                 final int cycle = queueWithCycleDetails.queue.rollCycle().toCycle(lastReadIndex);
                                 if (cycle != currentCycle) {
-                                    Jvm.startup().on(TestDeleteQueueFile.class, direction + " reading cycle " + cycle);
+                                    Jvm.debug().on(TestDeleteQueueFile.class, direction + " reading cycle " + cycle);
                                     currentCycle = cycle;
                                     cyclesRead++;
                                 }
@@ -394,22 +446,44 @@ public class TestDeleteQueueFile extends QueueTestCommon {
                             }
                         }
                     }
+                    // Keep repeated reopen coverage without letting empty-boundary spins dominate the test machine.
+                    Jvm.pause(1);
                 }
             } catch (Exception e) {
                 Jvm.error().on(TestDeleteQueueFile.class, "Error occurred", e);
+                throw new AssertionError("Tailer worker failed", e);
             }
             Jvm.startup().on(TestDeleteQueueFile.class, "Tailer thread terminated: " + direction);
         }
 
+        private void logIterationStart(ExcerptTailer tailer) {
+            // Deletion can leave the initial cursor unresolved; diagnostics must not decode its sentinel as a cycle.
+            Jvm.debug().on(TestDeleteQueueFile.class, direction + " Tailer starting at index=" + toHexString(tailer.index())
+                    + ", cycle=" + tailer.cycle());
+        }
+
         private DocumentContext readingDocumentWithRetries(ExcerptTailer excerptTailer) {
-            DocumentContext documentContext = null;
-            for (int i = 0; i < 2; i++) {
-                documentContext = excerptTailer.readingDocument();
-                if (documentContext.isPresent()) {
-                    break;
-                }
+            while (true) {
+                final DocumentContext documentContext = excerptTailer.readingDocument();
+                if (documentContext.isPresent() || reachedAvailableBoundary(excerptTailer) || !running.get())
+                    return documentContext;
+
+                documentContext.close();
+                Jvm.nanoPause();
             }
-            return documentContext;
+        }
+
+        private boolean reachedAvailableBoundary(ExcerptTailer tailer) {
+            final long lastReadIndex = tailer.lastReadIndex();
+            if (direction == TailerDirection.FORWARD) {
+                final OptionalLong last = lastAvailableIndex();
+                return !last.isPresent() || lastReadIndex >= last.getAsLong();
+            }
+            if (direction == TailerDirection.BACKWARD) {
+                final OptionalLong first = firstAvailableIndex();
+                return !first.isPresent() || lastReadIndex <= first.getAsLong();
+            }
+            return true;
         }
 
         private OptionalLong lastAvailableIndex() {
@@ -425,6 +499,9 @@ public class TestDeleteQueueFile extends QueueTestCommon {
         }
 
         private void logIterationResult(TailerDirection direction, ExcerptTailer tailer, int cyclesRead, long lastReadIndex) {
+            // Shutdown can stop the retry loop before a boundary; that is not a completed pass to validate.
+            if (!running.get())
+                return;
             final int remainingCycles = remainingCycles();
             // Check we read at least the number of cycles remaining now
             if (cyclesRead < remainingCycles) {
@@ -476,14 +553,12 @@ public class TestDeleteQueueFile extends QueueTestCommon {
         ) {
             RollCycleDetails firstCycle = queueWithCycleDetails.rollCycles.get(0);
             RollCycleDetails secondCycle = queueWithCycleDetails.rollCycles.get(1);
-            RollCycleDetails thirdCycle = queueWithCycleDetails.rollCycles.get(2);
-
             ExcerptTailer tailer = queue.createTailer();
 
-            // delete the store files
+            // The tailer's mapped first roll remains readable; refresh then skips the deleted second roll and
+            // reaches the ten records in the retained current roll.
             Files.delete(Paths.get(firstCycle.filename));
             Files.delete(Paths.get(secondCycle.filename));
-            Files.delete(Paths.get(thirdCycle.filename));
 
             int counter = 0;
             while (true) {
@@ -494,7 +569,7 @@ public class TestDeleteQueueFile extends QueueTestCommon {
                     counter++;
                 }
             }
-            assertEquals(10, counter); // we still get 10 because the current store is in memory
+            assertEquals(20, counter);
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/bench/QueueSingleThreadedJLBHBenchmark.java
+++ b/src/test/java/net/openhft/chronicle/queue/bench/QueueSingleThreadedJLBHBenchmark.java
@@ -78,14 +78,11 @@ public class QueueSingleThreadedJLBHBenchmark implements JLBHTask {
 
         try (DocumentContext dc = appender.writingDocument()) {
             dc.wire().bytes().write(datumBytes);
-            //datum.writeMarshallable(dc.wire().bytes());
         }
-
         try (DocumentContext dc = tailer.readingDocument()) {
             if (dc.wire() != null) {
                 datumWrite.writePosition(0);
                 dc.wire().readBytes(datumWrite);
-                //datum.readMarshallable(dc.wire().bytes());
                 jlbh.sample(System.nanoTime() - datum.getValue10());
             }
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingChronicleQueueTest.java
@@ -65,7 +65,7 @@ public class RollingChronicleQueueTest extends QueueTestCommon {
                     "listing.lowestCycle: 0\n" +
                     "# position: 232, header: 2\n" +
                     "--- !!data #binary\n" +
-                    "listing.modCount: 10\n" +
+                    "listing.modCount: 8\n" +
                     "# position: 264, header: 3\n" +
                     "--- !!data #binary\n" +
                     "chronicle.write.lock: -9223372036854775808\n" +

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
@@ -5,6 +5,7 @@ package net.openhft.chronicle.queue.impl;
 
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
+import net.openhft.chronicle.queue.RollCycles;
 import net.openhft.chronicle.queue.harness.WeeklyRollCycle;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import org.junit.Test;
@@ -14,6 +15,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -144,6 +146,43 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
             String name = weeklyCache.resourceFor(cycle).text;
             int parsed = weeklyCache.parseCount(name);
             assertEquals(cycle, parsed);
+        }
+    }
+
+    @Test
+    public void namedWeeklyFormatRoundTripsCycle() {
+        final RollingResourcesCache weeklyCache = new RollingResourcesCache(
+                RollCycles.WEEKLY, RollCycles.WEEKLY.defaultEpoch(), File::new, File::getName);
+        final int current = RollCycles.WEEKLY.current(System::currentTimeMillis,
+                RollCycles.WEEKLY.defaultEpoch());
+
+        for (int cycle = current - 10; cycle <= current + 10; cycle++) {
+            final String name = weeklyCache.resourceFor(cycle).text;
+            assertEquals("weekly filename " + name, cycle, weeklyCache.parseCount(name));
+        }
+    }
+
+    @Test
+    public void namedWeeklyFormatRoundTripsLocaleYearBoundaries() {
+        final Locale originalFormatLocale = Locale.getDefault(Locale.Category.FORMAT);
+        try {
+            for (Locale locale : new Locale[]{Locale.US, Locale.UK, Locale.FRANCE}) {
+                Locale.setDefault(Locale.Category.FORMAT, locale);
+                final RollingResourcesCache weeklyCache = new RollingResourcesCache(
+                        RollCycles.WEEKLY, RollCycles.WEEKLY.defaultEpoch(), File::new, File::getName);
+                final long firstMillis = Instant.parse("2018-12-16T00:00:00Z").toEpochMilli();
+                final int firstCycle = Math.toIntExact(Math.floorDiv(
+                        firstMillis - RollCycles.WEEKLY.defaultEpoch(),
+                        RollCycles.WEEKLY.lengthInMillis()));
+
+                for (int cycle = firstCycle; cycle < firstCycle + 170; cycle++) {
+                    final String name = weeklyCache.resourceFor(cycle).text;
+                    assertEquals(locale + " weekly filename " + name,
+                            cycle, weeklyCache.parseCount(name));
+                }
+            }
+        } finally {
+            Locale.setDefault(Locale.Category.FORMAT, originalFormatLocale);
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderInspectionLifecycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/AppenderInspectionLifecycleTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.impl.StoreFileListener;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class AppenderInspectionLifecycleTest extends QueueTestCommon {
+    @Test
+    public void publishedCycleProbePairsStoreFileEvents() {
+        File path = getTmpDir();
+        CountingListener listener = new CountingListener();
+        try (SingleChronicleQueue queue = builder(path, 0).storeFileListener(listener).build();
+             ExcerptAppender stalled = queue.createAppender()) {
+            stalled.writeText("old");
+            try (SingleChronicleQueue other = builder(path, TestRollCycles.TEST_DAILY.lengthInMillis()).build();
+                 ExcerptAppender publisher = other.createAppender()) {
+                publisher.writeText("published");
+            }
+            stalled.writeText("followed");
+            assertEquals(1, stalled.cycle());
+        }
+        BackgroundResourceReleaser.releasePendingResources();
+        assertTrue(listener.acquired.get() >= 3);
+        assertEquals(listener.acquired.get(), listener.released.get());
+    }
+
+    static SingleChronicleQueueBuilder builder(File path, long time) {
+        return SingleChronicleQueueBuilder.binary(path).testBlockSize()
+                .rollCycle(TestRollCycles.TEST_DAILY).timeProvider(() -> time);
+    }
+
+    static final class CountingListener implements StoreFileListener {
+        final AtomicInteger acquired = new AtomicInteger();
+        final AtomicInteger released = new AtomicInteger();
+
+        @Override
+        public void onAcquired(int cycle, File file) {
+            acquired.incrementAndGet();
+        }
+
+        @Override
+        public void onReleased(int cycle, File file) {
+            released.incrementAndGet();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/BufferedDocumentOwnershipTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/BufferedDocumentOwnershipTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
+import net.openhft.chronicle.wire.DocumentContext;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class BufferedDocumentOwnershipTest extends QueueTestCommon {
+    @Test
+    public void bufferedRollbackDoesNotUnlockAnotherAppender() throws Exception {
+        ExecutorService worker = Executors.newSingleThreadExecutor();
+        try (SingleChronicleQueue queue = builder().build(); ExcerptAppender owner = queue.createAppender()) {
+            ExcerptAppender buffered = worker.submit(queue::createAppender).get(5, TimeUnit.SECONDS);
+            try {
+                try (DocumentContext held = owner.writingDocument()) {
+                    held.wire().getValueOut().text("owner");
+                    worker.submit(() -> {
+                        try (DocumentContext document = buffered.writingDocument()) {
+                            document.wire().getValueOut().text("discard");
+                            document.rollbackOnClose();
+                        }
+                    }).get(5, TimeUnit.SECONDS);
+                    assertTrue("a private buffer never owns the other appender's lock", queue.writeLock().locked());
+                }
+                assertFalse(queue.writeLock().locked());
+                try (ExcerptTailer tailer = queue.createTailer()) {
+                    assertEquals("owner", tailer.readText());
+                    assertNull(tailer.readText());
+                }
+            } finally {
+                worker.submit(buffered::close).get(5, TimeUnit.SECONDS);
+            }
+        } finally {
+            worker.shutdownNow();
+            assertTrue(worker.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    public void failedBufferedFlushDoesNotLeakPayloadIntoNextDocument() throws Exception {
+        ExecutorService worker = Executors.newSingleThreadExecutor();
+        try (SingleChronicleQueue queue = builder().build(); ExcerptAppender owner = queue.createAppender()) {
+            ExcerptAppender buffered = worker.submit(queue::createAppender).get(5, TimeUnit.SECONDS);
+            try {
+                DocumentContext first = bufferWhileOwnerWrites(owner, buffered, worker, "failed payload");
+                queue.appendLock().lock();
+                try {
+                    worker.submit(() -> assertThrows(IllegalStateException.class, first::close)).get(5, TimeUnit.SECONDS);
+                } finally {
+                    queue.appendLock().unlock();
+                }
+                assertFalse(queue.writeLock().locked());
+                DocumentContext second = bufferWhileOwnerWrites(owner, buffered, worker, "fresh payload");
+                worker.submit(second::close).get(5, TimeUnit.SECONDS);
+                assertFalse(queue.writeLock().locked());
+                try (ExcerptTailer tailer = queue.createTailer()) {
+                    assertEquals("owner", tailer.readText());
+                    assertEquals("owner", tailer.readText());
+                    assertEquals("fresh payload", tailer.readText());
+                    assertNull(tailer.readText());
+                }
+                assertFalse(queue.dump().contains("failed payload"));
+            } finally {
+                worker.submit(buffered::close).get(5, TimeUnit.SECONDS);
+            }
+        } finally {
+            worker.shutdownNow();
+            assertTrue(worker.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    private DocumentContext bufferWhileOwnerWrites(ExcerptAppender owner, ExcerptAppender buffered,
+                                                  ExecutorService worker, String payload) throws Exception {
+        try (DocumentContext held = owner.writingDocument()) {
+            held.wire().getValueOut().text("owner");
+            return worker.submit(() -> {
+                DocumentContext document = buffered.writingDocument();
+                document.wire().getValueOut().text(payload);
+                return document;
+            }).get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private SingleChronicleQueueBuilder builder() {
+        return SingleChronicleQueueBuilder.binary(getTmpDir()).testBlockSize().doubleBuffer(true)
+                .rollCycle(TestRollCycles.TEST_DAILY).timeProvider(() -> 0);
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
@@ -6,16 +6,47 @@ package net.openhft.chronicle.queue.impl.single;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicLong;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class CycleOverflowTest extends QueueTestCommon {
+
+    @Test
+    public void extendedYearFilesRetainLogicalBoundsAfterRefreshAndReopen() {
+        for (RollCycle rollCycle : new RollCycle[]{TestRollCycles.TEST_DAILY, TestRollCycles.TEST_HOURLY}) {
+            File path = getTmpDir();
+            AtomicLong time = new AtomicLong();
+            try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(path).testBlockSize()
+                    .rollCycle(rollCycle).timeProvider(time::get).build();
+                 ExcerptAppender appender = queue.createAppender()) {
+                appender.writeText("low");
+                time.set((long) Integer.MAX_VALUE * rollCycle.lengthInMillis());
+                appender.writeText("high");
+                queue.refreshDirectoryListing();
+                assertEquals(0, queue.firstCycle());
+                assertEquals(Integer.MAX_VALUE, queue.lastCycle());
+            }
+            try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(path).testBlockSize()
+                    .rollCycle(rollCycle).timeProvider(time::get).build();
+                 ExcerptTailer tailer = queue.createTailer()) {
+                assertEquals(0, queue.firstCycle());
+                assertEquals(Integer.MAX_VALUE, queue.lastCycle());
+                assertEquals("low", tailer.readText());
+                assertTrue(tailer.moveToIndex(rollCycle.toIndex(Integer.MAX_VALUE, 0)));
+                assertEquals("high", tailer.readText());
+            }
+        }
+    }
 
     @Test
     public void overflowingMaxMessagesInCycleShouldThrowException() {
@@ -29,6 +60,44 @@ public class CycleOverflowTest extends QueueTestCommon {
                     appender.writeText(Integer.toString(i));
                 }
             });
+        } finally {
+            IOTools.deleteDirWithFiles(path);
+        }
+    }
+
+    @Test
+    public void maximumUInt31CycleIsNotTreatedAsEmpty() {
+        final File path = getTmpDir();
+        final RollCycle rollCycle = TestRollCycles.TEST_SECONDLY;
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        timeProvider.currentTimeMillis((long) Integer.MAX_VALUE * rollCycle.lengthInMillis());
+        long firstIndex;
+        try {
+            try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(path)
+                    .timeProvider(timeProvider)
+                    .rollCycle(rollCycle)
+                    .build();
+                 ExcerptAppender appender = queue.createAppender()) {
+                appender.writeText("maximum cycle");
+                firstIndex = appender.lastIndexAppended();
+            }
+
+            try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(path)
+                    .timeProvider(timeProvider)
+                    .rollCycle(rollCycle)
+                    .build()) {
+                assertEquals(Integer.MAX_VALUE, queue.firstCycle());
+                assertEquals(Integer.MAX_VALUE, queue.lastCycle());
+                assertEquals(firstIndex, queue.firstIndex());
+                assertTrue(queue.dump().contains("maximum cycle"));
+                try (ExcerptAppender appender = queue.createAppender()) {
+                    appender.writeText("after restart");
+                }
+                try (ExcerptTailer tailer = queue.createTailer()) {
+                    assertEquals("maximum cycle", tailer.readText());
+                    assertEquals("after restart", tailer.readText());
+                }
+            }
         } finally {
             IOTools.deleteDirWithFiles(path);
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/DirectoryPublicationBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/DirectoryPublicationBoundaryTest.java
@@ -4,10 +4,16 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.values.LongValue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.TableStore;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import org.junit.Test;
 
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +23,65 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.*;
 
 public class DirectoryPublicationBoundaryTest extends QueueTestCommon {
+    @Test
+    public void fileSystemBoundsUseLogicalCycles() throws Exception {
+        File path = getTmpDir();
+        assertTrue(path.mkdirs());
+        assertTrue(new File(path, "19700101.cq4").createNewFile());
+        assertTrue(new File(path, "+58815800711.cq4").createNewFile());
+        try (FileSystemDirectoryListing listing = new FileSystemDirectoryListing(path,
+                name -> name.startsWith("+") ? Integer.MAX_VALUE : 0, () -> 0)) {
+            listing.refresh(true);
+            assertEquals(0, listing.getMinCreatedCycle());
+            assertEquals(Integer.MAX_VALUE, listing.getMaxCreatedCycle());
+        }
+    }
+
+    @Test
+    public void readOnlyTailerSeesMinimumBeforeRefreshedMaximum() throws Exception {
+        File path = getTmpDir();
+        long time = 7L * TestRollCycles.TEST_DAILY.lengthInMillis();
+        try (SingleChronicleQueue queue = builder(path, time).build()) {
+            try (ExcerptAppender appender = queue.createAppender()) {
+                appender.writeText("cycle seven");
+            }
+            queue.tableStorePut("listing.lowestCycle", Integer.MAX_VALUE);
+            queue.tableStorePut("listing.highestCycle", Integer.MIN_VALUE);
+            Field listingField = SingleChronicleQueue.class.getDeclaredField("directoryListing");
+            listingField.setAccessible(true);
+            TableDirectoryListing listing = (TableDirectoryListing) listingField.get(queue);
+            Field maximumField = TableDirectoryListing.class.getDeclaredField("maxCycleValue");
+            maximumField.setAccessible(true);
+            LongValue maximum = (LongValue) maximumField.get(listing);
+            AtomicBoolean observed = new AtomicBoolean();
+            LongValue intercepted = (LongValue) Proxy.newProxyInstance(LongValue.class.getClassLoader(),
+                    new Class<?>[]{LongValue.class}, (proxy, method, args) -> {
+                        try {
+                            Object result = method.invoke(maximum, args);
+                            if (method.getName().equals("compareAndSwapValue") && Boolean.TRUE.equals(result)
+                                    && observed.compareAndSet(false, true)) {
+                                // Pause publication after the actual maximum CAS, before refresh can continue.
+                                try (SingleChronicleQueue reader = builder(path, time).readOnly(true).build();
+                                     ExcerptTailer tailer = reader.createTailer()) {
+                                    assertEquals(7, reader.firstCycle());
+                                    assertEquals("cycle seven", tailer.readText());
+                                }
+                            }
+                            return result;
+                        } catch (InvocationTargetException e) {
+                            throw e.getCause();
+                        }
+                    });
+            maximumField.set(listing, intercepted);
+            try {
+                queue.refreshDirectoryListing();
+            } finally {
+                maximumField.set(listing, maximum);
+            }
+            assertTrue(observed.get());
+        }
+    }
+
     @Test
     public void readOnlyRetryClosesEveryReturnedBinding() {
         List<AtomicBoolean> closed = new ArrayList<>();
@@ -59,4 +124,8 @@ public class DirectoryPublicationBoundaryTest extends QueueTestCommon {
         return null;
     }
 
+    private static SingleChronicleQueueBuilder builder(File path, long time) {
+        return SingleChronicleQueueBuilder.binary(path).testBlockSize()
+                .rollCycle(TestRollCycles.TEST_DAILY).timeProvider(() -> time);
+    }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/DirectoryPublicationBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/DirectoryPublicationBoundaryTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.core.values.LongValue;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.impl.TableStore;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class DirectoryPublicationBoundaryTest extends QueueTestCommon {
+    @Test
+    public void readOnlyRetryClosesEveryReturnedBinding() {
+        List<AtomicBoolean> closed = new ArrayList<>();
+        AtomicInteger calls = new AtomicInteger();
+        TableStore<?> table = (TableStore<?>) Proxy.newProxyInstance(TableStore.class.getClassLoader(),
+                new Class<?>[]{TableStore.class}, (proxy, method, args) -> {
+                    if (method.getName().equals("acquireValueFor")) {
+                        if (calls.incrementAndGet() == 2)
+                            throw new IllegalStateException("later binding not ready");
+                        AtomicBoolean state = new AtomicBoolean();
+                        closed.add(state);
+                        return Proxy.newProxyInstance(LongValue.class.getClassLoader(), new Class<?>[]{LongValue.class},
+                                (binding, operation, values) -> {
+                                    if (operation.getName().equals("close")) {
+                                        state.set(true);
+                                        return null;
+                                    }
+                                    if (operation.getName().equals("isClosed"))
+                                        return state.get();
+                                    return defaultValue(operation.getReturnType());
+                                });
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+        try (TableDirectoryListingReadOnly listing = new TableDirectoryListingReadOnly(table, () -> 0)) {
+            listing.init();
+            assertEquals(4, closed.size());
+            assertTrue("the failed attempt must release its returned binding", closed.get(0).get());
+        }
+        assertTrue(closed.stream().allMatch(AtomicBoolean::get));
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (type == boolean.class)
+            return false;
+        if (type == long.class)
+            return 0L;
+        if (type == int.class)
+            return 0;
+        return null;
+    }
+
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentAcquisitionFailureTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/DocumentAcquisitionFailureTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
+import net.openhft.chronicle.wire.Wire;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+
+import static org.junit.Assert.*;
+
+public class DocumentAcquisitionFailureTest extends QueueTestCommon {
+    @Test
+    public void acquisitionErrorReleasesLockAndRestoresCount() throws Exception {
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(getTmpDir()).testBlockSize()
+                .rollCycle(TestRollCycles.TEST_DAILY).timeProvider(() -> 0).build();
+             StoreAppender appender = (StoreAppender) queue.createAppender()) {
+            appender.writeText("before");
+            Field wireField = StoreAppender.class.getDeclaredField("wire");
+            Field countField = StoreAppender.class.getDeclaredField("count");
+            wireField.setAccessible(true);
+            countField.setAccessible(true);
+            Wire original = (Wire) wireField.get(appender);
+            AssertionError injected = new AssertionError("before entering the application header");
+            Wire intercepted = (Wire) Proxy.newProxyInstance(Wire.class.getClassLoader(), new Class<?>[]{Wire.class},
+                    (proxy, method, args) -> {
+                        if (method.getName().equals("enterHeader"))
+                            throw injected;
+                        try {
+                            return method.invoke(original, args);
+                        } catch (InvocationTargetException e) {
+                            throw e.getCause();
+                        }
+                    });
+            wireField.set(appender, intercepted);
+            try {
+                assertSame(injected, assertThrows(AssertionError.class, appender::writingDocument));
+                assertFalse(queue.writeLock().locked());
+                assertEquals(0, countField.getInt(appender));
+            } finally {
+                wireField.set(appender, original);
+                if (queue.writeLock().locked())
+                    queue.writeLock().unlock();
+            }
+            appender.writeText("after");
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                assertEquals("before", tailer.readText());
+                assertEquals("after", tailer.readText());
+                assertNull(tailer.readText());
+            }
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollCycleTest.java
@@ -25,7 +25,9 @@ import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class RollCycleTest extends QueueTestCommon {
 
@@ -41,35 +43,35 @@ public class RollCycleTest extends QueueTestCommon {
         SetTimeProvider timeProvider = new SetTimeProvider();
         ParallelQueueObserver observer = new ParallelQueueObserver(timeProvider, path.toPath());
 
-        try (ChronicleQueue queue = SingleChronicleQueueBuilder
+        try (ChronicleQueue observedQueue = observer.queue;
+             ChronicleQueue queue = SingleChronicleQueueBuilder
                 .binary(path)
                 .testBlockSize()
                 .rollCycle(TEST_DAILY)
                 .timeProvider(timeProvider)
                 .build();
              ExcerptAppender appender = queue.createAppender()) {
-
+            assertFalse(observedQueue.isClosed());
             Thread thread = new Thread(observer);
             thread.start();
+            try {
+                observer.await();
 
-            observer.await();
+                // two days pass
+                timeProvider.advanceMillis(TimeUnit.DAYS.toMillis(2));
 
-            // two days pass
-            timeProvider.advanceMillis(TimeUnit.DAYS.toMillis(2));
+                appender.writeText("0");
 
-            appender.writeText("0");
-
-            // allow parallel tailer to finish iteration
-            for (int i = 0; i < 5_000 && observer.documentsRead != 1; i++) {
-                timeProvider.advanceMicros(100);
-                Thread.sleep(1);
+                // allow parallel tailer to finish iteration
+                for (int i = 0; i < 5_000 && observer.documentsRead != 1; i++) {
+                    timeProvider.advanceMicros(100);
+                    Thread.sleep(1);
+                }
+            } finally {
+                observer.stopAndJoin(thread);
             }
-
-            thread.interrupt();
+            assertEquals(1, observer.documentsRead);
         }
-
-        assertEquals(1, observer.documentsRead);
-        observer.queue.close();
     }
 
     @Test
@@ -281,7 +283,7 @@ public class RollCycleTest extends QueueTestCommon {
                     Thread.sleep(1);
                 }
             } finally {
-                thread.interrupt();
+                observer.stopAndJoin(thread);
             }
 
             assertEquals(1 + cyclesToWrite, observer.documentsRead);
@@ -298,6 +300,8 @@ public class RollCycleTest extends QueueTestCommon {
         ChronicleQueue queue;
         CountDownLatch progressLatch;
         volatile int documentsRead;
+        private volatile boolean running = true;
+        private volatile Throwable failure;
 
         ParallelQueueObserver(TimeProvider timeProvider, @NotNull Path path) {
             queue = SingleChronicleQueueBuilder.binary(path.toFile())
@@ -313,27 +317,42 @@ public class RollCycleTest extends QueueTestCommon {
 
         @Override
         public void run() {
-
-            ExcerptTailer tailer = queue.createTailer();
-
-            progressLatch.countDown();
-
-            int lastDocId = -1;
-            while (!Thread.currentThread().isInterrupted()) {
-
-                String readText = tailer.readText();
-                if (readText != null) {
-                    // System.out.println("Read a document " + readText);
-                    documentsRead++;
-                    int docId = Integer.parseInt(readText);
-                    assertEquals(docId, lastDocId + 1);
-                    lastDocId = docId;
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                progressLatch.countDown();
+                int lastDocId = -1;
+                while (running) {
+                    String readText = tailer.readText();
+                    if (readText != null) {
+                        documentsRead++;
+                        int docId = Integer.parseInt(readText);
+                        assertEquals(docId, lastDocId + 1);
+                        lastDocId = docId;
+                    }
                 }
+            } catch (Throwable observerFailure) {
+                failure = observerFailure;
+            } finally {
+                progressLatch.countDown();
             }
         }
 
         void await() throws InterruptedException {
-            progressLatch.await();
+            assertTrue("observer did not start", progressLatch.await(5, TimeUnit.SECONDS));
+            checkFailure();
+        }
+
+        void stopAndJoin(Thread thread) throws InterruptedException {
+            // Interrupt alone does not establish that a reader has stopped dereferencing its native mapping.
+            // Join before the observer Queue closes, including assertion/failure exits from the test body.
+            running = false;
+            thread.join(10_000);
+            assertFalse("observer must stop before its Queue is closed", thread.isAlive());
+            checkFailure();
+        }
+
+        private void checkFailure() {
+            if (failure != null)
+                throw new AssertionError("Queue observer failed", failure);
         }
 
         public int documentsRead() {
@@ -342,12 +361,10 @@ public class RollCycleTest extends QueueTestCommon {
 
         @Override
         public void onAcquired(int cycle, File file) {
-            // System.out.println("Acquiring " + file);
         }
 
         @Override
         public void onReleased(int cycle, File file) {
-            // System.out.println("Releasing " + file);
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/RollingCycleTest.java
@@ -83,7 +83,7 @@ public class RollingCycleTest extends QueueTestCommon {
                     "listing.lowestCycle: 19059\n" +
                     "# position: 232, header: 2\n" +
                     "--- !!data #binary\n" +
-                    "listing.modCount: 11\n" +
+                    "listing.modCount: 9\n" +
                     "# position: 264, header: 3\n" +
                     "--- !!data #binary\n" +
                     "chronicle.write.lock: -9223372036854775808\n" +

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -29,7 +29,6 @@ import org.junit.runners.Parameterized.Parameters;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -245,7 +244,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testCleanupDir() throws Throwable {
+    public void testCleanupDir() {
         if (OS.isWindows())
             FlakyTestRunner.builder(this::testCleanupDir0).build().run();
         else
@@ -1756,7 +1755,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testToEndOnDeletedQueueFiles() throws IOException {
+    public void testToEndAfterOfflineQueueDeletion() {
         if (OS.isWindows()) {
             System.err.println("#460 Cannot test delete after close on windows");
             return;
@@ -1766,31 +1765,19 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         try (ChronicleQueue q = builder(dir, wireType).build();
              ExcerptAppender append = q.createAppender()) {
             append.writeDocument(w -> w.write("test").text("before text"));
+        }
 
-            ExcerptTailer tailer = q.createTailer(named ? "named" : null);
+        assertTrue("offline deletion must remove the complete Queue directory", IOTools.deleteDirWithFiles(dir));
+        assertTrue("test precondition: recreate the directory for a genuinely new Queue", dir.mkdirs());
 
-            // move to the end even though it doesn't exist yet.
+        try (ChronicleQueue q2 = builder(dir, wireType).build();
+             ExcerptAppender q2Appender = q2.createAppender()) {
+            final ExcerptTailer tailer = q2.createTailer(named ? "named" : null);
             tailer.toEnd();
+            assertEquals(TailerState.UNINITIALISED, tailer.state());
+            q2Appender.writeDocument(w -> w.write("test").text("new queue text"));
 
-            append.writeDocument(w -> w.write("test").text("text"));
-
-            assertTrue(tailer.readDocument(w -> w.read("test").text("text", Assert::assertEquals)));
-
-            try (Stream<Path> cq4Files = Files.find(dir.toPath(), 1, (p, basicFileAttributes) -> p.toString().endsWith("cq4"), FileVisitOption.FOLLOW_LINKS)) {
-                final List<Path> unDeletable = cq4Files.filter(path -> !path.toFile().delete())
-                        .collect(Collectors.toList());
-                assertTrue("Unable to delete" + unDeletable, unDeletable.isEmpty());
-            }
-
-            try (ChronicleQueue q2 = builder(dir, wireType).build();
-                 final ExcerptAppender q2Appender = q2.createAppender()) {
-                tailer = q2.createTailer(named ? "named" : null);
-                tailer.toEnd();
-                assertEquals(TailerState.UNINITIALISED, tailer.state());
-                q2Appender.writeDocument(w -> w.write("test").text("before text"));
-
-                assertTrue(tailer.readDocument(w -> w.read("test").text("before text", Assert::assertEquals)));
-            }
+            assertTrue(tailer.readDocument(w -> w.read("test").text("new queue text", Assert::assertEquals)));
         }
     }
 
@@ -3554,7 +3541,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         return clock;
     }
 
-    private boolean doMappedSegmentUnmappedRollTest(AtomicLong clock, StringBuilder builder) throws IOException, InterruptedException {
+    private boolean doMappedSegmentUnmappedRollTest(AtomicLong clock, StringBuilder builder) throws IOException {
         String time = Instant.ofEpochMilli(clock.get()).toString();
 
         final Random random = new Random(0xDEADBEEF);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -244,7 +244,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void testCleanupDir() {
+    public void testCleanupDir() throws Throwable {
         if (OS.isWindows())
             FlakyTestRunner.builder(this::testCleanupDir0).build().run();
         else

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -3,26 +3,38 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.MappedBytes;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
+import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.impl.StoreFileListener;
+import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
-import net.openhft.chronicle.wire.WriteAfterEOFException;
+import net.openhft.chronicle.wire.Wires;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
+import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 
 public class StoreAppenderTest extends QueueTestCommon {
 
@@ -62,7 +74,303 @@ public class StoreAppenderTest extends QueueTestCommon {
     }
 
     @Test
-    public void testCanWriteAfterWriteAfterEOFExceptionIsThrown() throws IOException {
+    public void deletingOldestHistoricalRollPreservesPublishedMaximum() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong();
+        final File oldestRoll;
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeBytes(Bytes.from("cycle-0"));
+            oldestRoll = appender.currentFile();
+            time.set(TEST_DAILY.lengthInMillis());
+            appender.writeBytes(Bytes.from("cycle-1"));
+            time.set(2L * TEST_DAILY.lengthInMillis());
+            appender.writeBytes(Bytes.from("cycle-2"));
+
+            assertTrue("test precondition: oldest historical roll must be removable", oldestRoll.delete());
+            queue.refreshDirectoryListing();
+            time.set(0);
+            appender.writeBytes(Bytes.from("existing-appender"));
+            assertEquals(2, appender.cycle());
+        }
+
+        try (SingleChronicleQueue reopened = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .build();
+             ExcerptAppender appender = reopened.createAppender()) {
+            appender.writeBytes(Bytes.from("reopened-appender"));
+            assertEquals(2, appender.cycle());
+        }
+    }
+
+    @Test
+    public void stalledAppenderDoesNotRecreateDeletedPublishedMaximum() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong stalledClock = new AtomicLong();
+        final AtomicLong advancingClock = new AtomicLong();
+
+        try (SingleChronicleQueue stalledQueue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(stalledClock::get)
+                .rollCycle(TEST_DAILY)
+                .build();
+             SingleChronicleQueue advancingQueue = SingleChronicleQueueBuilder.binary(directory)
+                     .timeProvider(advancingClock::get)
+                     .rollCycle(TEST_DAILY)
+                     .build();
+             ExcerptAppender stalledWriter = stalledQueue.createAppender()) {
+            stalledWriter.writeBytes(Bytes.from("cycle-0"));
+
+            advancingClock.set(TEST_DAILY.lengthInMillis());
+            final File publishedFile;
+            try (ExcerptAppender advancingWriter = advancingQueue.createAppender()) {
+                advancingWriter.writeBytes(Bytes.from("cycle-1"));
+                publishedFile = advancingWriter.currentFile();
+            }
+
+            assertTrue("test precondition: published maximum must be removed", publishedFile.delete());
+            final long stalledWritePositionBefore = ((StoreAppender) stalledWriter).store.writePosition();
+            final Bytes<?> stalledBytes = ((StoreAppender) stalledWriter).wire().bytes();
+            long end = stalledWritePositionBefore + 4 + Wires.lengthOf(stalledBytes.readInt(stalledWritePositionBefore));
+            final long stalledEnd = end + net.openhft.chronicle.bytes.BytesUtil.padOffset(end);
+            assertEquals(Wires.END_OF_DATA, stalledBytes.readInt(stalledEnd));
+            // Model an unsealed historical source so a duplicate seal is observable independently of writePosition.
+            stalledBytes.writeInt(stalledEnd, Wires.NOT_INITIALIZED);
+
+            // When wall time equals neither a newer nor the published cycle, an ordinary append
+            // must still open the published maximum as existing-only and fail if it disappeared.
+            final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> stalledWriter.writeBytes(Bytes.from("must-fail")));
+            assertTrue(failure.getMessage().contains("Highest/current roll 1 disappeared"));
+            assertFalse("failed append must not recreate the removed generation", publishedFile.exists());
+            assertEquals("failure must precede sealing the stalled roll",
+                    stalledWritePositionBefore, ((StoreAppender) stalledWriter).store.writePosition());
+            assertEquals("failure must not seal an unsealed source", Wires.NOT_INITIALIZED, stalledBytes.readInt(stalledEnd));
+        }
+    }
+
+    @Test
+    public void unusedAppenderDoesNotCreateDeletedPublishedMaximum() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong stalledClock = new AtomicLong();
+        final AtomicLong advancingClock = new AtomicLong(TEST_DAILY.lengthInMillis());
+
+        try (SingleChronicleQueue stalledQueue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(stalledClock::get)
+                .rollCycle(TEST_DAILY)
+                .build();
+             SingleChronicleQueue advancingQueue = SingleChronicleQueueBuilder.binary(directory)
+                     .timeProvider(advancingClock::get)
+                     .rollCycle(TEST_DAILY)
+                     .build();
+             ExcerptAppender unusedAppender = stalledQueue.createAppender()) {
+            final File publishedFile;
+            try (ExcerptAppender advancingWriter = advancingQueue.createAppender()) {
+                advancingWriter.writeBytes(Bytes.from("cycle-1"));
+                publishedFile = advancingWriter.currentFile();
+            }
+
+            assertEquals(1, stalledQueue.lastPublishedCycle());
+            assertTrue("test precondition: published maximum must be removed", publishedFile.delete());
+
+            // A first ordinary write follows the same existing-only rule as an already-live
+            // appender when its target is the published maximum.
+            final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> unusedAppender.writeBytes(Bytes.from("must-fail")));
+            assertTrue(failure.getMessage().contains("Highest/current roll 1 disappeared"));
+            assertFalse("failed append must not recreate the removed generation", publishedFile.exists());
+        }
+    }
+
+    @Test(timeout = 10_000)
+    public void incompletePublishedCycleIsReinitialised() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong();
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .timeoutMS(100)
+                .build()) {
+            try (ExcerptAppender appender = queue.createAppender()) {
+                appender.writeText("cycle-0");
+                time.set(TEST_DAILY.lengthInMillis());
+                appender.writeText("cycle-1");
+            }
+
+            final SingleChronicleQueueStore published = queue.storeForCycle(1, queue.epoch(), false, null);
+            final MappedBytes bytes = published.bytes();
+            bytes.writeInt(0, Wires.NOT_COMPLETE);
+            bytes.releaseLast();
+            queue.closeStore(published);
+
+            expectException("Renamed un-acquirable segment file to");
+            try (ExcerptAppender replacement = queue.createAppender()) {
+                replacement.writeText("recovered-cycle-1");
+                assertEquals(1, replacement.cycle());
+            }
+        }
+    }
+
+    @Test(timeout = 10_000)
+    public void stalledAppenderReinitialisesIncompletePublishedCycle() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong stalledTime = new AtomicLong();
+        final AtomicLong advancingTime = new AtomicLong(TEST_DAILY.lengthInMillis());
+
+        try (SingleChronicleQueue stalledQueue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(stalledTime::get)
+                .rollCycle(TEST_DAILY)
+                .timeoutMS(100)
+                .build();
+             SingleChronicleQueue advancingQueue = SingleChronicleQueueBuilder.binary(directory)
+                     .timeProvider(advancingTime::get)
+                     .rollCycle(TEST_DAILY)
+                     .timeoutMS(100)
+                     .build();
+             ExcerptAppender stalledAppender = stalledQueue.createAppender()) {
+            stalledAppender.writeText("cycle-0");
+            try (ExcerptAppender advancingAppender = advancingQueue.createAppender()) {
+                advancingAppender.writeText("cycle-1");
+            }
+
+            final SingleChronicleQueueStore published = advancingQueue.storeForCycle(
+                    1, advancingQueue.epoch(), false, null);
+            final MappedBytes bytes = published.bytes();
+            bytes.writeInt(0, Wires.NOT_COMPLETE);
+            bytes.releaseLast();
+            advancingQueue.closeStore(published);
+
+            expectException("Renamed un-acquirable segment file to");
+            stalledAppender.writeText("recovered-cycle-1");
+            assertEquals(1, stalledAppender.cycle());
+        }
+    }
+
+    @Test(timeout = 10_000)
+    public void steadyStateAppenderAndTailerReusePublishedCycleStore() throws IOException {
+        final int messageCount = 100;
+        final AtomicInteger acquisitions = new AtomicInteger();
+        final StoreFileListener listener = new StoreFileListener() {
+            @Override
+            public void onAcquired(int cycle, File file) {
+                acquisitions.incrementAndGet();
+            }
+
+            @Override
+            public void onReleased(int cycle, File file) {
+                // No action required: this regression counts unnecessary acquisitions.
+            }
+        };
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDirectory.newFolder())
+                .storeFileListener(listener)
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeText("warm-up");
+            BackgroundResourceReleaser.releasePendingResources();
+            acquisitions.set(0);
+
+            // Multiple iterations catch per-document reacquisition without turning this correctness
+            // regression into a throughput or wall-clock test.
+            for (int i = 0; i < messageCount; i++)
+                appender.writeText("message-" + i);
+
+            BackgroundResourceReleaser.releasePendingResources();
+            assertEquals("steady-state appends must reuse the appender's open store", 0, acquisitions.get());
+
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                try (DocumentContext warmUp = tailer.readingDocument()) {
+                    assertTrue("test precondition: the first document must be readable", warmUp.isPresent());
+                }
+                BackgroundResourceReleaser.releasePendingResources();
+                acquisitions.set(0);
+
+                int read = 1;
+                while (true) {
+                    try (DocumentContext document = tailer.readingDocument()) {
+                        if (!document.isPresent())
+                            break;
+                        read++;
+                    }
+                }
+
+                BackgroundResourceReleaser.releasePendingResources();
+                assertEquals(messageCount + 1, read);
+                assertEquals("steady-state tailing must reuse the tailer's open store", 0, acquisitions.get());
+            }
+        }
+    }
+
+    @Test
+    public void deletingHighestRollWithMetadataFailsClosed() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong();
+        final File highestRoll;
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeBytes(Bytes.from("cycle-0"));
+            time.set(TEST_DAILY.lengthInMillis());
+            appender.writeBytes(Bytes.from("cycle-1"));
+            highestRoll = appender.currentFile();
+            assertEquals(1, queue.lastPublishedCycle());
+        }
+
+        assertTrue("test precondition: highest roll must be removed after every handle is closed",
+                highestRoll.delete());
+        time.set(0);
+
+        final IllegalStateException failure = assertThrows(IllegalStateException.class, () -> {
+            try (SingleChronicleQueue unexpectedlyOpened = SingleChronicleQueueBuilder.binary(directory)
+                    .timeProvider(time::get)
+                    .rollCycle(TEST_DAILY)
+                    .build()) {
+                assertFalse("the constructor must reject the missing current generation",
+                        unexpectedlyOpened.isClosed());
+            }
+        });
+        assertTrue(failure.getMessage().contains("Highest/current roll 1 disappeared"));
+        assertFalse("failed reopen must not recreate the removed current roll", highestRoll.exists());
+    }
+
+    @Test
+    public void deletingWholeQueueOfflineAllowsClockSelectedInitialCycle() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong(3L * TEST_DAILY.lengthInMillis());
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeBytes(Bytes.from("cycle-3"));
+            assertEquals(3, appender.cycle());
+        }
+
+        assertTrue("offline deletion must remove rolls and Queue metadata", IOTools.deleteDirWithFiles(directory));
+        assertTrue("test precondition: recreate the now-new Queue directory", directory.mkdirs());
+        time.set(0);
+
+        try (SingleChronicleQueue newQueue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .build();
+             ExcerptAppender appender = newQueue.createAppender()) {
+            appender.writeBytes(Bytes.from("new-queue"));
+            assertEquals(0, appender.cycle());
+        }
+    }
+
+    @Test
+    public void writingDocumentIgnoresClockRollback() throws IOException {
         final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
 
         clock.addAndGet(-clock.get() % ONE_DAY);
@@ -79,17 +387,154 @@ public class StoreAppenderTest extends QueueTestCommon {
             // Write to a new cycle:
             appender.writingDocument().close();
 
-            // The code now throws WriteAfterEOFException for the old cycle:
+            final int latestCycle = queue.rollCycle().toCycle(appender.lastIndexAppended());
+
+            // A backwards clock must not move an ordinary writer into the sealed old cycle.
             clock.addAndGet(-1); // One millisecond earlier
 
-            assertThrows(WriteAfterEOFException.class, // is this a race?
-                    () -> appender.writingDocument().close());
+            appender.writingDocument().close();
+            assertEquals(latestCycle, queue.rollCycle().toCycle(appender.lastIndexAppended()));
 
             // advance back to the latest cycle and write
             clock.addAndGet(2);
             appender.writingDocument().close();
 
-            assertEquals(3, queue.entryCount());
+            assertEquals(4, queue.entryCount());
+        }
+    }
+
+    @Test
+    public void sequentialWriteBytesIgnoresClockRollback() throws IOException {
+        final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
+        clock.addAndGet(-clock.get() % ONE_DAY);
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder())
+                .timeProvider(clock::get)
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeBytes(Bytes.from("old-cycle"));
+            clock.addAndGet(ONE_DAY);
+            appender.writeBytes(Bytes.from("new-cycle"));
+
+            final int latestCycle = queue.rollCycle().toCycle(appender.lastIndexAppended());
+
+            clock.addAndGet(-1);
+            appender.writeBytes(Bytes.from("must-not-reopen"));
+            assertEquals(latestCycle, queue.rollCycle().toCycle(appender.lastIndexAppended()));
+
+            clock.addAndGet(2);
+            appender.writeBytes(Bytes.from("still-writable"));
+            assertEquals(4, queue.entryCount());
+        }
+    }
+
+    @Test
+    public void stalledWriterFollowsAnotherWriterToLaterCycle() throws IOException {
+        final AtomicLong advancingClock = new AtomicLong(System.currentTimeMillis());
+        advancingClock.addAndGet(-advancingClock.get() % ONE_DAY);
+        final AtomicLong stalledClock = new AtomicLong(advancingClock.get());
+        final File directory = queueDirectory.newFolder();
+
+        try (SingleChronicleQueue advancingQueue = SingleChronicleQueueBuilder.single(directory)
+                .timeProvider(advancingClock::get)
+                .build();
+             SingleChronicleQueue stalledQueue = SingleChronicleQueueBuilder.single(directory)
+                     .timeProvider(stalledClock::get)
+                     .build();
+             ExcerptAppender advancingWriter = advancingQueue.createAppender();
+             ExcerptAppender stalledWriter = stalledQueue.createAppender()) {
+            stalledWriter.writeText("initial");
+
+            advancingClock.addAndGet(3 * ONE_DAY);
+            advancingWriter.writeText("advanced");
+            final int latestCycle = advancingQueue.rollCycle().toCycle(advancingWriter.lastIndexAppended());
+
+            try (DocumentContext document = stalledWriter.writingDocument()) {
+                document.wire().write("message").text("followed-document");
+            }
+            assertEquals(latestCycle, stalledQueue.rollCycle().toCycle(stalledWriter.lastIndexAppended()));
+
+            stalledWriter.writeBytes(Bytes.from("followed-bytes"));
+            assertEquals(latestCycle, stalledQueue.rollCycle().toCycle(stalledWriter.lastIndexAppended()));
+            assertEquals(4, stalledQueue.entryCount());
+        }
+    }
+
+    @Test
+    public void ordinaryAppendUsesPublishedCycleWithoutRefreshingDirectoryListing() throws IOException {
+        final AtomicLong clock = new AtomicLong();
+        final File directory = queueDirectory.newFolder();
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(clock::get)
+                .rollCycle(TEST4_DAILY)
+                .forceDirectoryListingRefreshIntervalMs(1)
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeText("initial");
+            assertEquals(0, appender.cycle());
+
+            // A valid later filename makes lastCycle() perform a directory refresh and publish 5.
+            // The append hot path must use only cycles published by cooperating writers, so it
+            // neither scans the directory nor jumps to an externally planted empty file.
+            assertTrue(new File(directory, "19700106T4" + SingleChronicleQueue.SUFFIX).createNewFile());
+            clock.incrementAndGet();
+
+            appender.writeText("still-cycle-zero");
+            assertEquals("ordinary append must not refresh the directory listing", 0, appender.cycle());
+            assertEquals("the planted filename must be discoverable by an explicit refresh",
+                    5, queue.lastCycle());
+        }
+    }
+
+    @Test(timeout = 15_000)
+    public void stalledWriterSeesCyclePublishedByAnotherJvmWithoutRefreshingDirectoryListing()
+            throws IOException, InterruptedException {
+        final AtomicLong stalledClock = new AtomicLong();
+        final File directory = queueDirectory.newFolder();
+
+        try (SingleChronicleQueue stalledQueue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(stalledClock::get)
+                .rollCycle(TEST4_DAILY)
+                .forceDirectoryListingRefreshIntervalMs(1)
+                .build();
+             ExcerptAppender stalledWriter = stalledQueue.createAppender()) {
+            stalledWriter.writeText("initial");
+
+            final Process publisher = JavaProcessBuilder.create(PublishLaterCycle.class)
+                    .withProgramArguments(directory.getAbsolutePath(), "3")
+                    .start();
+            assertTrue("publisher process did not exit",
+                    publisher.waitFor(10, TimeUnit.SECONDS));
+            assertEquals("publisher process failed", 0, publisher.exitValue());
+            assertEquals("table-store publication must be visible across JVMs",
+                    3, stalledQueue.lastPublishedCycle());
+
+            // Make a filesystem refresh observable. The stalled writer must follow the cycle
+            // published through directory-listing.cq4t, without discovering this planted file.
+            assertTrue(new File(directory, "19700106T4" + SingleChronicleQueue.SUFFIX).createNewFile());
+            stalledClock.set(2);
+            stalledWriter.writeText("follow-cross-process-publication");
+
+            assertEquals(3, stalledWriter.cycle());
+            assertEquals("the append path must not refresh the filesystem listing",
+                    3, stalledQueue.lastPublishedCycle());
+            assertEquals("an explicit refresh must still discover the planted file",
+                    5, stalledQueue.lastCycle());
+        }
+    }
+
+    public static final class PublishLaterCycle {
+        public static void main(String[] args) {
+            final File directory = new File(args[0]);
+            final long clock = Long.parseLong(args[1]) * TEST4_DAILY.lengthInMillis();
+            try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                    .timeProvider(() -> clock)
+                    .rollCycle(TEST4_DAILY)
+                    .build();
+                 ExcerptAppender appender = queue.createAppender()) {
+                appender.writeText("published-by-child");
+            }
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
@@ -3,21 +3,28 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
+import net.openhft.chronicle.bytes.MappedBytes;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.time.SystemTimeProvider;
+import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.TableStore;
 import net.openhft.chronicle.queue.impl.table.Metadata;
 import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
 import net.openhft.chronicle.queue.impl.table.SingleTableStore;
+import net.openhft.chronicle.wire.MarshallableOut;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class TableDirectoryListingTest extends QueueTestCommon {
     private DirectoryListing listing;
@@ -25,6 +32,7 @@ public class TableDirectoryListingTest extends QueueTestCommon {
     private TableStore<Metadata.NoMeta> tablestore;
     private TableStore<Metadata.NoMeta> tablestoreReadOnly;
     private File testDirectory;
+    private File tableFile;
     private File tempFile;
 
     @NotNull
@@ -36,18 +44,18 @@ public class TableDirectoryListingTest extends QueueTestCommon {
     public void setUp() throws IOException {
         testDirectory = testDirectory();
         testDirectory.mkdirs();
-        File tableFile = new File(testDirectory, "dir-list" + SingleTableStore.SUFFIX);
+        tableFile = new File(testDirectory, "dir-list" + SingleTableStore.SUFFIX);
         tablestore = SingleTableBuilder.
                 binary(tableFile, Metadata.NoMeta.INSTANCE).build();
-        tablestoreReadOnly = SingleTableBuilder.
-                binary(tableFile, Metadata.NoMeta.INSTANCE).readOnly(true).build();
         SystemTimeProvider time = SystemTimeProvider.INSTANCE;
         listing = new TableDirectoryListing(tablestore,
                 testDirectory.toPath(),
                 f -> Integer.parseInt(f.split("\\.")[0]),
                 time);
-        listingReadOnly = new TableDirectoryListingReadOnly(tablestore, time);
         listing.init();
+        tablestoreReadOnly = SingleTableBuilder.
+                binary(tableFile, Metadata.NoMeta.INSTANCE).readOnly(true).build();
+        listingReadOnly = new TableDirectoryListingReadOnly(tablestoreReadOnly, time);
         listingReadOnly.init();
         tempFile = File.createTempFile("foo", "bar");
         tempFile.deleteOnExit();
@@ -55,7 +63,7 @@ public class TableDirectoryListingTest extends QueueTestCommon {
 
     @Override
     public void preAfter() {
-        Closeable.closeQuietly(tablestore, tablestoreReadOnly, listing, listingReadOnly);
+        Closeable.closeQuietly(listing, listingReadOnly, tablestore, tablestoreReadOnly);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -104,5 +112,398 @@ public class TableDirectoryListingTest extends QueueTestCommon {
         listing.onFileCreated(tempFile, 9);
         assertEquals(9, listing.getMaxCreatedCycle());
         assertEquals(9, listingReadOnly.getMaxCreatedCycle());
+    }
+
+    @Test
+    public void failedDirectoryListingDoesNotResetPublishedBounds() {
+        listing.onFileCreated(tempFile, 7);
+
+        final TableDirectoryListing failedListing = new TableDirectoryListing(
+                tablestore,
+                tempFile.toPath(),
+                ignored -> 0,
+                SystemTimeProvider.INSTANCE);
+        try {
+            failedListing.init();
+            final long refreshTime = failedListing.lastRefreshTimeMS();
+            failedListing.refresh(true);
+            assertEquals(7, failedListing.getMaxCreatedCycle());
+            assertEquals(7, failedListing.getMinCreatedCycle());
+            assertEquals(refreshTime, failedListing.lastRefreshTimeMS());
+        } finally {
+            failedListing.close();
+        }
+    }
+
+    @Test
+    public void legacyPublicationAfterRefreshIsVisibleWithoutAnotherEvent() throws IOException {
+        final File cycleSeven = new File(testDirectory, 7 + SingleChronicleQueue.SUFFIX);
+        assertTrue(cycleSeven.createNewFile());
+        listing.onFileCreated(cycleSeven, 7);
+        listing.refresh(true);
+        assertEquals(7, listing.getMaxCreatedCycle());
+
+        // Simulate the publication made by a pre-QUEUE-146 process after this instance has
+        // completed its filesystem scan. Current physical-bound reads must not depend on a
+        // second local refresh event.
+        final LongValue legacyHighestCycle = tablestore.acquireValueFor("listing.highestCycle");
+        final LongValue legacyModCount = tablestore.acquireValueFor("listing.modCount");
+        try {
+            legacyHighestCycle.setMaxValue(9);
+            legacyModCount.addAtomicValue(1);
+        } finally {
+            legacyHighestCycle.close();
+            legacyModCount.close();
+        }
+
+        assertEquals(9, listing.getMaxCreatedCycle());
+    }
+
+    @Test
+    public void refreshRetriesWhenLegacyMinimumIsPublishedAfterMaximumCas() throws Exception {
+        final TableDirectoryListing tableListing = (TableDirectoryListing) listing;
+        final LongValue legacyMinimum = tablestore.acquireValueFor("listing.lowestCycle");
+        final LongValue legacyMaximum = tablestore.acquireValueFor("listing.highestCycle");
+        final LongValue legacyModCount = tablestore.acquireValueFor("listing.modCount");
+        final Field maximumField = TableDirectoryListing.class.getDeclaredField("maxCycleValue");
+        maximumField.setAccessible(true);
+        final LongValue maximumDelegate = (LongValue) maximumField.get(tableListing);
+        final AtomicBoolean published = new AtomicBoolean();
+
+        final LongValue interceptedMaximum = (LongValue) Proxy.newProxyInstance(
+                LongValue.class.getClassLoader(),
+                new Class<?>[]{LongValue.class},
+                (proxy, method, args) -> {
+                    try {
+                        final Object result = method.invoke(maximumDelegate, args);
+                        if ("compareAndSwapValue".equals(method.getName())
+                                && Boolean.TRUE.equals(result)
+                                && published.compareAndSet(false, true)) {
+                            // Precisely model a pre-QUEUE-146 publication between the new
+                            // refresher's maximum and minimum CAS operations.
+                            assertTrue(new File(testDirectory, 9 + SingleChronicleQueue.SUFFIX).createNewFile());
+                            legacyMinimum.setMinValue(9);
+                            legacyMaximum.setMaxValue(9);
+                            legacyModCount.addAtomicValue(1);
+                        }
+                        return result;
+                    } catch (InvocationTargetException e) {
+                        throw e.getCause();
+                    }
+                });
+
+        maximumField.set(tableListing, interceptedMaximum);
+        try {
+            tableListing.refresh(true);
+        } finally {
+            maximumField.set(tableListing, maximumDelegate);
+            legacyMinimum.close();
+            legacyMaximum.close();
+            legacyModCount.close();
+        }
+
+        assertTrue(published.get());
+        assertEquals(9, tableListing.getMinCreatedCycle());
+        assertEquals(9, tableListing.getMaxCreatedCycle());
+    }
+
+    @Test
+    public void historicalDeletionAndLowerRecreationPreservePublishedMaximum() throws IOException {
+        final File cycleSeven = new File(testDirectory, 7 + SingleChronicleQueue.SUFFIX);
+        final File cycleEight = new File(testDirectory, 8 + SingleChronicleQueue.SUFFIX);
+        final File cycleNine = new File(testDirectory, 9 + SingleChronicleQueue.SUFFIX);
+        assertTrue(cycleSeven.createNewFile());
+        listing.onFileCreated(cycleSeven, 7);
+        assertTrue(cycleEight.createNewFile());
+        listing.onFileCreated(cycleEight, 8);
+        assertTrue(cycleNine.createNewFile());
+        listing.onFileCreated(cycleNine, 9);
+
+        assertTrue(cycleSeven.delete());
+        listing.refresh(true);
+        assertEquals(8, listing.getMinCreatedCycle());
+        assertEquals(9, listing.getMaxCreatedCycle());
+
+        final File cycleSix = new File(testDirectory, 6 + SingleChronicleQueue.SUFFIX);
+        assertTrue(cycleSix.createNewFile());
+        listing.onFileCreated(cycleSix, 6);
+        assertEquals(6, listing.getMinCreatedCycle());
+        assertEquals(6, persistedCycle("listing.lowestCycle"));
+        assertEquals(9, persistedCycle("listing.highestCycle"));
+    }
+
+    @Test
+    public void publishedModificationRefreshesAnotherListingsCurrentBounds() throws IOException {
+        final TableDirectoryListing secondListing = new TableDirectoryListing(
+                tablestore,
+                testDirectory.toPath(),
+                f -> Integer.parseInt(f.split("\\.")[0]),
+                SystemTimeProvider.INSTANCE);
+        try {
+            secondListing.init();
+            secondListing.refresh(true);
+
+            final File cycleFile = new File(testDirectory, 7 + SingleChronicleQueue.SUFFIX);
+            cycleFile.createNewFile();
+            listing.onFileCreated(cycleFile, 7);
+
+            secondListing.refresh(false);
+            assertEquals(7, secondListing.getMinCreatedCycle());
+            assertEquals(7, secondListing.getMaxCreatedCycle());
+        } finally {
+            secondListing.close();
+        }
+    }
+
+    @Test
+    public void preOpenedListingsPublishBoundsFromSharedValues() throws IOException {
+        final TableDirectoryListing secondListing = new TableDirectoryListing(
+                tablestore,
+                testDirectory.toPath(),
+                f -> Integer.parseInt(f.split("\\.")[0]),
+                SystemTimeProvider.INSTANCE);
+        try {
+            secondListing.init();
+
+            final File cycleFive = new File(testDirectory, 5 + SingleChronicleQueue.SUFFIX);
+            final File cycleSix = new File(testDirectory, 6 + SingleChronicleQueue.SUFFIX);
+            assertTrue(cycleFive.createNewFile());
+            listing.onFileCreated(cycleFive, 5);
+            assertTrue(cycleSix.createNewFile());
+            secondListing.onFileCreated(cycleSix, 6);
+
+            assertEquals(5, secondListing.getMinCreatedCycle());
+            assertEquals(6, secondListing.getMaxCreatedCycle());
+            listing.refresh(false);
+            assertEquals(5, listing.getMinCreatedCycle());
+            assertEquals(6, listing.getMaxCreatedCycle());
+        } finally {
+            secondListing.close();
+        }
+    }
+
+    @Test
+    public void lowerRecreatedCycleIsPublishedToAnotherOpenListing() throws IOException {
+        final TableDirectoryListing secondListing = new TableDirectoryListing(
+                tablestore,
+                testDirectory.toPath(),
+                f -> Integer.parseInt(f.split("\\.")[0]),
+                SystemTimeProvider.INSTANCE);
+        try {
+            secondListing.init();
+
+            final File cycleSix = new File(testDirectory, 6 + SingleChronicleQueue.SUFFIX);
+            assertTrue(cycleSix.createNewFile());
+            listing.onFileCreated(cycleSix, 6);
+            secondListing.refresh(false);
+            assertEquals(6, secondListing.getMinCreatedCycle());
+
+            final File cycleFive = new File(testDirectory, 5 + SingleChronicleQueue.SUFFIX);
+            assertTrue(cycleFive.createNewFile());
+            listing.onFileCreated(cycleFive, 5);
+
+            secondListing.refresh(false);
+            assertEquals(5, secondListing.getMinCreatedCycle());
+            assertEquals(6, secondListing.getMaxCreatedCycle());
+        } finally {
+            secondListing.close();
+        }
+    }
+
+    @Test
+    public void refreshRejectsMissingPublishedMaximum() throws IOException {
+        final File cycleSeven = new File(testDirectory, 7 + SingleChronicleQueue.SUFFIX);
+        assertTrue(cycleSeven.createNewFile());
+        listing.onFileCreated(cycleSeven, 7);
+        final long modCount = listing.modCount();
+        final long refreshTime = listing.lastRefreshTimeMS();
+
+        assertTrue(cycleSeven.delete());
+        final IllegalStateException failure = assertThrows(IllegalStateException.class, () -> listing.refresh(true));
+
+        assertTrue(failure.getMessage().contains("Highest/current roll 7 disappeared"));
+        assertEquals(7, listing.getMinCreatedCycle());
+        assertEquals(7, listing.getMaxCreatedCycle());
+        assertEquals(modCount, listing.modCount());
+        assertEquals(refreshTime, listing.lastRefreshTimeMS());
+    }
+
+    @Test
+    public void freshListingReportsUnsetCycle() {
+        assertEquals(MarshallableOut.UNSET_CONTEXT, listing.getMaxCreatedCycle());
+        assertEquals(MarshallableOut.UNSET_CONTEXT, listing.getMinCreatedCycle());
+        assertEquals(Integer.MIN_VALUE, persistedCycle("listing.highestCycle"));
+        assertEquals(Integer.MAX_VALUE, persistedCycle("listing.lowestCycle"));
+
+        listing.refresh(true);
+        assertEquals(MarshallableOut.UNSET_CONTEXT, listing.getMaxCreatedCycle());
+        assertEquals(Integer.MIN_VALUE, persistedCycle("listing.highestCycle"));
+    }
+
+    @Test
+    public void readOnlyListingDecodesLegacyUnsetCycle() {
+        setPersistedCycle("listing.highestCycle", Integer.MIN_VALUE);
+
+        assertEquals(MarshallableOut.UNSET_CONTEXT, listingReadOnly.getMaxCreatedCycle());
+        assertEquals(MarshallableOut.UNSET_CONTEXT, listingReadOnly.getMinCreatedCycle());
+    }
+
+    @Test
+    public void readOnlyListingDecodesRawStorageSentinelAsUnset() {
+        try (MappedBytes bytes = tablestoreReadOnly.bytes()) {
+            assertTrue(bytes.isBackingFileReadOnly());
+        }
+        setPersistedCycle("listing.highestCycle", Long.MIN_VALUE);
+
+        assertEquals(MarshallableOut.UNSET_CONTEXT, listingReadOnly.getMaxCreatedCycle());
+    }
+
+    @Test
+    public void readOnlyListingHidesPartiallyPublishedCycleZero() {
+        setPersistedCycle("listing.highestCycle", Long.MIN_VALUE);
+        setPersistedCycle("listing.lowestCycle", 0);
+        reopenReadOnlyListing();
+
+        assertEquals(MarshallableOut.UNSET_CONTEXT, listingReadOnly.getMaxCreatedCycle());
+        assertEquals(MarshallableOut.UNSET_CONTEXT, listingReadOnly.getMinCreatedCycle());
+
+        setPersistedCycle("listing.highestCycle", 0);
+        assertEquals(0, listingReadOnly.getMaxCreatedCycle());
+        assertEquals(0, listingReadOnly.getMinCreatedCycle());
+    }
+
+    @Test
+    public void unsetToCycleZeroPublicationSurvivesReopen() {
+        listing.onRoll(0);
+        assertEquals(0, listing.getMaxCreatedCycle());
+        assertEquals(0, listing.getMinCreatedCycle());
+
+        reopenReadOnlyListing();
+        assertEquals(0, listingReadOnly.getMaxCreatedCycle());
+        assertEquals(0, listingReadOnly.getMinCreatedCycle());
+    }
+
+    @Test
+    public void publishedCycleZeroMissingItsFileFailsClosed() {
+        listing.onRoll(0);
+
+        final IllegalStateException failure = assertThrows(IllegalStateException.class, () -> listing.refresh(true));
+
+        assertTrue(failure.getMessage().contains("Highest/current roll 0 disappeared"));
+        assertEquals(0, listing.getMaxCreatedCycle());
+    }
+
+    @Test
+    public void persistedCyclesOutsideDomainFailClosed() {
+        setPersistedCycle("listing.highestCycle", -2);
+        assertInvalidStoredCycle("listing.highestCycle", -2, listingReadOnly::getMaxCreatedCycle);
+        assertInvalidStoredCycle("listing.highestCycle", -2, () -> listing.refresh(true));
+
+        final long aboveUInt31 = (long) Integer.MAX_VALUE + 1;
+        setPersistedCycle("listing.highestCycle", aboveUInt31);
+        assertInvalidStoredCycle("listing.highestCycle", aboveUInt31, listingReadOnly::getMaxCreatedCycle);
+        assertInvalidStoredCycle("listing.highestCycle", aboveUInt31, () -> listing.refresh(true));
+
+        setPersistedCycle("listing.highestCycle", 0);
+        setPersistedCycle("listing.lowestCycle", -2);
+        assertInvalidStoredCycle("listing.lowestCycle", -2, listingReadOnly::getMinCreatedCycle);
+        assertInvalidStoredCycle("listing.lowestCycle", -2, () -> listing.refresh(true));
+
+        setPersistedCycle("listing.lowestCycle", aboveUInt31);
+        assertInvalidStoredCycle("listing.lowestCycle", aboveUInt31, listingReadOnly::getMinCreatedCycle);
+        assertInvalidStoredCycle("listing.lowestCycle", aboveUInt31, () -> listing.refresh(true));
+    }
+
+    @Test
+    public void maximumCycleRoundTripsAsAValidMinimum() {
+        listing.onRoll(Integer.MAX_VALUE);
+
+        assertEquals(Integer.MAX_VALUE, listing.getMaxCreatedCycle());
+        assertEquals(Integer.MAX_VALUE, listing.getMinCreatedCycle());
+        reopenReadOnlyListing();
+        assertEquals(Integer.MAX_VALUE, listingReadOnly.getMaxCreatedCycle());
+        assertEquals(Integer.MAX_VALUE, listingReadOnly.getMinCreatedCycle());
+    }
+
+    @Test
+    public void onRollRejectsCyclesOutsideUInt31() {
+        assertThrows(IllegalStateException.class, () -> listing.onRoll(MarshallableOut.UNSET_CONTEXT));
+    }
+
+    @Test
+    public void fileSystemListingDistinguishesMaximumCycleFromUnset() {
+        final DirectoryListing fileSystemListing = new FileSystemDirectoryListing(
+                testDirectory,
+                f -> Integer.parseInt(f.split("\\.")[0]),
+                SystemTimeProvider.INSTANCE);
+        try {
+            fileSystemListing.refresh(true);
+            assertEquals(MarshallableOut.UNSET_CONTEXT, fileSystemListing.getMaxCreatedCycle());
+            assertEquals(MarshallableOut.UNSET_CONTEXT, fileSystemListing.getMinCreatedCycle());
+
+            fileSystemListing.onRoll(Integer.MAX_VALUE);
+            assertEquals(Integer.MAX_VALUE, fileSystemListing.getMaxCreatedCycle());
+            assertEquals(Integer.MAX_VALUE, fileSystemListing.getMinCreatedCycle());
+            assertThrows(IllegalStateException.class,
+                    () -> fileSystemListing.onRoll(MarshallableOut.UNSET_CONTEXT));
+        } finally {
+            fileSystemListing.close();
+        }
+    }
+
+    @Test
+    public void refreshRejectsMissingLegacyPublication() throws IOException {
+        final File cycleSeven = new File(testDirectory, 7 + SingleChronicleQueue.SUFFIX);
+        assertTrue(cycleSeven.createNewFile());
+        listing.onFileCreated(cycleSeven, 7);
+
+        final LongValue legacyHighestCycle = tablestore.acquireValueFor("listing.highestCycle");
+        try {
+            legacyHighestCycle.setMaxValue(9);
+        } finally {
+            legacyHighestCycle.close();
+        }
+        assertThrows(IllegalStateException.class, () -> listing.refresh(true));
+        assertEquals(9, listing.getMaxCreatedCycle());
+    }
+
+    @Test
+    public void metadataContainsNoSeparateWriteFloor() {
+        assertFalse(tablestore.dump(net.openhft.chronicle.wire.WireType.BINARY_LIGHT)
+                .contains("listing.highestCycleWriteFloor"));
+    }
+
+    private int persistedCycle(final String key) {
+        final LongValue value = tablestore.acquireValueFor(key);
+        try {
+            return (int) value.getVolatileValue();
+        } finally {
+            value.close();
+        }
+    }
+
+    private void setPersistedCycle(final String key, final long cycle) {
+        final LongValue value = tablestore.acquireValueFor(key);
+        try {
+            value.setVolatileValue(cycle);
+        } finally {
+            value.close();
+        }
+    }
+
+    private void reopenReadOnlyListing() {
+        Closeable.closeQuietly(listingReadOnly, tablestoreReadOnly);
+        tablestoreReadOnly = SingleTableBuilder.
+                binary(tableFile, Metadata.NoMeta.INSTANCE).readOnly(true).build();
+        listingReadOnly = new TableDirectoryListingReadOnly(tablestoreReadOnly, SystemTimeProvider.INSTANCE);
+        listingReadOnly.init();
+    }
+
+    private static void assertInvalidStoredCycle(final String fieldName,
+                                                 final long cycle,
+                                                 final Runnable read) {
+        final IllegalStateException failure = assertThrows(IllegalStateException.class, read::run);
+        assertTrue(failure.getMessage().contains(fieldName));
+        assertTrue(failure.getMessage().contains(Long.toString(cycle)));
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/stress/RollCycleMultiThreadTest.java
@@ -194,7 +194,7 @@ public class RollCycleMultiThreadTest extends QueueTestCommon {
                                 "listing.lowestCycle: 0\n" +
                                 "# position: 232, header: 2\n" +
                                 "--- !!data #binary\n" +
-                                "listing.modCount: 8\n" +
+                                "listing.modCount: 7\n" +
                                 "# position: 264, header: 3\n" +
                                 "--- !!data #binary\n" +
                                 "chronicle.write.lock: -9223372036854775808\n" +


### PR DESCRIPTION
Keep the authoritative-cycle invariant in one delivery PR. Use five ordered review chapters, preserving the descendant chain #1740 -> #1741 -> #1745 -> #1746:

1. `RollingResourcesCache` weekly filename decoding, locale and year-boundary round trips. Alternate epochs require their own controls.
2. Transactional binding acquisition and ownership rollback.
3. Document-acquisition `Error` cleanup: nesting restoration and unlocking stay together.
4. Private-buffer rollback/failed-flush cleanup: lock ownership and failure-path clearing stay together.
5. Authoritative cycle publication and selection: UInt31/sentinel compatibility, persisted decoding, minimum-before-maximum publication, logical directory bounds, missing-published-roll preflight and forward-only selection, with all consumers and the regression matrix.

The selector's temporary-store inspection/event pairing belongs to chapter 5. It is not automatically an independently reproducible base ownership fix. A new published prerequisite stack is deferred unless an identified backport consumer justifies requalifying all descendants.

Head `5ee1a25d320480de42841a39b75f8d68461c12ee` and its staged base are unchanged by this review-map update.


<details>
<summary>Existing implementation and validation receipt (restructuring changes only the review map)</summary>

## Purpose

Q1 of QUEUE-146: keep ordinary appenders at or above the highest cycle published by any writer, including when wall time moves backwards, without adding directory scans to the steady-state append path.

## Contract

- Ordinary writes select the greater of the wall-clock cycle and the latest published cycle.
- Internal cycle state is either a UInt31 value (`0` through `Integer.MAX_VALUE`) or Wire's canonical `MarshallableOut.UNSET_CONTEXT`; both cycle zero and `Integer.MAX_VALUE` are valid.
- New writable initialisation and empty refreshes persist legacy `Integer.MIN_VALUE` so older readers still recognise an empty Queue. Persisted `long` values are decoded and range-checked before narrowing: raw `Long.MIN_VALUE`, legacy `Integer.MIN_VALUE` and `UNSET_CONTEXT` decode as unset; other values below `-1` or above `Integer.MAX_VALUE` fail closed.
- The legacy stored minimum may still be `Integer.MAX_VALUE`, so emptiness is determined from the decoded maximum rather than from the minimum alone.
- Existing public boundaries remain compatible: empty `firstCycle()`/`lastCycle()` calls still return `Integer.MAX_VALUE`/`Integer.MIN_VALUE`, and existing mapped empty representations remain readable.
- `listing.highestCycle` remains the single shared publication understood by old and new processes; this PR adds no persistent write-floor key.
- The append hot path reads that mapped publication directly and does not refresh the directory.
- Refresh CAS-protects both physical bounds against concurrent legacy `minimum -> maximum -> modCount` publication. It publishes minimum before maximum so a read-only opener cannot observe a non-empty maximum paired with the empty minimum sentinel.
- Directory refresh derives extrema from validated logical cycles, not lexical filenames; built-in daily/hourly names remain correctly ordered across extended years.
- Deleting closed historical rolls may move the physical minimum, but the published maximum must remain while Queue metadata remains.
- A writable Queue fails closed if the published maximum is already absent when the Queue refreshes, an appender first opens that destination, or an appender transitions to it.
- An appender already writing an open current mapping does not stat its pathname for every document. Unlinking that current `.cq4` file while the mapping is open is unsupported and is not synchronously detected by each append.
- Complete Queue replacement is a separate offline operation: close every instance and delete the whole directory, including Queue metadata.
- Weekly resource names round-trip through locale week-based-year fields without current-date dependence, including year boundaries.

Q2 owns the one-EOF ordinary advance. Q3 owns validated exact-index recovery.

## Review evidence

Production `//!` notes name the regressions that discriminate behavioural changes and sit beside the statements they justify. Import tidies, comment-only changes and unchanged production code do not carry artificial reviewer notes.

The storage/domain regressions cover:

- new initialisation and an empty refresh preserving legacy `Integer.MIN_VALUE` storage while reporting semantic `UNSET_CONTEXT`;
- the legacy `Integer.MIN_VALUE` maximum through a genuinely read-only mapped table;
- raw `Long.MIN_VALUE` through a genuinely read-only mapped table;
- a read-only opener at the legacy publication boundary and a real read-only tailer paused after refresh publishes its maximum;
- unset-to-cycle-zero publication and read-only reopen;
- missing published cycle zero failing closed;
- persisted values outside UInt31 failing closed in getters and refresh;
- `Integer.MAX_VALUE` as a valid minimum and maximum, including queue restart, diagnostic dump, a second appender and a tailer;
- both low and maximum cycles in daily/hourly extended-year filenames, followed by refresh and reopen.

The following tests are retained as compatibility and architecture guards. They also pass against unchanged `staged/develop`, so they are not claimed as discriminating final-diff evidence:

- `legacyPublicationAfterRefreshIsVisibleWithoutAnotherEvent`
- `historicalDeletionAndLowerRecreationPreservePublishedMaximum`
- `publishedModificationRefreshesAnotherListingsCurrentBounds`
- `preOpenedListingsPublishBoundsFromSharedValues`
- `lowerRecreatedCycleIsPublishedToAnotherOpenListing`
- `metadataContainsNoSeparateWriteFloor`

`TestDeleteQueueFile`'s refresh, tailer and chaos cases, plus `SingleChronicleQueueTest#testToEndAfterOfflineQueueDeletion`, exercise supported historical-roll deletion or complete offline replacement rather than deletion of the published/current roll. The chaos retry closes absent contexts and retries while a surviving boundary remains, avoiding a transient false failure during concurrent deletion. The existing ignored `tailerToEndFromEndWorksInFaceOfDeletedStoreFile` test remains ignored and is not cited as release evidence.

The changed dump expectations record the reduced directory-listing modification count. The benchmark delta only removes commented-out code; no latency probe or performance experiment remains.

Failure-ownership regressions cover transactional read-only binding acquisition, cleanup on document-acquisition `Error`, private-buffer rollback/failed flush, matched temporary store acquisition/release notifications, and joining the roll-test observer before closing its Queue. Queue closes bindings actually returned to it; allocation failures before a binding is returned remain Wire's responsibility.

Deletion-worker regressions distinguish shutdown from a completed pass and allow diagnostic logging of an unresolved starting cursor. They fix test-harness false failures without suppressing leak checks or unrelated errors.

## Current ancestry and validation

- Base: `191b73440f8f5aa95e6c5cf74087b14a3ae03393` (`staged/develop`).
- Head: `5ee1a25d320480de42841a39b75f8d68461c12ee`.
- Base equals merge base; 26 changed files and no POM delta.
- Existing branch history is preserved with a merge commit and a normal fast-forward push. The tree matches tested candidate `f534a870d1e828d4c5310f29ca18fbd5392bd8d0`.
- Current staged-base conflict resolved; newer exception assertions retained. The tailer fixture now joins its producer before expecting records in the later cycle, removing a race between the first visible record and completion of the batch.
- Full verification with the source-built Wire dependency: **1,159 tests, zero failures/errors, 52 skipped**. The subsequent producer-join-only test correction passed `StoreTailerTest` (25 tests) and Maven verification checks.
- Linux amd64/OpenJDK 21.0.12, Maven 3.9.11, offline isolated Maven repository, `-Dsurefire.rerunFailingTestsCount=0`. Required build checks passed.
- Wire runtime `2026.10-SNAPSHOT` was rebuilt from merged #1280 commit `3dd7fe5983c0133703ee72f57bced9a25270eb6f`; JAR SHA-256 `92803fb011f5071900f5c3b1b637cf39f6254e86b4e29f77f1256ecc96dde755`. This is source-build evidence for the local run; released immutable coordinates remain a gate.
- No Windows, macOS or ARM execution is claimed.

## Stack and review gates

The repaired order is `staged/develop` -> #1739 -> #1740 -> #1741. #1741 remains draft for final-stack review. The coordinate work in #1750 and follow-ups #1745/#1746 are unchanged.

Wire #1280 merged on 2026-09-07. Successful CI on the published heads, independent review and immutable release/BOM coordinates remain outstanding. Previous-head results do not qualify the new heads.


</details>

## Java 8 compilation repair — 12 September 2026

TeamCity builds 1354169, 1354178 and 1354190 fail test compilation because `testCleanupDir()` no longer declares the `Throwable` thrown by the Windows `FlakyTestRunner`. Restore the declaration in this PR; the test and runner behaviour are unchanged. The same error reproduced locally with the published BOM `2026.0-20260907.105301-92`, Wire `2026.10-20260911.101949-3` and Test Framework 2026.2.

After the one-line repair, clean Java 8u502 verification passed `SingleChronicleQueueTest`, `DirectoryPublicationBoundaryTest`, `AppenderInspectionLifecycleTest` and `DocumentAcquisitionFailureTest`: **311 reported, 299 executed, 12 existing skips, zero failures/errors/retries**. Command: `mvn -o -B clean verify -Dtest=SingleChronicleQueueTest,DirectoryPublicationBoundaryTest,AppenderInspectionLifecycleTest,DocumentAcquisitionFailureTest -Dsurefire.rerunFailingTestsCount=0`, using an isolated Maven repository. This is local Linux qualification; fresh head CI and review remain required.

The descendant #1740 already removes the Windows retry runner, so its parent update preserves that implementation and has an unchanged source tree.

Supported-platform build triage, 12 September 2026: current-head Zing Java 8 [build 1356777](https://teamcity.chronicle.software/build/1356777) fails `TestMethodWriterWithThreads[doubleBuffer=false]` in write-lock acquisition on all four attempts. Three bounded local attempts each on this exact head, its actual staged/develop target `191b73440f8f5aa95e6c5cf74087b14a3ae03393`, and current develop `4707043f3b1f9a1676a0514ccd3e65afe7ac44ce` all pass on Zulu Java 8 with retries disabled. That does not reproduce the Zing stall or establish that this PR leaves its frequency unchanged.

The independently established worker-ownership/failure-observation defect belongs in existing shared repair [#1756](https://github.com/OpenHFT/Chronicle-Queue/pull/1756), now at `d85d41f7192ddff15fc0890794ca3d3dfa12acc0`. Its mapped-queue controls fail against develop and the preceding repair, then pass on Java 8/21 and 32-bit Java 17. Incorporate the shared repair through the staged stack when appropriate and revalidate descendants. The original lock-stall cause remains unclassified; capture the holder and waiting-worker stacks in a matched zero-retry Zing run. This shared repair and local passes do not waive the current failing check or other merge requirements.

<!-- teamcity-repair-batch10-20260912 -->

### Related Zing crash investigation — 12 September 2026

Current #1731 Zing Java 8 [build 1357335](https://teamcity.chronicle.software/build/1357335) at `194eee19ab440a1fb6a205c6be23f77ce5432e50` crashes with SIGSEGV/exit 134 in `RollCycleTest`. Its observer is interrupted without being joined before Queue closure. This PR at `c75c120550902dcb7bb66007b04771a7f14a8dee` already owns the observer-join/tailer-close/failure-reporting change, so no duplicate version was added elsewhere. That source overlap is a repair candidate, not proof of the native crash's cause. Queue/Zing CI maintainers should retrieve the native dump and Surefire dumpstream from agent 1181, compare the existing repair with pinned target/develop controls, and establish a focused delivery route for the independently useful fixture change. The files are absent from both public and hidden published artifacts.

The separate deletion-reader execution/cleanup defect now has a develop control and a validated addition to shared [#1756](https://github.com/OpenHFT/Chronicle-Queue/pull/1756), `fe3d4725e8e2ecf3daa12819de25b625ec0d927e`. Preserve this PR's own deletion-worker changes when incorporating the shared repair. Neither that repair nor this newly linked crash investigation resolves this PR's separate method-writer Zing lock stall or satisfies its merge gates.
