### PR TITLE
QUEUE-146: recover exact indexed entries across a sealed cycle

### DIFF
--- a/docs/How_it_works.adoc
+++ b/docs/How_it_works.adoc
@@ -265,7 +265,13 @@ public void removeOldQueueFiles() throws IOException {
 }
 ....
 
-Use the `ChronicleQueue.numberOfReferences()` method to ensure that there are zero references to a given file before attempting to delete it.
+//! InternalAppenderWriteBytesTest#canBackfillPreviousCycleAfterEOF shows that Queue can reopen EOF while applying
+//! an exact-next historical entry. numberOfReferences() observes local handles only; maintenance exclusion
+//! is therefore an integration responsibility rather than evidence that Queue supplies online deletion safety.
+Use the `ChronicleQueue.numberOfReferences()` method to ensure that there are zero references to a given file before attempting to
+delete it. This is only a local file-handle check. If exact-index replication recovery is enabled, maintenance must also be excluded
+from its eligibility check through the archive/delete action until recovery retry and EOF normalisation have completed. An EOF marker
+and a zero reference count do not prove that the roll can never be reopened.
 
 == Configuration
 

--- a/docs/antora/modules/configuration/pages/roll-cycle.adoc
+++ b/docs/antora/modules/configuration/pages/roll-cycle.adoc
@@ -14,16 +14,24 @@ Example configuration of `rollCycle`:
 * `RollCycles.DAILY` events stored in the queue will be grouped into 24-hour periods
 * `RollCycles.HOURLY` every hour, a new queue file will be created for written events
 
-As new files are created (the queue is rolled) to accommodate events being written to the queue, a persisted data-structure (`directory-listing.cq4t`) is updated with the lowest and highest
-_cycle_ numbers present in the directory.
+As new files are created (the queue is rolled) to accommodate events being written to the queue, a persisted data-structure
+(`directory-listing.cq4t`) is updated with the lowest and highest _cycle_ numbers present in the directory.
 Maintaining this table allows an `ExcerptTailer` to busy-spin waiting for new data to be appended to the queue, without the need to make costly calls to the file-system to check for the existence of new queue files.
 
 The following sections describe how rolling is performed, how the roll cycle interval can be customized, and finally provide some general advice to consider when deciding the rolling schedule.
 
 == How Rolling Works
 
-When the queue reaches the point in time when it should roll, the appender will atomically write an end-of-file (EOF) mark at the end of the current file, to indicate that no other appender should write to it.
+When the queue reaches the point in time when it should roll, the appender will atomically write an end-of-file (EOF) mark at the end
+of the current file, to indicate that no ordinary appender should write to it.
 Likewise, no tailer should read further than this mark.
+
+//! canBackfillPreviousCycleAfterEOF and exactBackfillFindsEofInEmptySealedCycle require the
+//! ordinary-write seal to remain distinguishable from the explicitly invoked exact-recovery path.
+An EOF is not an archival-safety marker when exact-index replication recovery
+is enabled. The validated recovery path can temporarily reopen a sealed roll;
+see xref:replication:replication.adoc[Replication] for the required maintenance
+exclusion and completion contract.
 
 If the process was shut down and later restarted after rolling should have occurred, the appender will try to locate the old file(s) and write the EOF marker.
 However, after a certain timeout, the tailers will act as if there is an EOF mark in the file(s) regardless.
@@ -186,7 +194,14 @@ SingleChronicleQueue queue = ChronicleQueue.singleBuilder("/timezone")
 == Archiving Old Queue Files ★
 
 Over time, it may become necessary to automatically delete or archive old queue files.
-An automated process needs to ensure that there are no active file-handles open on a queue file before attempting to delete. facilitate housekeeping of older roll files, Chronicle Queue Enterprise provides the xref:command-line:command_line_tools.adoc#_archiverollfiles[ArchiveRollFiles utility].
+//! InternalAppenderWriteBytesTest#canBackfillPreviousCycleAfterEOF establishes only that EOF can be reopened.
+//! StoreAppenderTest#historicalWriteAfterReadyInterruptedRecordNormalisesAtCompletion establishes the explicit
+//! completion boundary; the surrounding replication and maintenance exclusion remains an integration duty.
+An automated process needs to ensure that there are no active file-handles open on a queue file before attempting to delete. When
+exact-index recovery is enabled, it must also coordinate with recovery as described in
+xref:replication:replication.adoc[Replication]; EOF and a zero reference count do not by themselves prove permanent immutability. To
+facilitate housekeeping of older roll files, Chronicle Queue Enterprise provides the
+xref:command-line:command_line_tools.adoc#_archiverollfiles[ArchiveRollFiles utility].
 
 == General Advice on Rolling
 

--- a/docs/antora/modules/replication/pages/replication.adoc
+++ b/docs/antora/modules/replication/pages/replication.adoc
@@ -33,6 +33,99 @@ At startup, replication locks the `source` queue, and waits for the `sink`(s) to
 If the `sink` has more records, they are replayed back to `source` (this is also known as "back filling") before it is unlocked and made usable again.
 This is done to provide automatic data re-synchronisation after a failover to the `sink`.
 
+//! StoreAppenderTest#ordinaryWritingDocumentRollsForwardPastSealedCurrentCycle,
+//! #sequentialWriteBytesRollsForwardPastSealedCurrentCycle and
+//! InternalAppenderWriteBytesTest#canBackfillPreviousCycleAfterEOF require a narrow distinction: the explicit
+//! exact-next path may reopen a historical seal, while ordinary append always treats EOF as final for that cycle.
+Back-fill can legitimately reopen a roll that the receiving node has already
+sealed. For example, leader A can fail after C received entries that B did not.
+If B is elected leader, time can advance and cause B to seal the incomplete
+older roll before C returns the missing entries. The end-of-data marker records
+B's incomplete local observation; it is not a cluster-wide decision that C's
+data may be discarded. Only the locked, exact-index back-fill path may replace
+that marker. Ordinary Queue appenders never replace it; if they encounter a
+sealed cycle, they roll forward to a writable cycle.
+The Queue recovery warning includes queue path, cycle and index. Replication
+should log its source and peer host context around this operation.
+
+If a back-fill attempt leaves its requested entry incomplete, CQE restarts by
+replaying that same index. A new Queue instance can replace the incomplete
+header and complete the entry. The incomplete header does not retain whether
+the failed attempt opened an end-of-data marker, so resealing the roll remains
+a separate back-fill completion responsibility.
+
+This recovery does not rewind consumers that have already advanced beyond the
+reopened cycle. Enterprise back-fill completes before the replacement source is
+unlocked for normal use.
+
+//! historicalWriteAfterReadyInterruptedRecordNormalisesAtCompletion and
+//! eofRestorationFailureIsNotReportedAsSuccess establish Queue's explicit, fail-closed
+//! normalisation boundary. Retry, shared completion and maintenance exclusion remain caller-owned.
+For maintenance purposes, EOF therefore means _hard-sealed against ordinary
+writes_, not permanently immutable. Queue does not publish a persisted
+"no exact recovery is in progress or can be retried" marker. EOF, stable file
+identity, file age and a zero local reference count are not, separately or
+together, sufficient proof that a roll may be archived or deleted. A system
+that enables exact-index recovery must provide an exclusion protocol which
+covers both the maintenance eligibility check and the archive/delete action,
+and which remains held until recovery has been retried and EOF normalisation
+has completed.
+
+CQE owns retry, EOF normalisation and completion ordering for the supported
+replication use case: it retries a failed exact-index back-fill after restart,
+calls `normaliseEOFs()` before publishing back-fill completion, and keeps
+ordinary source writes excluded until then. Queue-wide archive/delete exclusion
+still requires coordination with maintenance and is not supplied by EOF or CQE
+completion alone. Another internal caller of exact-index `writeBytes` assumes
+the same retry and normalisation responsibilities.
+
+//! InternalAppenderWriteBytesTest#exactWriteReplacesAnIncompleteRequestedEntryAfterQueueRestart,
+//! InternalAppenderWriteBytesTest#canBackfillPreviousCycleAfterEOF,
+//! InternalAppenderWriteBytesTest#publishedDuplicatePayloadsAreComparedWithoutMutation,
+//! StoreAppenderTest#publishedDuplicateDoesNotAdoptLaterReadyCrashRecord and
+//! StoreAppenderTest#exactWriteAdoptsReadyFirstRecordRetryBeforeWritingNext distinguish incomplete entries, EOF, authoritative
+//! published duplicates and ready unpublished crash records. Keep those decisions explicit instead of treating
+//! final Queue contents as publication-order evidence.
+Queue inspects the requested exact index, skipping user and sparse-index
+metadata because metadata does not consume an index. If the slot contains EOF,
+Queue replaces that word with one compare-and-swap, commits the data and any
+addressable sparse-index entry, and leaves the roll open for the remaining
+back-fill. CQE restores EOF once, during completion normalisation, so a normal
+multi-entry back-fill emits at most the one EOF-reopen warning. A published
+index is authoritative. An exact write for that index compares the supplied
+payload with the stored record without overwriting it or throwing: equal
+content is reported at debug level, while different content produces a warning
+with hex dumps of both versions and the supplied message is ignored. A ready
+first-writer record left beyond write-position publication is instead adopted
+without overwriting its payload. Otherwise a new index must be exactly next; a
+gap is rejected.
+
+//! StoreAppenderTest#exactWriteDoesNotRecreateDeletedPublishedMaximum and
+//! StoreAppenderTest#exactWriteRejectsAbsentCycleWithinPublishedRange require missing physical state within the
+//! retained published bounds to fail closed. Treating it as a new empty roll can recreate unsupported deletion.
+An exact write may create an absent roll outside Queue's retained published
+bounds. It rejects an absent highest roll, and an absent interior roll within
+those bounds, because the persisted state cannot distinguish unsupported
+deletion from a never-created sparse generation.
+
+Current queue files are padded, keeping every header—including end-of-data—
+four-byte aligned for atomic replacement. Legacy `dataVersion == 0` stores are
+unpadded and remain readable, but exact-index mutation rejects them before
+changing the recovery cursor, EOF, write position or payload.
+
+//! exactRecoveryRejectsUnsupportedSequenceBeforeCreatingRoll fixes the present declared-capacity
+//! boundary; non-indexed continuation is deliberately outside this change.
+Exact replication currently supports only indices within the roll cycle's
+declared `maxMessagesPerCycle()` range. Extending physical sequences beyond the
+sparse-index capacity, including non-indexed continuation and linear lookup,
+is separate future work.
+
+//! exactRecoveryFailsIfTheEofMarkerChangesBeforeCas requires the validated aligned header to be
+//! replaced once while Queue owns its write lock; no transport or Wire recovery contract is implied.
+EOF recovery is implemented in Queue by validating the exact index and then
+performing the aligned header compare-and-swap while holding Queue's write
+lock. It does not depend on a Wire EOF-recovery operation.
+
 The set of hosts onto which the queue is replicated, is defined as a `cluster`.
 The configuration for a cluster is as follows:
 

--- a/docs/antora/modules/replication/pages/replication.adoc
+++ b/docs/antora/modules/replication/pages/replication.adoc
@@ -82,6 +82,7 @@ the same retry and normalisation responsibilities.
 //! InternalAppenderWriteBytesTest#exactWriteReplacesAnIncompleteRequestedEntryAfterQueueRestart,
 //! InternalAppenderWriteBytesTest#canBackfillPreviousCycleAfterEOF,
 //! InternalAppenderWriteBytesTest#publishedDuplicatePayloadsAreComparedWithoutMutation,
+//! StoreAppenderTest#readyCrashDuplicatesCompareMatchingAndDifferentPayloads,
 //! StoreAppenderTest#publishedDuplicateDoesNotAdoptLaterReadyCrashRecord and
 //! StoreAppenderTest#exactWriteAdoptsReadyFirstRecordRetryBeforeWritingNext distinguish incomplete entries, EOF, authoritative
 //! published duplicates and ready unpublished crash records. Keep those decisions explicit instead of treating
@@ -96,8 +97,11 @@ index is authoritative. An exact write for that index compares the supplied
 payload with the stored record without overwriting it or throwing: equal
 content is reported at debug level, while different content produces a warning
 with hex dumps of both versions and the supplied message is ignored. A ready
-first-writer record left beyond write-position publication is instead adopted
-without overwriting its payload. Otherwise a new index must be exactly next; a
+first-writer record left beyond write-position publication is compared using
+the same diagnostic policy and adopted without overwriting its payload.
+Equal retries are silent when debug logging is disabled, whether the existing
+record was already published or is being adopted after a crash.
+Otherwise a new index must be exactly next; a
 gap is rejected.
 
 //! StoreAppenderTest#exactWriteDoesNotRecreateDeletedPublishedMaximum and

--- a/docs/managing_roll_files_directly.adoc
+++ b/docs/managing_roll_files_directly.adoc
@@ -73,6 +73,15 @@ This will provide a new List with all candidates in the provided `dir`.
 
 NOTE: It always the ultimate decision of the user code to actually decide if a candidate should be deleted or not.
 
+//! InternalAppenderWriteBytesTest#canBackfillPreviousCycleAfterEOF shows that EOF can be reopened;
+//! StoreAppenderTest#historicalWriteAfterReadyInterruptedRecordNormalisesAtCompletion shows when Queue reseals
+//! it. Neither test proves that Queue's candidate API supplies external online-maintenance exclusion.
+IMPORTANT: A removable candidate or EOF marker is not proof of permanent
+immutability when exact-index replication recovery is enabled. Coordinate the
+whole eligibility-check and archive/delete operation with recovery, and do not
+release that exclusion until failed recovery has been retried and EOF
+normalisation has completed.
+
 NOTE: The method above is only supported on Linux/BSD systems and not Windows.
 
 If the used code intends to remove all candidates unconditionally, the following snippet can be used:

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
@@ -127,10 +127,16 @@ public interface ExcerptAppender extends ExcerptCommon<ExcerptAppender>, Marshal
     @Nullable
     Wire wire();
 
+    //! historicalWriteAfterReadyInterruptedRecordNormalisesAtCompletion and
+    //! eofRestorationFailureIsNotReportedAsSuccess require completion to be explicit and fail-closed: exact recovery
+    //! may reopen a historical seal, so construction or an ordinary append cannot stand in for this operation.
     /**
-     * Ensure all already-rolled cq4 files are correctly ended with EOF
-     * Used by replication sinks on startup to cover off any edge cases where the replicated EOF was not received/applied
-     * Can also be used on any appender, but this is not currently done automatically
+     * Ensure all already-rolled cq4 files are correctly ended with EOF.
+     * Used by replication sinks before publishing back-fill completion to cover cases where a
+     * failed exact-index recovery left an older cycle open. The exact-index caller remains
+     * responsible for retrying failed writes, invoking this operation successfully and excluding
+     * archive/delete maintenance until both have completed. Queue does not persist a recovery-intent
+     * marker, and appender construction or ordinary append is not a completion guarantee.
      */
     default void normaliseEOFs() {
         // Intentionally no-op: optional hook for ensuring EOF markers on rolled files

--- a/src/main/java/net/openhft/chronicle/queue/impl/RollingResourcesCache.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/RollingResourcesCache.java
@@ -9,6 +9,7 @@ import net.openhft.chronicle.queue.RollCycle;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -98,30 +99,7 @@ public class RollingResourcesCache {
     private int parseCount0(@NotNull String name) {
         try {
             TemporalAccessor parse = formatter.parse(name);
-            if (!parse.isSupported(ChronoField.EPOCH_DAY)) {
-                final WeekFields weekFields = WeekFields.of(formatter.getLocale());
-                if (parse.isSupported(weekFields.weekBasedYear()) && parse.isSupported(weekFields.weekOfWeekBasedYear())) {
-                    int year = Math.toIntExact(parse.getLong(weekFields.weekBasedYear()));
-                    int week = Math.toIntExact(parse.getLong(weekFields.weekOfWeekBasedYear()));
-                    //! RollingResourcesCacheTest#namedWeeklyFormatRoundTripsCycle,
-                    //! #namedWeeklyFormatRoundTripsLocaleYearBoundaries and
-                    //! ChangeRollCycleTest#changeRollCycleWithReadOnlyTailer fail when a week-formatted filename
-                    //! is reconstructed through the current date, calendar year, or week-of-year. Those fields can
-                    //! select another week at locale/year boundaries. Resolve the parsed week-based fields on the
-                    //! roll epoch's weekday, then apply the same length-and-epoch geometry as every other format so
-                    //! resourceFor(cycle) and parseCount(name) remain inverses.
-                    final int rollDayOfWeek = LocalDate.ofEpochDay(epoch / ONE_DAY_IN_MILLIS)
-                            .get(weekFields.dayOfWeek());
-                    LocalDate ld = LocalDate.of(year, 7, 1)
-                            .with(weekFields.weekBasedYear(), year)
-                            .with(weekFields.weekOfWeekBasedYear(), week)
-                            .with(weekFields.dayOfWeek(), rollDayOfWeek);
-                    long epochSecond = ld.toEpochDay() * 86400;
-                    return Maths.toInt32((epochSecond - (epoch / 1000)) / (length / 1000));
-                }
-                throw new UnsupportedOperationException("Unable to parse " + name + " using format " + format);
-            }
-            long epochDay = parse.getLong(ChronoField.EPOCH_DAY) * 86400;
+            long epochDay = resolveEpochDay(parse, name) * 86400;
             if (parse.isSupported(ChronoField.SECOND_OF_DAY))
                 epochDay += parse.getLong(ChronoField.SECOND_OF_DAY);
 
@@ -132,20 +110,52 @@ public class RollingResourcesCache {
         }
     }
 
+    private long resolveEpochDay(TemporalAccessor parse, String name) {
+        if (parse.isSupported(ChronoField.EPOCH_DAY))
+            return parse.getLong(ChronoField.EPOCH_DAY);
+
+        final WeekFields weekFields = WeekFields.of(formatter.getLocale());
+        if (!parse.isSupported(weekFields.weekBasedYear()) || !parse.isSupported(weekFields.weekOfWeekBasedYear()))
+            throw new UnsupportedOperationException("Unable to parse " + name + " using format " + format);
+
+        //! RollingResourcesCacheTest#namedWeeklyFormatRoundTripsCycle,
+        //! #namedWeeklyFormatRoundTripsLocaleYearBoundaries,
+        //! #nonCanonicalNamedWeeksAreRejected and
+        //! ChangeRollCycleTest#changeRollCycleWithReadOnlyTailer fail when a week-formatted filename is reconstructed
+        //! through the current date, calendar year, or week-of-year, or when cycle-tree ordering reads EPOCH_DAY
+        //! directly. Resolve the parsed week-based fields once for both parseCount() and toLong(), on the roll epoch's
+        //! weekday, then reject a week/year pair which formats to another canonical roll name. Without that check an
+        //! alias such as 2021W53 can collide with 2022W01 during physical roll enumeration.
+        final int year = Math.toIntExact(parse.getLong(weekFields.weekBasedYear()));
+        final int week = Math.toIntExact(parse.getLong(weekFields.weekOfWeekBasedYear()));
+        final int rollDayOfWeek = LocalDate.ofEpochDay(epoch / ONE_DAY_IN_MILLIS)
+                .get(weekFields.dayOfWeek());
+        final LocalDate resolved = LocalDate.of(year, 7, 1)
+                .with(weekFields.weekBasedYear(), year)
+                .with(weekFields.weekOfWeekBasedYear(), week)
+                .with(weekFields.dayOfWeek(), rollDayOfWeek);
+        if (resolved.get(weekFields.weekBasedYear()) != year
+                || resolved.get(weekFields.weekOfWeekBasedYear()) != week
+                || !name.equals(formatter.format(resolved)))
+            throw new DateTimeException("Non-canonical roll name " + name + " for format " + format);
+        return resolved.toEpochDay();
+    }
+
     public Long toLong(File file) {
         final Long cachedValue = filenameToTimestampCache.get(file);
         if (cachedValue != null) {
             return cachedValue;
         }
 
-        final TemporalAccessor parse = formatter.parse(fileToName.apply(file));
+        final String name = fileToName.apply(file);
+        final TemporalAccessor parse = formatter.parse(name);
         final long value;
         if (length == ONE_DAY_IN_MILLIS) {
             value = parse.getLong(ChronoField.EPOCH_DAY);
         } else if (length < ONE_DAY_IN_MILLIS) {
             value = Instant.from(parse).toEpochMilli() / length;
         } else {
-            long daysSinceEpoch = parse.getLong(ChronoField.EPOCH_DAY);
+            long daysSinceEpoch = resolveEpochDay(parse, name);
             long adjShift = daysSinceEpoch < 0 ? -1 : 0;
             value = adjShift + ((daysSinceEpoch * 86400) / (length / 1000));
         }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
@@ -15,21 +15,55 @@ import net.openhft.chronicle.queue.ExcerptAppender;
  */
 public interface InternalAppender extends ExcerptAppender {
 
+    //! exactWriteReplacesAnIncompleteRequestedEntryAfterQueueRestart, canBackfillPreviousCycleAfterEOF and
+    //! historicalWriteAfterReadyInterruptedRecordNormalisesAtCompletion require the internal API contract to expose
+    //! retry, physical recovery and completion responsibilities. Without them a replication caller could treat EOF
+    //! as immutable or acknowledge a backfill before resealing it; the implementation decisions are justified beside
+    //! their respective branches rather than by this interface-level documentation note.
+    //! InternalAppenderWriteBytesTest#publishedDuplicatePayloadsAreComparedWithoutMutation requires this contract to
+    //! state that duplicate comparison is diagnostic and never rejects or overwrites an already-published record.
+    //! exactWriteDoesNotRecreateDeletedPublishedMaximum and exactWriteRejectsAbsentCycleWithinPublishedRange require
+    //! the same contract to distinguish a creatable new sparse roll from missing retained publication state.
     /**
      * Append an excerpt at the specified index, if the index is a valid next index for the queue.
+     * This internal replication path can replace an end-of-data marker when restoring an exact
+     * missing index. Replacing the marker is logged as a warning; the cycle remains open for the
+     * rest of the backfill and is resealed by {@link #normaliseEOFs()} at completion.
+     * <p>
+     * For queues that support this path, {@code StoreAppender} establishes padding when it
+     * constructs the Wire. Exact-index recovery has no unpadded mode.
+     * <p>
+     * Queue serialises concurrent backfill appenders with its write lock. A published index is
+     * authoritative and treated as already applied; a gap is rejected. A duplicate is compared
+     * with the published payload: equal content is reported at debug level, while different
+     * content is warned with both payloads as hex and the supplied duplicate is ignored.
+     * An absent roll may be created only outside the retained published bounds. An absent
+     * highest roll or interior roll within those bounds is rejected because Queue cannot
+     * distinguish unsupported deletion from a never-created sparse generation.
+     * If an attempt leaves the requested header incomplete, a later exact-index call can replace it,
+     * including from a new Queue instance after restart. That retry does not infer whether the failed
+     * attempt opened an end-of-data marker, so restoring any missing marker is a separate completion step.
+     * The caller must retry after failure, call {@link #normaliseEOFs()} before publishing recovery
+     * completion, and exclude archive/delete maintenance throughout that interval. EOF is a hard
+     * seal for ordinary writes, not proof that exact recovery can never reopen the roll.
      * <p>
      * If the index is:
      * <dl>
-     *     <dt>Greater than the next valid indices for the queue</dt>
+     *     <dt>Greater than the next valid index for the queue</dt>
      *     <dd>An {@link IllegalIndexException} is thrown</dd>
      *
-     *     <dt>Less than or equal to the last index in the queue</dt>
-     *     <dd>The method returns without modifying the queue</dd>
+     *     <dt>Less than or equal to the last index published before this call</dt>
+     *     <dd>The supplied payload is compared with the authoritative published record and is
+     *     never written. Equal content produces a debug message; different content produces a
+     *     warning with both payloads as hex. A distinct ready first-writer record left beyond the
+     *     write-position publication boundary is adopted successfully without overwriting it.</dd>
      * </dl>
      *
-     * @param index index the index to append at
-     * @param bytes bytes the contents of the excerpt to write
-     * @throws IllegalIndexException if the index specified is larger than the valid next indices of the queue
+     * @param index the exact queue index to append at
+     * @param bytes the contents of the excerpt to write
+     * @throws IllegalIndexException if {@code index} is greater than the next valid queue index
+     * @throws IllegalArgumentException if the sequence is outside the roll cycle's declared capacity
+     * @throws IllegalStateException if the target roll is absent within the retained published bounds
      */
     void writeBytes(long index, BytesStore<?, ?> bytes);
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
@@ -20,8 +20,9 @@ public interface InternalAppender extends ExcerptAppender {
     //! retry, physical recovery and completion responsibilities. Without them a replication caller could treat EOF
     //! as immutable or acknowledge a backfill before resealing it; the implementation decisions are justified beside
     //! their respective branches rather than by this interface-level documentation note.
-    //! InternalAppenderWriteBytesTest#publishedDuplicatePayloadsAreComparedWithoutMutation requires this contract to
-    //! state that duplicate comparison is diagnostic and never rejects or overwrites an already-published record.
+    //! InternalAppenderWriteBytesTest#publishedDuplicatePayloadsAreComparedWithoutMutation and
+    //! StoreAppenderTest#readyCrashDuplicatesCompareMatchingAndDifferentPayloads require this contract to state that
+    //! duplicate comparison is diagnostic and never rejects or overwrites either a published or ready crash record.
     //! exactWriteDoesNotRecreateDeletedPublishedMaximum and exactWriteRejectsAbsentCycleWithinPublishedRange require
     //! the same contract to distinguish a creatable new sparse roll from missing retained publication state.
     /**
@@ -35,7 +36,8 @@ public interface InternalAppender extends ExcerptAppender {
      * <p>
      * Queue serialises concurrent backfill appenders with its write lock. A published index is
      * authoritative and treated as already applied; a gap is rejected. A duplicate is compared
-     * with the published payload: equal content is reported at debug level, while different
+     * with the existing payload, including a ready crash record not yet published: equal content is
+     * reported at debug level (silent when disabled), while different
      * content is warned with both payloads as hex and the supplied duplicate is ignored.
      * An absent roll may be created only outside the retained published bounds. An absent
      * highest roll or interior roll within those bounds is rejected because Queue cannot
@@ -55,8 +57,11 @@ public interface InternalAppender extends ExcerptAppender {
      *     <dt>Less than or equal to the last index published before this call</dt>
      *     <dd>The supplied payload is compared with the authoritative published record and is
      *     never written. Equal content produces a debug message; different content produces a
-     *     warning with both payloads as hex. A distinct ready first-writer record left beyond the
-     *     write-position publication boundary is adopted successfully without overwriting it.</dd>
+     *     warning with both payloads as hex.</dd>
+     *
+     *     <dt>A ready record beyond the write-position publication boundary</dt>
+     *     <dd>The requested ready record is compared using the same diagnostic policy and adopted
+     *     successfully without overwriting it. Publication stops at that requested record.</dd>
      * </dl>
      *
      * @param index the exact queue index to append at

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -565,8 +565,18 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
                               final long indexOfNext,
                               final long startAddress,
                               boolean inclusive) throws EOFException {
+        return linearScanByPosition(wire, toPosition, indexOfNext, startAddress, inclusive, true);
+    }
+
+    private long linearScanByPosition(@NotNull final Wire wire,
+                                      final long toPosition,
+                                      final long indexOfNext,
+                                      final long startAddress,
+                                      boolean inclusive,
+                                      boolean useLastSequenceShortcut) throws EOFException {
         long start = REPORT_LINEAR_SCAN ? System.nanoTime() : 0;
-        long index = linearScanByPosition0(wire, toPosition, indexOfNext, startAddress, inclusive);
+        long index = linearScanByPosition0(
+                wire, toPosition, indexOfNext, startAddress, inclusive, useLastSequenceShortcut);
         if (REPORT_LINEAR_SCAN) {
             printLinearScanTime(index, startAddress, start, "linearScan by position");
         }
@@ -591,6 +601,15 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
                                long indexOfNext,
                                long startAddress,
                                boolean inclusive) throws EOFException {
+        return linearScanByPosition0(wire, toPosition, indexOfNext, startAddress, inclusive, true);
+    }
+
+    private long linearScanByPosition0(@NotNull final Wire wire,
+                                       final long toPosition,
+                                       long indexOfNext,
+                                       long startAddress,
+                                       boolean inclusive,
+                                       boolean useLastSequenceShortcut) throws EOFException {
         linearScanByPositionCount++;
         assert toPosition >= 0;
         Bytes<?> bytes = wire.bytes();
@@ -598,9 +617,12 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
 
         // Optimized path if the `toPosition` is the last written position.
         long lastAddress = writePosition.getVolatileValue();
-        long lastIndex = this.sequence.getSequence(lastAddress);
+        long lastIndex = useLastSequenceShortcut
+                ? this.sequence.getSequence(lastAddress)
+                : Sequence.NOT_FOUND;
 
-        i = calculateInitialValue(toPosition, indexOfNext, startAddress, bytes, lastAddress, lastIndex);
+        i = calculateInitialValue(toPosition, indexOfNext, startAddress, bytes,
+                lastAddress, lastIndex, useLastSequenceShortcut);
 
         // Scan through the entries until the target position is found or exceeded.
         while (bytes.readPosition() <= toPosition) {
@@ -663,8 +685,14 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
      * @param lastIndex    The index of the last written entry.
      * @return The starting index for the scan.
      */
-    private long calculateInitialValue(long toPosition, long indexOfNext, long startAddress, Bytes<?> bytes, long lastAddress, long lastIndex) {
-        if (lastAddress > 0 && toPosition == lastAddress
+    private long calculateInitialValue(long toPosition,
+                                       long indexOfNext,
+                                       long startAddress,
+                                       Bytes<?> bytes,
+                                       long lastAddress,
+                                       long lastIndex,
+                                       boolean useLastSequenceShortcut) {
+        if (useLastSequenceShortcut && lastAddress > 0 && toPosition == lastAddress
                 && lastIndex != Sequence.NOT_FOUND && lastIndex != Sequence.NOT_FOUND_RETRY) {
             bytes.readPositionUnlimited(toPosition);
             return lastIndex - 1;
@@ -723,9 +751,24 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
     long sequenceForPosition(@NotNull ExcerptContext ec,
                              final long position,
                              boolean inclusive) throws StreamCorruptedException {
+        return sequenceForPosition(ec.wireForIndex(), position, inclusive, true);
+    }
+
+    long sequenceForPositionWithoutSequenceShortcut(@NotNull Wire wire,
+                                                     final long position,
+                                                     boolean inclusive) throws StreamCorruptedException {
+        //! StoreAppenderTest#exactPreflightRejectsStaleAliasingEncodedSequence requires exact preflight to use the
+        //! sparse index but not the usual last-position shortcut. That shortcut trusts the lossy paired sequence, so
+        //! a crash can make an older aliased pair validate a newer full write position and misclassify exact-next.
+        return sequenceForPosition(wire, position, inclusive, false);
+    }
+
+    private long sequenceForPosition(@NotNull Wire wire,
+                                     final long position,
+                                     boolean inclusive,
+                                     boolean useLastSequenceShortcut) throws StreamCorruptedException {
         long indexOfNext = 0;
         long lastKnownAddress = 0;
-        @NotNull Wire wire = ec.wireForIndex();
         try {
             final LongArrayValues index2indexArr = getIndex2index(wire);
             int used2 = getUsedAsInt(index2indexArr);
@@ -773,7 +816,8 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
         }
         try {
             // Perform a linear scan if no exact match is found.
-            return linearScanByPosition(wire, position, indexOfNext, lastKnownAddress, inclusive);
+            return linearScanByPosition(
+                    wire, position, indexOfNext, lastKnownAddress, inclusive, useLastSequenceShortcut);
         } catch (EOFException e) {
             throw new UncheckedIOException(e);
         }
@@ -967,8 +1011,13 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
             for (int i = 0; i < 128; i++) {
 
                 long address = writePosition.getVolatileValue(0);
+                //! eosOnlyRestartPreservesReadySequenceZeroBeforeOrdinaryAppend reproduces the address-zero crash
+                //! where ready data reaches storage before writePosition. Returning empty here loses that record;
+                //! the existing physical scan can classify it without attempting general index repair.
+                //! restartScansCommittedRecordAfterSparseIndexPublicationWasLost is integration evidence for the
+                //! pre-existing non-zero-address scan and deliberately does not claim this changed branch.
                 if (address == 0)
-                    return -1;
+                    break;
                 long sequence = sequence1.getSequence(address);
                 if (sequence == Sequence.NOT_FOUND_RETRY)
                     continue;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.*;
 import java.security.SecureRandom;
 import java.text.ParseException;
+import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -945,6 +946,18 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         return pool.listCyclesBetween(lowerCycle, upperCycle);
     }
 
+    NavigableSet<Long> listFreshPhysicalCycles() {
+        //! StoreAppenderTest#cachedCycleTreeDoesNotHideMalformedPhysicalRoll and
+        //! #duplicateLogicalCycleFilenameFailsNormalisationWithoutMutation require constructor and completion scans
+        //! to bypass the directory-modification cache and validate every current .cq4 filename. A cached endpoint
+        //! match is not a physical snapshot because external maintenance does not update listing.modCount.
+        return storeSupplier.freshPhysicalCycles();
+    }
+
+    void evictCachedCycleMapping(int cycle) {
+        storeSupplier.evictCycleMapping(cycle);
+    }
+
     /**
      * Adds a {@link Closeable} listener that will be closed when this queue is closed.
      *
@@ -1129,6 +1142,14 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         return directoryListing.getMinCreatedCycle();
     }
 
+    int firstPublishedCycleWithoutRefresh() {
+        //! StoreAppenderTest#corruptedEofNormalisationCursorFailsBeforeMutation requires completion to validate its
+        //! persisted cursor before a filesystem refresh can publish a new listing modification count. The mapped
+        //! minimum supplies only the cursor's safe default; physical bounds are still refreshed and validated after
+        //! the cursor has been accepted.
+        return directoryListing.getMinCreatedCycle();
+    }
+
     /**
      * allows the appenders to inform the queue that they have rolled
      *
@@ -1167,6 +1188,13 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         //! stalledWriterSeesCyclePublishedByAnotherJvmWithoutRefreshingDirectoryListing fail if
         //! this delegates to lastCycle(): both require the mapped maximum without a directory refresh.
         return directoryListing.getMaxCreatedCycle();
+    }
+
+    boolean cycleFileExists(final int cycle) {
+        //! stalledAppenderDoesNotRecreateDeletedPublishedMaximum and
+        //! unusedAppenderDoesNotCreateDeletedPublishedMaximum require a wire-null appender to
+        //! distinguish a missing published pathname before recovery scans stale directory bounds.
+        return dateCache.resourceFor(cycle).path.isFile();
     }
 
     /**
@@ -1378,16 +1406,21 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     private static final class CachedCycleTree {
         private final long directoryModCount;
         private final NavigableMap<Long, File> cachedCycleTree;
+        private final NavigableSet<Long> cachedCycles;
 
         /**
          * Constructs a CachedCycleTree with the specified directory modification count and cached cycle tree.
          *
          * @param directoryModCount the modification count of the directory
          * @param cachedCycleTree   the cached map of cycles to files
+         * @param cachedCycles      the parsed Queue cycles represented by the files
          */
-        CachedCycleTree(final long directoryModCount, final NavigableMap<Long, File> cachedCycleTree) {
+        CachedCycleTree(final long directoryModCount,
+                        final NavigableMap<Long, File> cachedCycleTree,
+                        final NavigableSet<Long> cachedCycles) {
             this.directoryModCount = directoryModCount;
             this.cachedCycleTree = cachedCycleTree;
+            this.cachedCycles = cachedCycles;
         }
     }
 
@@ -1456,8 +1489,22 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 try {
                     mappedBytes = mappedFileCache.get(path);
                 } catch (FileNotFoundException e) {
+                    //! There is no deterministic hook inside the existence/open race: a supported writer holds the
+                    //! Queue lock, while external maintenance does not. If the path vanishes after the initial check,
+                    //! an existing-only acquisition must return absent instead of recreating it through createFile();
+                    //! otherwise completion could certify a different generation from the one it enumerated.
+                    if (createStrategy != CreateStrategy.CREATE)
+                        return null;
                     createFile(path);
                     mappedBytes = mappedFileCache.get(path);
+                }
+                //! There is likewise no deterministic hook between cache acquisition and this pathname recheck.
+                //! A POSIX unlink can leave mappedBytes usable, so strict completion must reject that stale mapping
+                //! before reading or writing EOF rather than report success for an inode no longer in the directory.
+                if (createStrategy == CreateStrategy.REINITIALIZE_EXISTING && !path.isFile()) {
+                    mappedBytes.close();
+                    mappedFileCache.remove(path);
+                    return null;
                 }
                 mappedBytes.singleThreadedCheckDisabled(true);
                 mappedBytes.chunkCount(chunkCount);
@@ -1630,7 +1677,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
          * @return a NavigableMap of cycle numbers and their corresponding files
          */
         @NotNull
-        private NavigableMap<Long, File> cycleTree(final boolean force) {
+        private CachedCycleTree cycleTreeSnapshot(final boolean force) {
 
             final File parentFile = path;
 
@@ -1644,13 +1691,37 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
                 final RollingResourcesCache dateCache = SingleChronicleQueue.this.dateCache;
                 final NavigableMap<Long, File> tree = new TreeMap<>();
+                final NavigableSet<Long> cycles = new TreeSet<>();
 
                 final File[] files = parentFile.listFiles((File file) -> file.getPath().endsWith(SUFFIX));
-                if (files != null)
-                    for (File file : files)
-                        tree.put(dateCache.toLong(file), file);
+                if (files != null) {
+                    for (File file : files) {
+                        final String rollName = fileToText().apply(file);
+                        final int cycle = dateCache.parseCount(rollName);
+                        final String canonicalName = dateCache.resourceFor(cycle).text;
+                        //! StoreAppenderTest#duplicateLogicalCycleFilenameFailsNormalisationWithoutMutation requires
+                        //! every physical name to be the canonical inverse of its parsed Queue cycle. Checking only
+                        //! ordering-key uniqueness lets a coarse custom format map two different dates to one cycle,
+                        //! after which a TreeSet silently omits one file and completion publishes a false cursor.
+                        if (!rollName.equals(canonicalName))
+                            throw new DateTimeException("Non-canonical roll name " + rollName
+                                    + "; cycle " + cycle + " is " + canonicalName);
+                        // Exact canonical inversion makes distinct physical names mapping to one cycle impossible.
+                        cycles.add((long) cycle);
 
-                cachedValue = new CachedCycleTree(directoryModCount, tree);
+                        final long orderingKey = dateCache.toLong(file);
+                        //! Canonical roll names are one-to-one for supported formats, so no current test can reach
+                        //! this second duplicate-key guard after the cycle/name checks above. Retain it for a custom
+                        //! format whose distinct canonical names resolve to one ordering key: silently replacing a
+                        //! physical generation would make tailing and completion disagree about that position.
+                        final File previous = tree.put(orderingKey, file);
+                        if (previous != null)
+                            throw new IllegalStateException("Roll files resolve to the same ordering key "
+                                    + orderingKey + ": " + previous + " and " + file);
+                    }
+                }
+
+                cachedValue = new CachedCycleTree(directoryModCount, tree, cycles);
 
                 while (true) {
                     final CachedCycleTree existing = cachedTree.get();
@@ -1666,7 +1737,25 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 }
             }
 
-            return cachedValue.cachedCycleTree;
+            return cachedValue;
+        }
+
+        @NotNull
+        private NavigableMap<Long, File> cycleTree(final boolean force) {
+            return cycleTreeSnapshot(force).cachedCycleTree;
+        }
+
+        private NavigableSet<Long> freshPhysicalCycles() {
+            return new TreeSet<>(cycleTreeSnapshot(true).cachedCycles);
+        }
+
+        private void evictCycleMapping(int cycle) {
+            //! No deterministic cross-platform test can replace a roll pathname between the physical snapshot and
+            //! cache lookup. Evict before strict reacquisition so a recreated pathname cannot resolve to the former
+            //! inode's cached mapping; sealing that mapping would falsely certify a generation not present in the
+            //! snapshot. StoreAppenderTest#currentMappedGenerationDisappearingAfterEnumerationDoesNotAdvanceCursor
+            //! separately discriminates bypassing WireStorePool's same-cycle oldStore shortcut.
+            mappedFileCache.remove(dateCache.resourceFor(cycle).path);
         }
 
         /**
@@ -1748,12 +1837,22 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         public NavigableSet<Long> cycles(int lowerCycle, int upperCycle) {
             throwExceptionIfClosed();
 
-            final NavigableMap<Long, File> tree = cycleTree(false);
-            final Long lowerKey = toKey(lowerCycle, "lowerCycle");
-            final Long upperKey = toKey(upperCycle, "upperCycle");
-            assert lowerKey != null;
-            assert upperKey != null;
-            return tree.subMap(lowerKey, true, upperKey, true).navigableKeySet();
+            //! StoreAppenderTest#dailyNonZeroEpochEnumeratesCycleZero,
+            //! #hourlyNonZeroEpochEnumeratesCycleZero and #weeklyNonZeroEpochEnumeratesCycleZero require this public
+            //! supplier contract to return Queue cycle numbers. The tree keys are absolute time buckets used only
+            //! for ordering; filtering by those keys can also exclude a non-canonical alias before validation.
+            //! Return the validated logical-cycle subset instead.
+            final NavigableSet<Long> cycles = cycleTreeSnapshot(false).cachedCycles;
+            final NavigableSet<Long> selected = new TreeSet<>(
+                    cycles.subSet((long) lowerCycle, true, (long) upperCycle, true));
+            //! SingleChronicleQueueTest#testCountExceptsWithRubbishData preserves the established endpoint failure
+            //! contract. Returning a partial or empty subset after the tree representation changed would make an
+            //! invalid count range look valid instead of reporting that its physical boundary is absent.
+            if (!selected.contains((long) lowerCycle))
+                throw new IllegalStateException("file not found for lowerCycle=" + lowerCycle);
+            if (!selected.contains((long) upperCycle))
+                throw new IllegalStateException("file not found for upperCycle=" + upperCycle);
+            return selected;
         }
 
         /**
@@ -1770,18 +1869,5 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             return !store.isClosed() && cycle >= directoryListing.getMinCreatedCycle() && cycle <= directoryListing.getMaxCreatedCycle();
         }
 
-        /**
-         * Converts a cycle number to a key used in the cycle tree.
-         *
-         * @param cyle the cycle number
-         * @param m    the label to use in case of an error
-         * @return the key for the cycle tree
-         */
-        private Long toKey(int cyle, String m) {
-            final File file = dateCache.resourceFor(cyle).path;
-            if (!file.exists())
-                throw new IllegalStateException("'file not found' for the " + m + ", file=" + file);
-            return dateCache.toLong(file);
-        }
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1845,12 +1845,13 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             final NavigableSet<Long> cycles = cycleTreeSnapshot(false).cachedCycles;
             final NavigableSet<Long> selected = new TreeSet<>(
                     cycles.subSet((long) lowerCycle, true, (long) upperCycle, true));
-            //! SingleChronicleQueueTest#testCountExceptsWithRubbishData preserves the established endpoint failure
-            //! contract. Returning a partial or empty subset after the tree representation changed would make an
-            //! invalid count range look valid instead of reporting that its physical boundary is absent.
-            if (!selected.contains((long) lowerCycle))
+            //! SingleChronicleQueueTest#testCountExceptsWithRubbishData covers initially absent endpoints, while
+            //! StoreAppenderTest#cachedCycleEnumerationRejectsDeletedBoundaries requires action-time pathname checks
+            //! even when modCount has not invalidated this cached set. Membership alone would return a deleted
+            //! physical boundary as a valid count range. These checks are outside the ordinary append hot path.
+            if (!selected.contains((long) lowerCycle) || !dateCache.resourceFor(lowerCycle).path.exists())
                 throw new IllegalStateException("file not found for lowerCycle=" + lowerCycle);
-            if (!selected.contains((long) upperCycle))
+            if (!selected.contains((long) upperCycle) || !dateCache.resourceFor(upperCycle).path.exists())
                 throw new IllegalStateException("file not found for upperCycle=" + upperCycle);
             return selected;
         }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
@@ -3,6 +3,8 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesUtil;
 import net.openhft.chronicle.bytes.MappedBytes;
 import net.openhft.chronicle.bytes.MappedFile;
 import net.openhft.chronicle.core.Jvm;
@@ -392,6 +394,31 @@ public class SingleChronicleQueueStore extends AbstractCloseable implements Wire
         return indexing.lastSequenceNumber(ec);
     }
 
+    long lastPublishedSequenceNumber(Wire wire) {
+        throwExceptionIfClosedInSetter();
+        final long publishedPosition = writePosition.getVolatileValue();
+        //! InternalAppenderWriteBytesTest#exactBackfillFindsEofInEmptySealedCycle requires zero to mean that no data
+        //! sequence has been published even when metadata and EOF follow the store header. Scanning position zero as
+        //! application data would invent a published boundary and reject the valid sequence-zero recovery as old.
+        if (publishedPosition == 0)
+            return -1;
+
+        //! StoreAppenderTest#sameCycleGapDoesNotPublishReadyCrashRecord,
+        //! #publishedDuplicateDoesNotAdoptLaterReadyCrashRecord,
+        //! #exactPreflightScansPublishedBoundaryWhenEncodedSequenceWasLost and
+        //! #exactPreflightRejectsStaleAliasingEncodedSequence require preflight to derive the sequence from the full
+        //! published position without repairing sparse indexes. RollCycleEncodeSequence retains only low position
+        //! bits, so a stale pre-crash pair can alias a later write position and falsely report an earlier sequence;
+        //! accepting that fast path rejects the true exact-next index as a gap. The sparse index bounds this
+        //! exact-only physical scan, while disabling its last-position shortcut makes it read-only and independent
+        //! of the lossy pair.
+        try {
+            return indexing.sequenceForPositionWithoutSequenceShortcut(wire, publishedPosition, true);
+        } catch (StreamCorruptedException e) {
+            throw Jvm.rethrow(e);
+        }
+    }
+
     /**
      * Returns a string representation of the store's current state, including details about indexing,
      * write position, mapped file, and whether the store is closed.
@@ -518,6 +545,10 @@ public class SingleChronicleQueueStore extends AbstractCloseable implements Wire
         // If unable to reserve bytes, create a new instance of MappedBytes and try again
         try (MappedBytes bytes = MappedBytes.mappedBytes(mappedFile.file(), mappedFile.chunkSize())) {
             Wire wire0 = WireType.valueOf(wire).apply(bytes);
+            //! StoreAppenderTest#writeEofReplacementUsesStorePadding forces this replacement-Wire
+            //! branch and requires it to inherit the store's physical padding mode. Exact-recovery
+            //! preflight tests reject legacy targets earlier and do not execute this fallback.
+            wire0.usePadding(dataVersion > 0);
             return writeEOFAndShrink(wire0, timeoutMS);
 
         } catch (Exception e) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -1521,6 +1521,7 @@ class StoreAppender extends AbstractCloseable
                 }
 
                 long lastPhysicalSequence = lastPublishedSequence;
+                long requestedReadyPosition = -1;
                 long position = publishedPosition
                         + lengthOf(bytes.readVolatileInt(publishedPosition)) + SPB_HEADER_SIZE;
                 for (; ; ) {
@@ -1533,7 +1534,20 @@ class StoreAppender extends AbstractCloseable
                         if (++lastPhysicalSequence >= rollCycle.maxMessagesPerCycle())
                             throw new IllegalStateException("Physical sequence exceeds maxMessagesPerCycle in cycle "
                                     + cycle + " for queue=" + queue.fileAbsolutePath());
+                        if (lastPhysicalSequence == requestedSequence)
+                            requestedReadyPosition = position;
                     } else if (!isReadyMetaData(header)) {
+                        //! readyCrashDuplicatesCompareMatchingAndDifferentPayloads and
+                        //! readyCrashDuplicateEqualityIsSilentWhenDebugDisabled require the same diagnostic policy
+                        //! for a ready crash record as for a published duplicate. Compare only the requested record,
+                        //! after classifying the complete physical prefix and before adoption changes publication;
+                        //! silently adopting a different payload would hide a divergent retry.
+                        if (requestedReadyPosition >= 0) {
+                            bytes.readLimit(requestedReadyPosition + SPB_HEADER_SIZE
+                                    + lengthOf(bytes.readVolatileInt(requestedReadyPosition)));
+                            bytes.readPosition(requestedReadyPosition);
+                            compareExistingEntry(cycle, requestedSequence, bytes, suppliedBytes, "ready");
+                        }
                         return new ExactIndexState(true, publishedPosition, lastPublishedSequence,
                                 lastPhysicalSequence, header);
                     }
@@ -1559,7 +1573,7 @@ class StoreAppender extends AbstractCloseable
                 warnUnableToComparePublishedEntry(cycle, sequenceNumber, suppliedBytes, scanResult);
                 return;
             }
-            comparePublishedEntry(cycle, sequenceNumber, existingBytes, suppliedBytes);
+            compareExistingEntry(cycle, sequenceNumber, existingBytes, suppliedBytes, "published");
 
         } finally {
             existingBytes.readPosition(savedReadPosition);
@@ -1568,28 +1582,31 @@ class StoreAppender extends AbstractCloseable
         }
     }
 
-    private void comparePublishedEntry(final int cycle,
-                                       final long sequenceNumber,
-                                       @NotNull final Bytes<?> existingBytes,
-                                       @NotNull final BytesStore<?, ?> suppliedBytes) {
+    private void compareExistingEntry(final int cycle,
+                                      final long sequenceNumber,
+                                      @NotNull final Bytes<?> existingBytes,
+                                      @NotNull final BytesStore<?, ?> suppliedBytes,
+                                      final String recordState) {
         final int header = existingBytes.readVolatileInt();
         assert isReadyData(header);
         final int existingLength = lengthOf(header);
         final long suppliedLength = suppliedBytes.readRemaining();
         final long index = queue.rollCycle().toIndex(cycle, sequenceNumber);
         //! InternalAppenderWriteBytesTest#publishedDuplicatePayloadsAreComparedWithoutMutation distinguishes both
-        //! outcomes. Equal content is debug-only (and therefore silent when debug is disabled); different content
-        //! warns with both hex dumps, but neither path throws or overwrites the authoritative published record.
+        //! outcomes for published data; readyCrashDuplicatesCompareMatchingAndDifferentPayloads requires parity
+        //! for ready crash data. readyCrashDuplicateEqualityIsSilentWhenDebugDisabled pins the debug guard:
+        //! equal content is silent when disabled, while different content still warns with both hex dumps.
+        //! Neither path throws or overwrites the authoritative existing record.
         if (existingLength == suppliedLength
                 && existingBytes.equalBytes(suppliedBytes, existingLength)) {
             if (Jvm.isDebugEnabled(getClass()))
-                Jvm.debug().on(getClass(), "Exact-index duplicate matches published content and was ignored: queue="
+                Jvm.debug().on(getClass(), "Exact-index duplicate matches " + recordState + " content and was ignored: queue="
                         + queue.fileAbsolutePath() + ", cycle=" + cycle + ", index=0x" + Long.toHexString(index)
                         + ", length=" + existingLength);
             return;
         }
 
-        Jvm.warn().on(getClass(), "Exact-index duplicate differs from published content and was ignored: queue="
+        Jvm.warn().on(getClass(), "Exact-index duplicate differs from " + recordState + " content and was ignored: queue="
                 + queue.fileAbsolutePath() + ", cycle=" + cycle + ", index=0x" + Long.toHexString(index)
                 + ", existingLength=" + existingLength + ", suppliedLength=" + suppliedLength
                 + "\nexisting:\n" + existingBytes.toHexString(existingLength)

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -15,6 +15,7 @@ import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.QueueSystemProperties;
+import net.openhft.chronicle.queue.RollCycle;
 import net.openhft.chronicle.queue.impl.ExcerptContext;
 import net.openhft.chronicle.queue.impl.WireStorePool;
 import net.openhft.chronicle.queue.impl.WireStoreSupplier;
@@ -30,6 +31,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StreamCorruptedException;
 import java.nio.BufferOverflowException;
+import java.time.DateTimeException;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueue.WARN_SLOW_APPENDER_MS;
@@ -109,17 +113,32 @@ class StoreAppender extends AbstractCloseable
             try {
                 // Process cycles and handle EOF markers
                 if (firstCycle != UNSET_CONTEXT) {
+                    //! constructionSealsEveryRollBelowTheFirstSealedRoll fails if the back-scan excludes the first
+                    //! sealed generation. sparseRollsAreTraversedByExistingCycle requires walking actual survivors
+                    //! rather than fabricating every numeric cycle, while
+                    //! NormaliseEOFsTest#deletingOldestPublishedRollDoesNotBlockAReusedQueue is integration evidence
+                    //! for refreshed physical bounds after supported historical deletion; the accepted base already
+                    //! permits that deletion but does not use this physical back-scan.
+                    final ExistingCycles range = enumerateExistingCycles();
+                    firstCycle = range.first;
+                    lastExistingCycle = range.last;
+                    final NavigableSet<Long> existingCycles = range.cycles;
                     // Backing down until EOF-ed cycle is encountered
-                    for (int eofCycle = lastExistingCycle; eofCycle >= firstCycle; eofCycle--) {
+                    for (long existingCycle : existingCycles.descendingSet()) {
+                        final int eofCycle = Math.toIntExact(existingCycle);
                         setCycle2(eofCycle, WireStoreSupplier.CreateStrategy.READ_ONLY);
+                        if (wire == null)
+                            break;
                         if (cycleHasEOF()) {
                             // Make sure all older cycles have EOF marker
                             if (eofCycle > firstCycle)
-                                normaliseEOFs0(eofCycle - 1);
+                                normaliseEOFs0(eofCycle);
 
                             // If first non-EOF file is in the past, it's possible it will be replicated/backfilled to
-                            if (eofCycle < lastExistingCycle)
-                                setCycle2(eofCycle + 1 /* TODO: Position on existing one? */, WireStoreSupplier.CreateStrategy.READ_ONLY);
+                            final Long nextExistingCycle = existingCycles.higher(existingCycle);
+                            if (nextExistingCycle != null)
+                                setCycle2(Math.toIntExact(nextExistingCycle),
+                                        WireStoreSupplier.CreateStrategy.READ_ONLY);
                             break;
                         }
                     }
@@ -377,6 +396,20 @@ class StoreAppender extends AbstractCloseable
      * @param createStrategy The strategy used to create a new store.
      */
     private void setCycle2(final int cycle, final WireStoreSupplier.CreateStrategy createStrategy) {
+        setCycle2(cycle, createStrategy, true);
+    }
+
+    private void setCycle2StrictExisting(final int cycle) {
+        //! StoreAppenderTest#currentMappedGenerationDisappearingAfterEnumerationDoesNotAdvanceCursor requires
+        //! completion to bypass WireStorePool's same-cycle oldStore shortcut. Otherwise an unlinked POSIX inode can
+        //! be resealed through its retained mapping and certified by the cursor even though its pathname disappeared.
+        queue.evictCachedCycleMapping(cycle);
+        setCycle2(cycle, WireStoreSupplier.CreateStrategy.REINITIALIZE_EXISTING, false);
+    }
+
+    private void setCycle2(final int cycle,
+                           final WireStoreSupplier.CreateStrategy createStrategy,
+                           final boolean reuseCurrentStore) {
         queue.throwExceptionIfClosed();
         if (cycle < 0)
             throw new IllegalArgumentException("You can not have a cycle that starts " +
@@ -386,7 +419,10 @@ class StoreAppender extends AbstractCloseable
 
         SingleChronicleQueueStore oldStore = this.store;
 
-        SingleChronicleQueueStore newStore = storePool.acquire(cycle, createStrategy, oldStore);
+        SingleChronicleQueueStore newStore = storePool.acquire(
+                cycle, createStrategy, reuseCurrentStore ? oldStore : null);
+        if (!reuseCurrentStore && newStore == null)
+            throw missingPhysicalCycle(cycle);
 
         // If the store has changed, update and close the old one
         if (newStore != oldStore) {
@@ -471,6 +507,18 @@ class StoreAppender extends AbstractCloseable
      * @throws UnrecoverableTimeoutException If a timeout occurs during the operation.
      */
     private boolean resetPosition() {
+        if (store == null || wire == null)
+            return false;
+        try {
+            final boolean changed = resetPosition(store.lastSequenceNumber(this));
+            assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
+            return changed;
+        } catch (StreamCorruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private boolean resetPosition(long lastSequenceNumber) {
         long originalHeaderNumber = wire.headerNumber();
         long INVALID_HEADER_NUMBER = -1;
 
@@ -483,18 +531,15 @@ class StoreAppender extends AbstractCloseable
             Bytes<?> bytes = wire.bytes();
             assert !QueueSystemProperties.CHECK_INDEX || checkPositionOfHeader(bytes);
 
-            final long lastSequenceNumber = store.lastSequenceNumber(this);
             wire.headerNumber(queue.rollCycle().toIndex(cycle, lastSequenceNumber + 1) - 1);
 
             assert !QueueSystemProperties.CHECK_INDEX || wire.headerNumber() != INVALID_HEADER_NUMBER ||
                     checkIndex(wire.headerNumber(), positionOfHeader);
 
             bytes.writeLimit(bytes.capacity());
-
-            assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
             return originalHeaderNumber != wire.headerNumber();
 
-        } catch (@NotNull BufferOverflowException | StreamCorruptedException e) {
+        } catch (@NotNull BufferOverflowException e) {
             throw new AssertionError(e);
         }
     }
@@ -628,13 +673,32 @@ class StoreAppender extends AbstractCloseable
      * This method locks the writeLock and calls the internal {@link #normaliseEOFs0(int)} method for each cycle.
      */
     public void normaliseEOFs() {
+        normaliseEOFs(null);
+    }
+
+    void normaliseEOFs(@Nullable Runnable afterCycleEnumeration) {
         long start = System.nanoTime();
         final WriteLock writeLock = queue.writeLock();
         writeLock.lock();
         try {
-            // use the getter, not the raw field: after the construction-time back-scan releases its
-            // parked store the field is Integer.MIN_VALUE, and the getter resolves that to lastCycle
-            normaliseEOFs0(cycle());
+            //! restartedHistoricalBackfillLowersEofNormalisationBound and
+            //! historicalWriteAfterReadyInterruptedRecordNormalisesAtCompletion require the shared cursor to bring
+            //! every touched historical roll back into completion. currentTimestampBackfillIsNormalisedOnlyAfterItBecomesHistorical,
+            //! futureExactWriteDoesNotAdvanceEofCursorAcrossTimestampCurrentCycle and
+            //! backfillBelowRolledBackHighWaterIsNormalisedAtCompletion require the cap to preserve the effective
+            //! current/future ordinary-write destination until it becomes historical.
+            // CQE retries failed backfills before completion. The shared cursor records the
+            // earliest cycle touched by those attempts; completion seals every such historical
+            // cycle without sealing the effective ordinary-write destination.
+            final int lastPublishedCycle = queue.lastPublishedCycle();
+            final int activeCycle = Math.max(queue.cycle(), lastPublishedCycle);
+            final int normaliseTo = (int) Math.min((long) lastPublishedCycle + 1, activeCycle);
+            //! generationDisappearingAfterEnumerationDoesNotAdvanceCursor uses the package-local
+            //! interleaving hook to replace the physical snapshot before the first mutation.
+            //! currentMappedGenerationDisappearingAfterEnumerationDoesNotAdvanceCursor additionally requires that
+            //! revalidation not reuse an unlinked mapping. They distinguish action-time validation without exposing
+            //! the hook through ExcerptAppender.
+            normaliseEOFs0(normaliseTo, afterCycleEnumeration);
         } finally {
             writeLock.unlock();
             long tookMillis = (System.nanoTime() - start) / 1_000_000;
@@ -650,25 +714,178 @@ class StoreAppender extends AbstractCloseable
      * @param cycle the target cycle up to which EOF normalization should occur
      */
     private void normaliseEOFs0(int cycle) {
-        int first = queue.firstCycle();
+        normaliseEOFs0(cycle, null);
+    }
 
-        if (first == Integer.MAX_VALUE)
+    private void normaliseEOFs0(int cycle, @Nullable Runnable afterCycleEnumeration) {
+        final int publishedFirst = queue.firstPublishedCycleWithoutRefresh();
+        if (publishedFirst == UNSET_CONTEXT)
             return;
+        final LongValue normalisedEOFsTo = queue.tableStoreAcquire(
+                NORMALISED_EOFS_TO_TABLESTORE_KEY, publishedFirst);
+        final long storedNormalisedEOFsTo = normalisedEOFsTo.getVolatileValue();
+        //! corruptedEofNormalisationCursorFailsBeforeMutation requires the persisted long to be validated before it
+        //! becomes a Queue cycle or a directory refresh updates listing metadata. Narrowing first can alias a corrupt
+        //! value into UInt31 and then report completion while skipping historical rolls; unlike directory metadata,
+        //! this cursor has no legacy unset encoding.
+        if (storedNormalisedEOFsTo < 0 || storedNormalisedEOFsTo > Integer.MAX_VALUE)
+            throw new IllegalStateException("Invalid EOF normalisation cycle " + storedNormalisedEOFsTo
+                    + " for queue=" + queue.fileAbsolutePath());
 
-        final LongValue normalisedEOFsTo = queue.tableStoreAcquire(NORMALISED_EOFS_TO_TABLESTORE_KEY, first);
-        int eofCycle = Math.max(first, (int) normalisedEOFsTo.getVolatileValue());
+        //! sparseRollsAreTraversedByExistingCycle,
+        //! cachedCycleTreeDoesNotHideMalformedPhysicalRoll and
+        //! duplicateLogicalCycleFilenameFailsNormalisationWithoutMutation require a fresh snapshot of every physical
+        //! generation. Numeric iteration invents gaps, while a listing.modCount-keyed cache can hide external files
+        //! and canonical-key filtering can omit aliases before validation.
+        final ExistingCycles range = enumerateExistingCycles();
+        final int first = range.first;
+        if (range.isEmpty())
+            return;
+        final NavigableSet<Long> existingCycles = range.cycles;
+        final int eofCycle = Math.max(first, Math.toIntExact(storedNormalisedEOFsTo));
+        if (afterCycleEnumeration != null)
+            afterCycleEnumeration.run();
         if (Jvm.isDebugEnabled(StoreAppender.class)) {
             Jvm.debug().on(StoreAppender.class, "Normalising from cycle " + eofCycle);
         }
 
-        for (; eofCycle < Math.min(queue.cycle(), cycle); ++eofCycle) {
-            setCycle2(eofCycle, WireStoreSupplier.CreateStrategy.REINITIALIZE_EXISTING);
-            if (wire != null) {
-                assert queue.writeLock().locked();
-                store.writeEOF(wire, timeoutMS());
-                normalisedEOFsTo.setMaxValue(eofCycle);
-            }
+        //! restartRetriesIncompleteHistoricalRecoveryAndNormalisesEof and
+        //! historicalWriteAfterReadyInterruptedRecordNormalisesAtCompletion require each survivor below the cap to
+        //! be sealed before advancing the cursor. eofRestorationFailureIsNotReportedAsSuccess,
+        //! generationDisappearingAfterEnumerationDoesNotAdvanceCursor and
+        //! currentMappedGenerationDisappearingAfterEnumerationDoesNotAdvanceCursor require mutation failure or
+        //! disappearance to abort completion; otherwise CQE could acknowledge recovery while a historical roll
+        //! remains writable or absent by pathname.
+        final int activeCycle = Math.max(queue.cycle(), queue.lastPublishedCycle());
+        final int normaliseTo = Math.min(activeCycle, cycle);
+        for (long existingCycle : existingCycles) {
+            if (existingCycle < eofCycle)
+                continue;
+            if (existingCycle >= normaliseTo)
+                break;
+
+            final int cycleToNormalise = Math.toIntExact(existingCycle);
+            setCycle2StrictExisting(cycleToNormalise);
+            assert queue.writeLock().locked();
+            ensureEndOfData("Unable to normalise end-of-data: queue="
+                    + queue.fileAbsolutePath() + ", cycle=" + cycleToNormalise);
         }
+        //! sparseRollsAreTraversedByExistingCycle requires the cursor to advance across physically absent gaps only
+        //! after every surviving roll below the cap has been sealed. Publishing each observed cycle separately would
+        //! repeatedly rescan large sparse ranges; publishing before the loop completed could certify an unsealed roll.
+        // The directory enumeration proves that every skipped cycle is absent.
+        normalisedEOFsTo.setMaxValue(normaliseTo);
+    }
+
+    private ExistingCycles enumerateExistingCycles() {
+        RuntimeException initialFailure = null;
+        ExistingCycles range = null;
+        try {
+            range = enumerateExistingCycles0();
+        } catch (RuntimeException failure) {
+            initialFailure = failure;
+        }
+        if (range != null && range.hasBothBoundaries())
+            return range;
+
+        final boolean initiallyObservedPublishedBounds = range != null && !range.isEmpty();
+        try {
+            //! cachedCycleTreeDoesNotHideMalformedPhysicalRoll and
+            //! duplicateLogicalCycleFilenameFailsNormalisationWithoutMutation require a failed filename scan to
+            //! retry the physical snapshot without first publishing directory metadata. A parseable alias can make
+            //! refresh() increment listing.modCount even though completion must fail without persistent mutation.
+            if (initialFailure == null)
+                queue.refreshDirectoryListing();
+            range = enumerateExistingCycles0();
+        } catch (RuntimeException refreshedFailure) {
+            //! malformedPhysicalRollNameFailsNormalisationWithoutAdvancingCursor requires parsing
+            //! or enumeration failure to retain its cause after the one permitted refresh. A
+            //! fabricated endpoint set could certify completion while omitting touched history.
+            if (initialFailure != null)
+                refreshedFailure.addSuppressed(initialFailure);
+            throw new IllegalStateException("Cannot enumerate physical roll generations after refresh: queue="
+                    + queue.fileAbsolutePath(), refreshedFailure);
+        }
+        requireConsistentRefreshedRange(initiallyObservedPublishedBounds, range,
+                queue.fileAbsolutePath(), initialFailure);
+        return range;
+    }
+
+    private ExistingCycles enumerateExistingCycles0() {
+        //! exactEofRecoveryAtMaximumCycleIsRejectedBeforeMutation and
+        //! CycleOverflowTest#maximumUInt31CycleIsNotTreatedAsEmpty require physical enumeration to use semantic
+        //! publication state. The public firstCycle() maps an empty Queue to Integer.MAX_VALUE and cannot distinguish
+        //! that sentinel from the last valid UInt31 cycle.
+        final int first = queue.firstPublishedCycleWithoutRefresh();
+        if (first == UNSET_CONTEXT)
+            return ExistingCycles.empty();
+        final int last = queue.lastPublishedCycle();
+        try {
+            return new ExistingCycles(first, last, queue.listFreshPhysicalCycles());
+        } catch (DateTimeException incompatibleRollFilename) {
+            //! malformedPhysicalRollNameFailsNormalisationWithoutAdvancingCursor and
+            //! nonCanonicalWeeklyRollFailsNormalisationWithoutAdvancingCursor require even a single-file parse or
+            //! canonical-name failure to abort. Treating first == last as proof fabricates a generation that was
+            //! never validated and can advance the completion cursor falsely.
+            throw new IllegalStateException("Cannot enumerate all roll cycles with the persisted roll format: queue="
+                    + queue.fileAbsolutePath() + ", first=" + first + ", last=" + last,
+                    incompatibleRollFilename);
+        }
+    }
+
+    static void requireConsistentRefreshedRange(boolean initiallyObservedPublishedBounds,
+                                                ExistingCycles range,
+                                                String queuePath,
+                                                RuntimeException initialFailure) {
+        //! refreshedEmptyPhysicalRangeFailsClosed requires a nonempty initial observation that
+        //! disappears during refresh to fail without publishing completion. The original failure
+        //! remains attached so callers can distinguish stale bounds from malformed names.
+        if (range.hasBothBoundaries()
+                && !(initiallyObservedPublishedBounds && range.isEmpty()))
+            return;
+        final IllegalStateException failure = new IllegalStateException(
+                "Directory bounds remained inconsistent after refresh: queue=" + queuePath
+                        + ", first=" + range.first + ", last=" + range.last
+                        + ", observedCycles=" + range.cycles);
+        if (initialFailure != null)
+            failure.addSuppressed(initialFailure);
+        throw failure;
+    }
+
+    static final class ExistingCycles {
+        private final int first;
+        private final int last;
+        private final NavigableSet<Long> cycles;
+
+        ExistingCycles(int first, int last, NavigableSet<Long> cycles) {
+            this.first = first;
+            this.last = last;
+            this.cycles = cycles;
+        }
+
+        private static ExistingCycles empty() {
+            return new ExistingCycles(UNSET_CONTEXT, UNSET_CONTEXT, new TreeSet<>());
+        }
+
+        private boolean hasBothBoundaries() {
+            return isEmpty()
+                    || (!cycles.isEmpty() && cycles.first() == first && cycles.last() == last);
+        }
+
+        private boolean isEmpty() {
+            return first == UNSET_CONTEXT;
+        }
+    }
+
+    private void recordBackfillNormalisation(final int recoveredCycle) {
+        //! ordinaryAppenderRollsForwardAfterHistoricalIndexedRecovery proves that lowering the completion cursor for
+        //! an exact historical write must not lower the ordinary destination; the shared maximum continues to choose
+        //! the live roll while a later completion can still reseal the recovered history.
+        // Lower the shared cursor even when clock rollback makes this the active high-water cycle.
+        // normaliseEOFs0() excludes that active roll; retaining the lower bound lets a later
+        // completion seal it after a newer roll is published.
+        queue.tableStoreAcquire(NORMALISED_EOFS_TO_TABLESTORE_KEY, recoveredCycle)
+                .setMinValue(recoveredCycle);
     }
 
     /**
@@ -684,6 +901,12 @@ class StoreAppender extends AbstractCloseable
     private void setWireIfNull(final int cycle, WireStoreSupplier.CreateStrategy createStrategy) {
         //! unusedAppenderDoesNotCreateDeletedPublishedMaximum requires a caller-selected acquisition strategy: the
         //! previous CREATE-only helper would recreate an absent generation already published in Queue metadata.
+        //! stalledAppenderDoesNotRecreateDeletedPublishedMaximum and
+        //! unusedAppenderDoesNotCreateDeletedPublishedMaximum require an existing-only target to
+        //! be rejected before EOF normalisation can reinterpret its stale physical bounds.
+        if (createStrategy == WireStoreSupplier.CreateStrategy.REINITIALIZE_EXISTING
+                && !queue.cycleFileExists(cycle))
+            throw missingPublishedCycle(cycle);
         normaliseEOFs0(cycle);
 
         setCycle2(cycle, createStrategy);
@@ -746,6 +969,11 @@ class StoreAppender extends AbstractCloseable
                 + " disappeared while Queue metadata remains");
     }
 
+    private IllegalStateException missingPhysicalCycle(int missingCycle) {
+        return new IllegalStateException("Roll generation disappeared while normalising EOF: queue="
+                + queue.fileAbsolutePath() + ", cycle=" + missingCycle);
+    }
+
     /**
      * Writes a header for the current wire, ensuring the correct position and header number
      * is set for the next write operation.
@@ -754,11 +982,25 @@ class StoreAppender extends AbstractCloseable
      * @return the position of the written header
      */
     private long writeHeader(final long safeLength) {
+        //! canBackfillPreviousCycleAfterEOF and exactWriteReplacesAnIncompleteRequestedEntryWithAWarning require
+        //! exact recovery to inspect the next physical header before Wire opens or overwrites it. Ordinary writes
+        //! still call this combined helper; splitting positioning from enterHeader changes no ordinary semantics.
+        positionForNextHeader();
+        return wire.enterHeader(safeLength);
+    }
+
+    /**
+     * Positions at the next physical header without opening it. Exact recovery must inspect that
+     * header before deciding whether it may replace EOF or an incomplete record.
+     */
+    private void positionForNextHeader() {
+        //! exactBackfillFindsEofAfterSecondaryIndexMetadata,
+        //! exactBackfillFindsEofAfterTrailingUserMetadata and exactBackfillFindsEofInEmptySealedCycle require the
+        //! position to be derived from the published record and then scanned across non-indexed metadata.
         Bytes<?> bytes = wire.bytes();
         // writePosition points at the last record in the queue, so we can just skip it and we're ready for write
-        long pos = positionOfHeader;
         long lastPos = store.writePosition();
-        if (pos < lastPos) {
+        if (positionOfHeader < lastPos) {
             // queue moved since we last touched it - recalculate header number
 
             try {
@@ -767,11 +1009,116 @@ class StoreAppender extends AbstractCloseable
                 Jvm.warn().on(getClass(), "Couldn't find last sequence", ex);
             }
         }
-        int header = bytes.readVolatileInt(lastPos);
+        final int header = bytes.readVolatileInt(lastPos);
         assert header != NOT_INITIALIZED;
-        lastPos += lengthOf(bytes.readVolatileInt(lastPos)) + SPB_HEADER_SIZE;
+        lastPos += lengthOf(header) + SPB_HEADER_SIZE;
         bytes.writePosition(lastPos);
-        return wire.enterHeader(safeLength);
+    }
+
+    /**
+     * Inspects the requested index, skipping metadata because it does not consume an index.
+     * Opens the requested slot for exact recovery. EOF is deliberately left open so a CQE backfill
+     * can append the rest of that cycle without reopening and warning for every entry; the caller
+     * must invoke {@link #normaliseEOFs()} before publishing backfill completion.
+     */
+    private void prepareExactIndexRecovery(final long recoveryIndex) {
+        assert writeLock.locked();
+
+        final int recoveryCycle = queue.rollCycle().toCycle(recoveryIndex);
+        final Bytes<?> bytes = wire.bytes();
+        positionForNextHeader();
+        long recoveryPosition = bytes.writePosition();
+        for (; ; ) {
+            // Exact-index recovery is rejected for legacy unpadded stores before this method.
+            recoveryPosition += BytesUtil.padOffset(recoveryPosition);
+            final int header = bytes.readVolatileInt(recoveryPosition);
+            if (header == NOT_INITIALIZED) {
+                //! exactWriteInitializesUnusedRequestedEntryWithoutWarning is integration-preservation evidence that
+                //! an unused exact-next slot opens without a recovery warning while still entering the completion
+                //! range; the accepted base already writes an unused slot, but does not record that obligation.
+                recordBackfillNormalisation(recoveryCycle);
+                bytes.writePosition(recoveryPosition);
+                return;
+            }
+            if (header == END_OF_DATA) {
+                //! exactEofRecoveryAtMaximumCycleIsRejectedBeforeMutation fails if exact recovery opens the final
+                //! UInt31 roll. There is no successor which can make that roll historical, so completion's active
+                //! cycle exclusion cannot safely reseal it. The read-only preflight normally rejects first; this
+                //! check remains as fail-closed protection against a non-cooperating change after that inspection.
+                if (recoveryCycle == Integer.MAX_VALUE)
+                    throw maximumCycleRecoveryFailure(recoveryIndex);
+                //! canBackfillPreviousCycleAfterEOF requires only the observed EOF word to be reopened, with the
+                //! touched cycle recorded before mutation so completion can reseal it after a later failure.
+                recordBackfillNormalisation(recoveryCycle);
+                bytes.writePosition(recoveryPosition);
+                replaceEndOfDataMarkerForRecovery(bytes, recoveryPosition);
+                warnExactIndexRecovery("reopened end-of-data", recoveryIndex,
+                        recoveryPosition, header);
+                return;
+            }
+            if ((header & NOT_COMPLETE) != 0) {
+                //! exactWriteReplacesAnIncompleteRequestedEntryAfterQueueRestart requires the exact-next incomplete
+                //! header to be cleared in place and warned once; it is neither a published duplicate nor corruption.
+                recordBackfillNormalisation(recoveryCycle);
+                bytes.writePosition(recoveryPosition);
+                warnExactIndexRecovery("replaced incomplete header", recoveryIndex,
+                        recoveryPosition, header);
+                // Clear the failed header here so Wire.enterHeader does not emit a second warning.
+                bytes.writeVolatileInt(recoveryPosition, NOT_INITIALIZED);
+                return;
+            }
+            if (isReadyMetaData(header)) {
+                //! exactBackfillCanAddASecondaryIndexBeforeResealing and
+                //! exactBackfillFindsEofAfterTrailingUserMetadata require ready metadata to consume physical bytes
+                //! without consuming the requested Queue index.
+                recoveryPosition += SPB_HEADER_SIZE + lengthOf(header);
+                continue;
+            }
+            if (isReadyData(header)) {
+                //! The exactIndexStateWithoutMutation() preflight and capped publishUnpublishedRecords() consume
+                //! every ready record needed by a valid request while the shared write lock is held, so no
+                //! cooperative test can reach this branch. Retain the failure for mapped-file corruption or a
+                //! writer which bypasses that lock; treating the record as a free slot would overwrite ready data.
+                // publishUnpublishedRecords() runs before this scan while the write lock is
+                // held, so ready data beyond the published position indicates corruption.
+                throw new IllegalStateException("Ready data record after the published write position at "
+                        + recoveryPosition + " in " + queue.fileAbsolutePath());
+            }
+            //! Cooperative writers cannot produce another terminal word while the Queue write lock is held, so no
+            //! current test discriminates this residual corruption guard. Treating an unknown ready/reserved word as
+            //! a free slot would overwrite physical state whose Queue-index meaning has not been established.
+            throw new IllegalStateException("Unexpected recovery header 0x" + Integer.toHexString(header));
+        }
+    }
+
+    private IllegalStateException maximumCycleRecoveryFailure(final long recoveryIndex) {
+        return new IllegalStateException("Cannot reopen end-of-data in the final UInt31 cycle for exact-index "
+                + "recovery: queue=" + queue.fileAbsolutePath()
+                + ", index=0x" + Long.toHexString(recoveryIndex));
+    }
+
+    private void warnExactIndexRecovery(final String action, final long recoveryIndex,
+                                        final long recoveryPosition, final int header) {
+        final int recoveryCycle = queue.rollCycle().toCycle(recoveryIndex);
+        Jvm.warn().on(getClass(), "Exact-index recovery " + action + ": queue="
+                + queue.fileAbsolutePath()
+                + ", cycle=" + recoveryCycle
+                + ", index=0x" + Long.toHexString(recoveryIndex)
+                + ", position=" + recoveryPosition
+                + ", header=0x" + Integer.toHexString(header));
+    }
+
+    /**
+     * Performs the single atomic mutation that opens a sealed roll for exact-index recovery.
+     * Package visibility permits the failed-CAS invariant to be tested without reflection.
+     */
+    static void replaceEndOfDataMarkerForRecovery(Bytes<?> bytes, long recoveryPosition) {
+        //! StoreAppenderTest#exactRecoveryFailsIfTheEofMarkerChangesBeforeCas directly discriminates the expected-word
+        //! compare-and-swap. An unconditional write could reopen a header changed after inspection and overwrite a
+        //! concurrent or corrupt terminal state instead of failing closed.
+        if (!bytes.compareAndSwapInt(recoveryPosition, END_OF_DATA, NOT_INITIALIZED))
+            throw new IllegalStateException("End-of-data changed while starting exact-index recovery at "
+                    + recoveryPosition);
     }
 
     private void advanceOrdinaryAppendCycle() {
@@ -849,6 +1196,11 @@ class StoreAppender extends AbstractCloseable
 
         try {
             long pos = positionOfHeader;
+            //! eosOnlyRestartPreservesReadySequenceZeroBeforeOrdinaryAppend proves zero can also mean a ready first
+            //! record whose write position was not published. Let lastSequenceNumber() perform its physical scan
+            //! instead of asserting against the empty-store sentinel.
+            if (pos == 0)
+                return true;
 
             long seq1 = queue.rollCycle().toSequenceNumber(wire.headerNumber() + 1) - 1;
             long seq2 = store.sequenceForPosition(this, pos, true);
@@ -905,10 +1257,9 @@ class StoreAppender extends AbstractCloseable
             Bytes<?> wireBytes = wire.bytes();
             wireBytes.write(bytes);
             wire.updateHeader(positionOfHeader, false, 0);
-            lastIndex(wire.headerNumber());
-            lastPosition = positionOfHeader;
-            store.writePosition(positionOfHeader);
-            writeIndexForPosition(lastIndex, positionOfHeader);
+            //! writeBytesAndIndexFiveTimesTest and testIndexQueue require ordinary byte appends to publish local
+            //! position, mapped writePosition and sparse index through the same ordering used by exact recovery.
+            recordCommittedData(wire.headerNumber(), positionOfHeader);
         } catch (StreamCorruptedException e) {
             throw new AssertionError(e);
         } finally {
@@ -946,6 +1297,14 @@ class StoreAppender extends AbstractCloseable
         }
     }
 
+    void ensureEndOfData(final String failureMessage) {
+        //! eofRestorationFailureIsNotReportedAsSuccess fails if a false writeEOF result is accepted without proving
+        //! that another writer installed EOF. Completion must either observe that seal or propagate failure.
+        if (store.writeEOF(wire, timeoutMS()) || cycleHasEOF())
+            return;
+        throw new IllegalStateException(failureMessage);
+    }
+
     /**
      * Appends bytes without write lock. Should only be used if write lock is acquired externally. Never use without write locking as it WILL corrupt
      * the queue file and cause data loss.
@@ -957,7 +1316,65 @@ class StoreAppender extends AbstractCloseable
     protected void writeBytesInternal(final long index, @NotNull final BytesStore<?, ?> bytes) {
         checkAppendLock(true);
 
-        final int cycle = queue.rollCycle().toCycle(index);
+        //! exactRecoveryRejectsUnsupportedSequenceBeforeCreatingRoll and
+        //! rejectedExactGapIntoExistingLaterRollDoesNotSealTheCurrentRoll require capacity and gap classification
+        //! before roll selection can create a file, seal the current roll or publish a cycle.
+        //! ordinaryAppenderContinuesInCurrentCycleAfterIndexedWriteToUnsealedRoll is integration-preservation
+        //! evidence that a valid exact write does not disturb the ordinary destination; the accepted base also
+        //! keeps that destination.
+        final RollCycle rollCycle = queue.rollCycle();
+        final int cycle = rollCycle.toCycle(index);
+        final long sequenceNumber = rollCycle.toSequenceNumber(index);
+        if (sequenceNumber >= rollCycle.maxMessagesPerCycle())
+            throw new IllegalArgumentException("Exact-index sequence " + sequenceNumber
+                    + " is outside maxMessagesPerCycle=" + rollCycle.maxMessagesPerCycle()
+                    + " for index=0x" + Long.toHexString(index));
+
+        //! sameCycleGapDoesNotPublishReadyCrashRecord and
+        //! publishedDuplicateDoesNotAdoptLaterReadyCrashRecord require every exact request, including one for the
+        //! appender's current roll, to classify published and physical state through a read-only view first. Deferring
+        //! this until after resetPosition() and crash-record adoption makes a rejected gap or old duplicate publish
+        //! unrelated ready data.
+        final ExactIndexState exactIndexState = exactIndexStateWithoutMutation(
+                cycle, sequenceNumber, bytes);
+        //! exactWriteDoesNotRecreateDeletedPublishedMaximum and
+        //! exactWriteRejectsAbsentCycleWithinPublishedRange require absence to remain distinct from an existing
+        //! empty store. The published maximum is authoritative, and an absent interior generation is ambiguous
+        //! between a deliberate sparse gap and unsupported deletion; only targets outside the retained bounds may
+        //! be created without persisted per-cycle provenance.
+        if (!exactIndexState.targetExists)
+            requireAbsentExactTargetCanBeCreated(cycle);
+        //! publishedDuplicatePayloadsAreComparedWithoutMutation and CreateAtIndexTest#testWriteBytesWithIndex require
+        //! a published duplicate to be compared before returning: equal content is debug-only, while different
+        //! content warns with both hex dumps and is ignored. Comparing after roll selection could seal or move the
+        //! source appender merely to diagnose an already-applied index.
+        //! StoreAppenderInternalWriteBytesTest#internalWriteBytesShouldBeIdempotentUnderConcurrentUpdates,
+        //! #internalWriteBytesShouldBeIdempotent and WriteBytesIndexTest#writeMultipleAppenders retain the broader
+        //! independent-Queue, per-entry reopen and live-tailer compatibility coverage.
+        //! independentQueueExactWritersReplayAcrossCyclesAndRestart adds deterministic sparse-cycle completion and
+        //! full Queue-object restart coverage. Together with CreateAtIndexTest#testWriteBytesWithIndex, these tests
+        //! consolidate the narrower deleted cannotOverwriteExistingEntries_DifferentQueueInstance and
+        //! writeBytesAndIndexFiveTimesWithOverwriteTest cases. They are integration-preservation tests rather than
+        //! accepted-base discriminators. In every case the first published record remains authoritative.
+        if (exactIndexState.hasPublishedIndex()
+                && index <= exactIndexState.publishedIndex(rollCycle, cycle))
+            return;
+
+        final long nextIndexInTarget = exactIndexState.nextPhysicalIndex(rollCycle, cycle);
+        //! InternalAppenderWriteBytesTest#cannotWriteToNonZeroIndexOfNewRollCycleWithoutMutation and
+        //! rejectedExactGapIntoExistingLaterRollDoesNotSealTheCurrentRoll require the physical next-index comparison
+        //! beside the rejection itself and before roll selection. Deferring it could create the target or seal and
+        //! move the source appender even though the requested sequence leaves a gap.
+        if (index > nextIndexInTarget)
+            throw new IllegalIndexException(index, nextIndexInTarget - 1);
+
+        //! exactEofRecoveryAtMaximumCycleIsRejectedBeforeMutation requires the terminal EOF decision to be made
+        //! through the read-only preflight. Reaching prepareExactIndexRecovery() first could move this appender and
+        //! lower the shared completion cursor even though the final UInt31 roll can never become historical.
+        if (cycle == Integer.MAX_VALUE
+                && index == nextIndexInTarget
+                && exactIndexState.terminalHeader == END_OF_DATA)
+            throw maximumCycleRecoveryFailure(index);
 
         if (wire == null)
             setWireIfNull(cycle);
@@ -966,22 +1383,37 @@ class StoreAppender extends AbstractCloseable
         if (this.cycle != cycle)
             rollCycleTo(cycle, this.cycle > cycle);
 
-        // in case our cached headerNumber is incorrect.
-        resetPosition();
+        requirePaddedExactStore(store, cycle);
+
+        //! exactPreflightRejectsStaleAliasingEncodedSequence requires mutation to retain the full-position result
+        //! from preflight. Calling the general resetPosition() here would re-read the lossy paired sequence and could
+        //! reject a valid exact-next request after the read-only classification had already proved its boundary.
+        resetPosition(exactIndexState.lastPublishedSequence);
+        final long adoptedIndex = publishUnpublishedRecords(cycle, index, exactIndexState);
+        //! exactWriteAdoptsReadyFirstRecordRetryBeforeWritingNext and
+        //! restartPublishesReadyRecordLeftBeyondWritePosition require ready crash records to be published before
+        //! opening an exact-next slot. Capping publication at the requested index prevents an older ready duplicate
+        //! from adopting unrelated later records; gap and published-duplicate classification already completed
+        //! without mutation.
+        if (index == adoptedIndex)
+            return;
 
         long headerNumber = wire.headerNumber();
 
-        boolean isNextIndex = index == headerNumber + 1;
-        if (!isNextIndex) {
-            if (index > headerNumber + 1)
-                throw new IllegalIndexException(index, headerNumber);
-
-            // this can happen when using queue replication when we are back filling from a number of sinks at them same time
-            // its normal behaviour in the is use case so should not be a WARN
-            if (Jvm.isDebugEnabled(getClass()))
-                Jvm.debug().on(getClass(), "Trying to overwrite index " + Long.toHexString(index) + " which is before the end of the queue");
+        //! The read-only preflight and this recheck execute under the shared Queue write lock, so a cooperative test
+        //! cannot change headerNumber between them. Retain the bounds for a non-cooperating mapped writer: accepting a
+        //! later header would skip a gap, while overwriting an earlier one would violate first-writer authority.
+        if (index > headerNumber + 1)
+            throw new IllegalIndexException(index, headerNumber);
+        //! The shared lock makes publication after preflight unreachable for cooperating writers, so no deterministic
+        //! Queue test discriminates this fallback. A writer bypassing that lock can still publish first; compare its
+        //! authoritative record and ignore the supplied duplicate rather than overwrite it or throw.
+        if (index <= headerNumber) {
+            comparePublishedEntry(store, wire, cycle, sequenceNumber, bytes);
             return;
         }
+
+        prepareExactIndexRecovery(index);
 
         writeBytesInternal(bytes, false);
         //assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
@@ -991,6 +1423,292 @@ class StoreAppender extends AbstractCloseable
         if (!isIndex) {
             throw new IllegalStateException("index: " + index + ", header: " + headerNumber);
         }
+
+    }
+
+    /**
+     * Publishes ready data left beyond the store write position when a writer stopped between
+     * making a header ready and {@link #recordCommittedData(long, long)}. Publication stops at the
+     * requested ready record, or at the final predecessor of an exact-next request, so replaying an
+     * older index cannot publish unrelated later data.
+     */
+    private long publishUnpublishedRecords(final int cycle,
+                                           final long requestedIndex,
+                                           final ExactIndexState exactIndexState) {
+        //! exactWriteAdoptsReadyFirstRecordRetryBeforeWritingNext and
+        //! restartPublishesReadyRecordLeftBeyondWritePosition cover interruptions where a ready record precedes
+        //! writePosition publication. Publish only through the requested ready record, or through all contiguous
+        //! predecessors of an exact-next request. Publishing every physical record would let an old duplicate adopt
+        //! unrelated later data. General sparse-index repair remains out of scope.
+        final RollCycle rollCycle = queue.rollCycle();
+        final long requestedSequence = rollCycle.toSequenceNumber(requestedIndex);
+        final long sequenceToPublish = Math.min(requestedSequence, exactIndexState.lastPhysicalSequence);
+        if (sequenceToPublish <= exactIndexState.lastPublishedSequence)
+            return Long.MIN_VALUE;
+
+        final Bytes<?> bytes = wire.bytes();
+        final long publishedPosition = store.writePosition();
+        //! The Queue write lock prevents a cooperative discriminator for an action-time publication change. Retain
+        //! this comparison for a non-cooperating mapped writer; indexing from a stale position could publish the wrong
+        //! physical record after preflight had classified another boundary.
+        if (publishedPosition != exactIndexState.publishedPosition)
+            throw new IllegalStateException("Exact-index target changed after preflight: queue="
+                    + queue.fileAbsolutePath() + ", cycle=" + cycle);
+        long position = publishedPosition
+                + lengthOf(bytes.readVolatileInt(publishedPosition)) + SPB_HEADER_SIZE;
+        long lastReadyDataPosition = -1;
+        long readySequence = exactIndexState.lastPublishedSequence;
+        for (; ; ) {
+            position += BytesUtil.padOffset(position);
+            final int header = bytes.readVolatileInt(position);
+            if (isReadyData(header)) {
+                lastReadyDataPosition = position;
+                if (++readySequence == sequenceToPublish)
+                    break;
+            } else if (!isReadyMetaData(header)) {
+                break;
+            }
+            position += SPB_HEADER_SIZE + lengthOf(header);
+        }
+        //! The same lock prevents a cooperative test from changing the scanned ready-record prefix. Fail closed if a
+        //! non-cooperating writer does so: publishing a shorter or different prefix would assign the requested Queue
+        //! sequence to physical data that preflight did not validate.
+        if (lastReadyDataPosition < 0 || readySequence != sequenceToPublish)
+            throw new IllegalStateException("Exact-index physical state changed after preflight: queue="
+                    + queue.fileAbsolutePath() + ", cycle=" + cycle);
+
+        final long lastIndex = rollCycle.toIndex(cycle, readySequence);
+        try {
+            recordBackfillNormalisation(cycle);
+            wire.headerNumber(lastIndex);
+            recordCommittedData(lastIndex, lastReadyDataPosition);
+            return lastIndex;
+        } catch (StreamCorruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Reads the publication boundary, contiguous physical records and terminal header through a
+     * private read-only view, so every duplicate or gap can be classified before this appender
+     * rolls, seals or publishes anything.
+     */
+    private ExactIndexState exactIndexStateWithoutMutation(final int cycle,
+                                                           final long requestedSequence,
+                                                           @NotNull final BytesStore<?, ?> suppliedBytes) {
+        final RollCycle rollCycle = queue.rollCycle();
+        try (SingleChronicleQueueStore target = queue.storeForCycle(cycle, queue.epoch(), false, null)) {
+            if (target == null)
+                return ExactIndexState.absent();
+            requirePaddedExactStore(target, cycle);
+            try (MappedBytes bytes = target.bytes()) {
+                final long publishedPosition = target.writePosition();
+                final Wire preflightWire = queue.wireType().apply(bytes);
+                preflightWire.usePadding(target.dataVersion() > 0);
+                final long lastPublishedSequence = target.lastPublishedSequenceNumber(preflightWire);
+                //! Supported publication cannot produce an out-of-capacity sequence, so no cooperative test reaches
+                //! this guard. Validate the persisted scan result before composing a Queue index; accepting a corrupt
+                //! negative or oversized value could alias the exact-next boundary and authorize the wrong slot.
+                if (lastPublishedSequence < -1
+                        || lastPublishedSequence >= rollCycle.maxMessagesPerCycle())
+                    throw new IllegalStateException("Invalid published sequence " + lastPublishedSequence
+                            + " in cycle " + cycle + " for queue=" + queue.fileAbsolutePath());
+
+                if (requestedSequence <= lastPublishedSequence) {
+                    comparePublishedEntry(target, preflightWire, cycle, requestedSequence, suppliedBytes);
+                    return new ExactIndexState(true, publishedPosition, lastPublishedSequence,
+                            lastPublishedSequence, NOT_INITIALIZED);
+                }
+
+                long lastPhysicalSequence = lastPublishedSequence;
+                long position = publishedPosition
+                        + lengthOf(bytes.readVolatileInt(publishedPosition)) + SPB_HEADER_SIZE;
+                for (; ; ) {
+                    position += BytesUtil.padOffset(position);
+                    final int header = bytes.readVolatileInt(position);
+                    if (isReadyData(header)) {
+                        //! No supported writer can place more ready records than maxMessagesPerCycle, so there is no
+                        //! cooperative discriminator. Stop before incrementing beyond the declared sequence domain;
+                        //! otherwise corrupt physical data could wrap or authorize an unsupported exact index.
+                        if (++lastPhysicalSequence >= rollCycle.maxMessagesPerCycle())
+                            throw new IllegalStateException("Physical sequence exceeds maxMessagesPerCycle in cycle "
+                                    + cycle + " for queue=" + queue.fileAbsolutePath());
+                    } else if (!isReadyMetaData(header)) {
+                        return new ExactIndexState(true, publishedPosition, lastPublishedSequence,
+                                lastPhysicalSequence, header);
+                    }
+                    position += SPB_HEADER_SIZE + lengthOf(header);
+                }
+            }
+        }
+    }
+
+    private void comparePublishedEntry(@NotNull final SingleChronicleQueueStore target,
+                                       @NotNull final Wire comparisonWire,
+                                       final int cycle,
+                                       final long sequenceNumber,
+                                       @NotNull final BytesStore<?, ?> suppliedBytes) {
+        final Bytes<?> existingBytes = comparisonWire.bytes();
+        final long savedReadPosition = existingBytes.readPosition();
+        final long savedReadLimit = existingBytes.readLimit();
+        final long savedWritePosition = existingBytes.writePosition();
+        try {
+            final ExcerptContext comparisonContext = new WireExcerptContext(comparisonWire, timeoutMS());
+            final ScanResult scanResult = target.moveToIndexForRead(comparisonContext, sequenceNumber);
+            if (scanResult != ScanResult.FOUND) {
+                warnUnableToComparePublishedEntry(cycle, sequenceNumber, suppliedBytes, scanResult);
+                return;
+            }
+            comparePublishedEntry(cycle, sequenceNumber, existingBytes, suppliedBytes);
+
+        } finally {
+            existingBytes.readPosition(savedReadPosition);
+            existingBytes.readLimit(savedReadLimit);
+            existingBytes.writePosition(savedWritePosition);
+        }
+    }
+
+    private void comparePublishedEntry(final int cycle,
+                                       final long sequenceNumber,
+                                       @NotNull final Bytes<?> existingBytes,
+                                       @NotNull final BytesStore<?, ?> suppliedBytes) {
+        final int header = existingBytes.readVolatileInt();
+        assert isReadyData(header);
+        final int existingLength = lengthOf(header);
+        final long suppliedLength = suppliedBytes.readRemaining();
+        final long index = queue.rollCycle().toIndex(cycle, sequenceNumber);
+        //! InternalAppenderWriteBytesTest#publishedDuplicatePayloadsAreComparedWithoutMutation distinguishes both
+        //! outcomes. Equal content is debug-only (and therefore silent when debug is disabled); different content
+        //! warns with both hex dumps, but neither path throws or overwrites the authoritative published record.
+        if (existingLength == suppliedLength
+                && existingBytes.equalBytes(suppliedBytes, existingLength)) {
+            if (Jvm.isDebugEnabled(getClass()))
+                Jvm.debug().on(getClass(), "Exact-index duplicate matches published content and was ignored: queue="
+                        + queue.fileAbsolutePath() + ", cycle=" + cycle + ", index=0x" + Long.toHexString(index)
+                        + ", length=" + existingLength);
+            return;
+        }
+
+        Jvm.warn().on(getClass(), "Exact-index duplicate differs from published content and was ignored: queue="
+                + queue.fileAbsolutePath() + ", cycle=" + cycle + ", index=0x" + Long.toHexString(index)
+                + ", existingLength=" + existingLength + ", suppliedLength=" + suppliedLength
+                + "\nexisting:\n" + existingBytes.toHexString(existingLength)
+                + "\nsupplied:\n" + toHexDump(suppliedBytes, suppliedLength));
+    }
+
+    private void warnUnableToComparePublishedEntry(final int cycle,
+                                                   final long sequenceNumber,
+                                                   @NotNull final BytesStore<?, ?> suppliedBytes,
+                                                   @NotNull final ScanResult reason) {
+        //! A cooperative Queue cannot publish an index which its own read path cannot find, so no deterministic valid
+        //! input reaches this branch. Preserve the non-throwing duplicate contract while warning that corruption or a
+        //! non-cooperating writer prevented the requested comparison; the supplied payload remains ignored.
+        final long index = queue.rollCycle().toIndex(cycle, sequenceNumber);
+        Jvm.warn().on(getClass(), "Exact-index duplicate could not be compared and was ignored: queue="
+                + queue.fileAbsolutePath() + ", cycle=" + cycle + ", index=0x" + Long.toHexString(index)
+                + ", suppliedLength=" + suppliedBytes.readRemaining() + ", reason=" + reason
+                + "\nsupplied:\n" + toHexDump(suppliedBytes, suppliedBytes.readRemaining()));
+    }
+
+    private static String toHexDump(@NotNull final BytesStore<?, ?> bytesStore,
+                                    final long length) {
+        if (bytesStore instanceof Bytes)
+            return ((Bytes<?>) bytesStore).toHexString(length);
+
+        final Bytes<?> bytes = bytesStore.bytesForRead();
+        try {
+            bytes.readPosition(bytesStore.readPosition());
+            return bytes.toHexString(length);
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    private static final class WireExcerptContext implements ExcerptContext {
+        @NotNull
+        private final Wire wire;
+        private final long timeoutMS;
+
+        private WireExcerptContext(@NotNull final Wire wire, final long timeoutMS) {
+            this.wire = wire;
+            this.timeoutMS = timeoutMS;
+        }
+
+        @Override
+        public Wire wire() {
+            return wire;
+        }
+
+        @Override
+        public Wire wireForIndex() {
+            return wire;
+        }
+
+        @Override
+        public long timeoutMS() {
+            return timeoutMS;
+        }
+    }
+
+    private static final class ExactIndexState {
+        private final boolean targetExists;
+        private final long publishedPosition;
+        private final long lastPublishedSequence;
+        private final long lastPhysicalSequence;
+        private final int terminalHeader;
+
+        private ExactIndexState(boolean targetExists,
+                                long publishedPosition,
+                                long lastPublishedSequence,
+                                long lastPhysicalSequence,
+                                int terminalHeader) {
+            this.targetExists = targetExists;
+            this.publishedPosition = publishedPosition;
+            this.lastPublishedSequence = lastPublishedSequence;
+            this.lastPhysicalSequence = lastPhysicalSequence;
+            this.terminalHeader = terminalHeader;
+        }
+
+        private static ExactIndexState absent() {
+            return new ExactIndexState(false, 0, -1, -1, NOT_INITIALIZED);
+        }
+
+        private boolean hasPublishedIndex() {
+            return lastPublishedSequence >= 0;
+        }
+
+        private long publishedIndex(RollCycle rollCycle, int cycle) {
+            return rollCycle.toIndex(cycle, lastPublishedSequence);
+        }
+
+        private long nextPhysicalIndex(RollCycle rollCycle, int cycle) {
+            return rollCycle.toIndex(cycle, lastPhysicalSequence + 1);
+        }
+    }
+
+    private void requireAbsentExactTargetCanBeCreated(final int targetCycle) {
+        final int publishedLast = queue.lastPublishedCycle();
+        if (publishedLast == UNSET_CONTEXT)
+            return;
+        final int publishedFirst = queue.firstPublishedCycleWithoutRefresh();
+        if (targetCycle < publishedFirst || targetCycle > publishedLast)
+            return;
+        if (targetCycle == publishedLast)
+            throw missingPublishedCycle(targetCycle);
+        throw new IllegalStateException("Cannot create absent exact-index cycle " + targetCycle
+                + " within retained published range " + publishedFirst + ".." + publishedLast
+                + " for queue=" + queue.fileAbsolutePath());
+    }
+
+    private void requirePaddedExactStore(final SingleChronicleQueueStore target, final int cycle) {
+        //! exactRecoveryRejectsLegacyUnpaddedStore and
+        //! crossCycleExactRecoveryRejectsLegacyTargetBeforeRollover require exact-index recovery
+        //! to reject the target's unpadded physical format before roll selection or mutation.
+        //! They do not exercise SingleChronicleQueueStore's replacement-Wire EOF fallback.
+        if (target.dataVersion() == 0)
+            throw new UnsupportedOperationException("Exact-index recovery is not supported for "
+                    + "legacy unpadded queue stores: queue=" + queue.fileAbsolutePath()
+                    + ", cycle=" + cycle);
     }
 
     private void writeBytesInternal(@NotNull final BytesStore<?, ?> bytes, boolean metadata) {
@@ -998,9 +1716,10 @@ class StoreAppender extends AbstractCloseable
         try {
             int safeLength = (int) queue.overlapSize();
             assert count == 0 : "count=" + count;
-            //! InternalAppenderWriteBytesTest#cannotAppendToPreviousCycle requires an exact-index write to surface
-            //! EOF from its named physical destination. Passing false keeps the ordinary one-roll retry out of this
-            //! strict path; rolling forward would report success at an index the caller did not request.
+            //! canBackfillPreviousCycleAfterEOF and exactBackfillFindsEofInEmptySealedCycle require exact recovery to
+            //! handle the intended physical EOF before this call. Passing false keeps Q2's ordinary successor-cycle
+            //! retry out of the exact path; enabling it here would report success at an index the caller did not
+            //! request and canBackfillPreviousCycleAfterEOF would no longer remain in the recovered cycle.
             openContext(metadata, safeLength, false);
 
             try {
@@ -1155,6 +1874,16 @@ class StoreAppender extends AbstractCloseable
     void writeIndexForPosition(final long index, final long position) throws StreamCorruptedException {
         long sequenceNumber = queue.rollCycle().toSequenceNumber(index);
         store.setPositionForSequenceNumber(this, sequenceNumber, position);
+    }
+
+    private void recordCommittedData(final long index, final long position) throws StreamCorruptedException {
+        //! testIndexQueue and writeBytesAndIndexFiveTimesTest pin the common final state for ordinary, context and
+        //! exact writes. Keeping one helper prevents those paths publishing different subsets; the tests do not
+        //! independently stop between assignments or establish crash durability for this precise order.
+        lastPosition = position;
+        lastIndex(index);
+        store.writePosition(position);
+        writeIndexForPosition(index, position);
     }
 
     /**
@@ -1489,17 +2218,19 @@ class StoreAppender extends AbstractCloseable
                 throw e;
             }
 
-            lastPosition = positionOfHeader;
-
             if (!metaData) {
-                lastIndex(wire.headerNumber());
-                store.writePosition(positionOfHeader);
-                if (lastIndex != Long.MIN_VALUE) {
-                    writeIndexForPosition(lastIndex, positionOfHeader);
-                    if (queue.appenderListener != null) {
-                        callAppenderListener();
-                    }
+                //! writeBytesAndIndexFiveTimesTest exercises the context-close route as well as direct bytes. Reuse
+                //! recordCommittedData() for data only; metadata consumes physical space but must not publish a queue
+                //! index or writePosition as application data.
+                //! eosOnlyRestartPreservesReadySequenceZeroBeforeOrdinaryAppend also requires this path to publish
+                //! sequence zero: updateHeader() has made the data header ready and assigned its queue index, while a
+                //! lastIndex sentinel guard here would hide the first valid record from restart recovery.
+                recordCommittedData(wire.headerNumber(), positionOfHeader);
+                if (queue.appenderListener != null) {
+                    callAppenderListener();
                 }
+            } else {
+                lastPosition = positionOfHeader;
             }
         }
 

--- a/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ChronicleQueueIndexTest.java
@@ -80,8 +80,6 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
                 .build();
              InternalAppender appender = (InternalAppender) queue.createAppender()) {
 
-//            assertFalse(hasEOFAtEndOfFile(file1));
-
             writer2.accept(appender);
 
             // Simulate the end of the day i.e the queue closes the day rolls
@@ -96,7 +94,6 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
         try (ChronicleQueue queue123 = SingleChronicleQueueBuilder.builder()
                 .path(file).build()) {
             String dump = queue123.dump();
-            // System.out.println(dump);
             return dump.contains(" EOF") && dump.contains("--- !!not-ready-meta-data");
         }
     }
@@ -106,31 +103,36 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
 
         File file1 = getTmpDir();
         file1.deleteOnExit();
+        final SetTimeProvider time = new SetTimeProvider(1_000_000_000L);
+        final int firstCycle = RollCycles.DEFAULT.current(time, 0);
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.builder()
                 .path(file1)
                 .rollCycle(RollCycles.DEFAULT)
+                .timeProvider(time)
                 .build();
              InternalAppender appender = (InternalAppender) queue.createAppender()) {
 
             Bytes<byte[]> hello_world = Bytes.from("Hello World 1");
-            appender.writeBytes(RollCycles.DEFAULT.toIndex(18264, 0L), hello_world);
+            appender.writeBytes(RollCycles.DEFAULT.toIndex(firstCycle, 0L), hello_world);
             hello_world.releaseLast();
             hello_world = Bytes.from("Hello World 2");
-            appender.writeBytes(RollCycles.DEFAULT.toIndex(18264, 1L), hello_world);
+            appender.writeBytes(RollCycles.DEFAULT.toIndex(firstCycle, 1L), hello_world);
             hello_world.releaseLast();
 
             // Simulate the end of the day i.e the queue closes the day rolls
             // (note the change of index from 18264 to 18265)
         }
+        time.advanceMillis(RollCycles.DEFAULT.lengthInMillis());
         try (ChronicleQueue queue = SingleChronicleQueueBuilder.builder()
                 .path(file1)
                 .rollCycle(RollCycles.DEFAULT)
+                .timeProvider(time)
                 .build();
              InternalAppender appender = (InternalAppender) queue.createAppender()) {
 
             // add a message for the new day
             Bytes<byte[]> hello_world = Bytes.from("Hello World 3");
-            appender.writeBytes(RollCycles.DEFAULT.toIndex(18265, 0L), hello_world);
+            appender.writeBytes(RollCycles.DEFAULT.toIndex(firstCycle + 1, 0L), hello_world);
             hello_world.releaseLast();
 
             final ExcerptTailer tailer = queue.createTailer();
@@ -171,7 +173,6 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
             for (int j = 0; j < 8; j++) {
                 try (DocumentContext dc = appender.writingDocument()) {
                     dc.wire().write("hello").text(msg + (i++));
-                    // long indexWritten = dc.index();
                 }
                 stp.advanceMillis(1500);
             }
@@ -205,7 +206,6 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
             try (DocumentContext dc = tailer.readingDocument()) {
                 assertTrue(dc.isPresent());
                 String s5 = dc.wire().read("hello").text();
-                // System.out.println(s5);
                 assertEquals(msg + 4, s5);
             }
         }
@@ -251,8 +251,6 @@ public class ChronicleQueueIndexTest extends QueueTestCommon {
                 }
                 stp.advanceMillis(millis);
             }
-//            System.out.println(queue.dump());
-
             // read all (meta + data)
             List<String> allReads = readKeyed(queue, true);
             assertEquals(Arrays.asList(strings), allReads);

--- a/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/CreateAtIndexTest.java
@@ -18,9 +18,7 @@ import java.io.File;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.single;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 @RequiredForClient
 public class CreateAtIndexTest extends QueueTestCommon {
@@ -28,6 +26,7 @@ public class CreateAtIndexTest extends QueueTestCommon {
     @Test
     public void
     testWriteBytesWithIndex() {
+        ignoreException("Exact-index recovery reopened end-of-data");
         final Bytes<?> HELLO_WORLD = Bytes.from("hello world");
         File tmp = getTmpDir();
         try (ChronicleQueue queue = single(tmp).testBlockSize().rollCycle(TEST_DAILY).build();
@@ -41,37 +40,14 @@ public class CreateAtIndexTest extends QueueTestCommon {
                 .testBlockSize()
                 .build();
              InternalAppender appender = (InternalAppender) queue.createAppender()) {
+            final String before = queue.dump();
 
-            String before = queue.dump();
-            appender.writeBytes(0x421d00000000L, HELLO_WORLD);
-            String after = queue.dump();
-            // the appender's first write normalises EOFs, adding a normalisedEOFsTo record;
-            // assert that delta explicitly, then require the dumps to match once it is masked out
-            assertFalse(before.contains("normalisedEOFsTo"));
-            assertTrue(after.contains("normalisedEOFsTo"));
-            assertEquals(cleanDump(before), cleanDump(after));
+            expectException("Exact-index duplicate differs from published content and was ignored");
+            appender.writeBytes(0x421d00000000L, Bytes.from("ignored duplicate"));
+
+            assertEquals("a published duplicate must not mutate persisted Queue state",
+                    before, queue.dump());
         }
-
-/*
-        TODO FIX
-        if (Jvm.isAssertEnabled()) {
-            try (ChronicleQueue queue = single(tmp)
-                    .testBlockSize()
-                    .build()) {
-                InternalAppender appender = (InternalAppender) queue.acquireAppender();
-
-                String before = queue.dump();
-                try {
-                    appender.writeBytes(0x421d00000000L, Bytes.from("hellooooo world"));
-                    fail();
-                } catch (IllegalStateException e) {
-                    // expected
-                }
-                String after = queue.dump();
-                assertEquals(before, after);
-            }
-        }
-        */
 
         // try too far
         try (ChronicleQueue queue = single(tmp)
@@ -96,13 +72,6 @@ public class CreateAtIndexTest extends QueueTestCommon {
             IOTools.deleteDirWithFiles(tmp, 2);
         } catch (IORuntimeException ignored) {
         }
-    }
-
-    private static String cleanDump(String dump) {
-        return dump
-                .replaceAll("# \\d+ bytes remaining", "# NN bytes remaining")
-                .replaceAll("modCount: (\\d+)", "modCount: 00")
-                .replaceAll("# position: \\d+, header: \\d+\\R--- !!data #binary\\RnormalisedEOFsTo: \\d+\\R", "");
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
@@ -4,24 +4,32 @@
 package net.openhft.chronicle.queue;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesUtil;
+import net.openhft.chronicle.bytes.MappedBytes;
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.onoes.LogLevel;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.impl.single.*;
+import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.WireType;
-import net.openhft.chronicle.wire.WriteAfterEOFException;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static net.openhft.chronicle.queue.DirectoryUtils.tempDir;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_HOURLY;
+import static net.openhft.chronicle.wire.Wires.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -35,7 +43,7 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void canWriteAtEndOfLastExistingRollCycle() {
+    public void exactWriteInitializesUnusedRequestedEntryWithoutWarning() {
         @NotNull Bytes<byte[]> test = Bytes.from("hello world");
         @NotNull Bytes<byte[]> test2 = Bytes.from("hello world again");
         Bytes<?> result = Bytes.elasticHeapByteBuffer();
@@ -59,6 +67,165 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
             tailer.readBytes(result);
             assertEquals(test2, result);
             result.clear();
+        }
+    }
+
+    @Test
+    public void exactWriteReplacesAnIncompleteRequestedEntryWithAWarning() {
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir())
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first"));
+            final long requestedIndex = appender.lastIndexAppended() + 1;
+            putNextHeader(q, appender.cycle(), NOT_COMPLETE);
+
+            expectException("Exact-index recovery replaced incomplete header");
+            ((InternalAppender) appender).writeBytes(requestedIndex, Bytes.from("recovered"));
+
+            assertBytesAtIndex(q, requestedIndex, Bytes.from("recovered"));
+            assertNoDataAfter(q, requestedIndex);
+        }
+    }
+
+    @Test
+    public void exactWriteReplacesAnIncompleteRequestedEntryAfterQueueRestart() {
+        final File directory = getTmpDir();
+        final long requestedIndex;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first"));
+            requestedIndex = appender.lastIndexAppended() + 1;
+            putNextHeader(q, appender.cycle(), NOT_COMPLETE);
+        }
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            Assert.assertEquals("CQE must replay the incomplete index after restart",
+                    requestedIndex, q.lastIndex() + 1);
+            expectException("Exact-index recovery replaced incomplete header");
+            ((InternalAppender) appender).writeBytes(requestedIndex, Bytes.from("recovered"));
+
+            assertBytesAtIndex(q, requestedIndex, Bytes.from("recovered"));
+            assertNoDataAfter(q, requestedIndex);
+        }
+    }
+
+    @Test
+    public void restartedHistoricalBackfillLowersEofNormalisationBound() {
+        final File directory = getTmpDir();
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        final long requestedIndex;
+        final int recoveredCycle;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("cycle-0"));
+            requestedIndex = appender.lastIndexAppended() + 1;
+            recoveredCycle = q.rollCycle().toCycle(requestedIndex);
+
+            for (int i = 1; i <= 3; i++) {
+                timeProvider.advanceMillis(TimeUnit.MINUTES.toMillis(65));
+                appender.writeText("cycle-" + i);
+                appender.normaliseEOFs();
+            }
+
+            Assert.assertTrue("test requires the EOF cursor to have advanced beyond the recovery cycle",
+                    q.tableStoreGet("normalisedEOFsTo") > recoveredCycle);
+            removeEndOfData(q, recoveredCycle);
+            Assert.assertFalse(hasEOF(q, recoveredCycle));
+        }
+
+        // Simulate a process restart while the recovered roll remains historical by timestamp.
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            ((InternalAppender) appender).writeBytes(requestedIndex, Bytes.from("recovered"));
+
+            Assert.assertTrue("every backfilled cycle must lower the shared EOF normalisation bound",
+                    q.tableStoreGet("normalisedEOFsTo") <= recoveredCycle);
+            Assert.assertFalse("historical backfill remains open until completion normalisation",
+                    hasEOF(q, recoveredCycle));
+
+            appender.normaliseEOFs();
+
+            Assert.assertTrue("completion normalisation must restore the historical seal",
+                    hasEOF(q, recoveredCycle));
+            assertBytesAtIndex(q, requestedIndex, Bytes.from("recovered"));
+        }
+    }
+
+    @Test
+    public void currentTimestampBackfillIsNormalisedOnlyAfterItBecomesHistorical() {
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir())
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first"));
+            final long backfillIndex = appender.lastIndexAppended() + 1;
+            final int backfillCycle = q.rollCycle().toCycle(backfillIndex);
+
+            ((InternalAppender) appender).writeBytes(backfillIndex, Bytes.from("backfilled"));
+            Assert.assertTrue("every backfill must retain its normalization lower bound",
+                    q.tableStoreGet("normalisedEOFsTo") <= backfillCycle);
+
+            appender.normaliseEOFs();
+            Assert.assertFalse("normalisation must leave the wall-clock roll cycle open",
+                    hasEOF(q, backfillCycle));
+
+            timeProvider.advanceMillis(TimeUnit.MINUTES.toMillis(65));
+            appender.normaliseEOFs();
+            Assert.assertTrue("the retained lower bound must seal the cycle once it is historical",
+                    hasEOF(q, backfillCycle));
+        }
+    }
+
+    @Test
+    public void ordinaryAppenderContinuesInCurrentCycleAfterIndexedWriteToUnsealedRoll() {
+        @NotNull Bytes<byte[]> first = Bytes.from("first ordinary entry");
+        @NotNull Bytes<byte[]> indexed = Bytes.from("indexed entry");
+        @NotNull Bytes<byte[]> following = Bytes.from("following ordinary entry");
+        Bytes<?> result = Bytes.elasticHeapByteBuffer();
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir())
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .build();
+             ExcerptAppender appender = q.createAppender();
+             ExcerptTailer tailer = q.createTailer()) {
+            appender.writeBytes(first);
+            final long indexedWriteIndex = appender.lastIndexAppended() + 1;
+            final int currentCycle = appender.cycle();
+
+            ((InternalAppender) appender).writeBytes(indexedWriteIndex, indexed);
+            Assert.assertEquals(currentCycle, appender.cycle());
+            Assert.assertFalse("an indexed write to an unsealed current roll must not add EOF",
+                    hasEOF(q, currentCycle));
+
+            appender.writeBytes(following);
+            Assert.assertEquals(currentCycle, appender.cycle());
+            Assert.assertEquals(indexedWriteIndex + 1, appender.lastIndexAppended());
+
+            assertNextBytes(tailer, result, first);
+            assertNextBytes(tailer, result, indexed);
+            assertNextBytes(tailer, result, following);
+            Assert.assertFalse(tailer.readBytes(result.clear()));
         }
     }
 
@@ -91,123 +258,55 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
     }
 
     @Test
-    public void cannotOverwriteExistingEntries() {
+    public void publishedDuplicatePayloadsAreComparedWithoutMutation() {
         @NotNull Bytes<byte[]> originalBytes = Bytes.from("hello world");
+        final Bytes<byte[]> matchingBytes = Bytes.from("hello world");
         final Bytes<byte[]> overwriteBytes = Bytes.from("HELLO WORLD");
         Bytes<?> result = Bytes.elasticHeapByteBuffer();
-        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir()).timeProvider(() -> 0).build();
-             ExcerptAppender appender = q.createAppender()) {
-            appender.writeBytes(originalBytes);
+        final List<String> debugMessages = new ArrayList<>();
+        final List<String> warningMessages = new ArrayList<>();
+        Jvm.setThreadLocalExceptionHandlers(null,
+                (clazz, message, thrown) -> warningMessages.add(message),
+                (clazz, message, thrown) -> debugMessages.add(message));
+        try {
+            try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir())
+                    .timeProvider(() -> 0)
+                    .build();
+                 ExcerptAppender appender = q.createAppender()) {
+                appender.writeBytes(originalBytes);
+                final String queueBeforeDuplicates = q.dump();
+                final long matchingReadPosition = matchingBytes.readPosition();
+                final long overwriteReadPosition = overwriteBytes.readPosition();
 
-            // try to overwrite - will not overwrite
-            ((InternalAppender) appender).writeBytes(0, overwriteBytes);
+                ((InternalAppender) appender).writeBytes(0, matchingBytes);
+                ((InternalAppender) appender).writeBytes(0, overwriteBytes);
 
-            ExcerptTailer tailer = q.createTailer();
-            tailer.readBytes(result);
-            assertEquals(originalBytes, result);
-            assertEquals(1, tailer.index());
+                assertEquals(matchingReadPosition, matchingBytes.readPosition());
+                assertEquals(overwriteReadPosition, overwriteBytes.readPosition());
+                assertEquals(queueBeforeDuplicates, q.dump());
+                ExcerptTailer tailer = q.createTailer();
+                tailer.readBytes(result);
+                assertEquals(originalBytes, result);
+                assertEquals(1, tailer.index());
+            }
+        } finally {
+            Jvm.setThreadLocalExceptionHandlers(null, null, null);
         }
-    }
 
-    @Test
-    public void cannotOverwriteExistingEntries_DifferentQueueInstance() {
-        @NotNull Bytes<byte[]> test = Bytes.from("hello world");
-        @NotNull Bytes<byte[]> test2 = Bytes.from("hello world2");
-        Bytes<?> result = Bytes.elasticHeapByteBuffer();
-        long index;
-        final File tmpDir = getTmpDir();
-        final String expected = "" +
-                "--- !!meta-data #binary\n" +
-                "header: !STStore {\n" +
-                "  wireType: !WireType BINARY_LIGHT,\n" +
-                "  metadata: !SCQMeta {\n" +
-                "    roll: !SCQSRoll { length: 86400000, format: yyyyMMdd'T4', epoch: 0 },\n" +
-                "    sourceId: 0\n" +
-                "  }\n" +
-                "}\n" +
-                "# position: 176, header: 0\n" +
-                "--- !!data #binary\n" +
-                "listing.highestCycle: 0\n" +
-                "# position: 216, header: 1\n" +
-                "--- !!data #binary\n" +
-                "listing.lowestCycle: 0\n" +
-                "# position: 256, header: 2\n" +
-                "--- !!data #binary\n" +
-                "listing.modCount: 1\n" +
-                "# position: 288, header: 3\n" +
-                "--- !!data #binary\n" +
-                "chronicle.write.lock: -9223372036854775808\n" +
-                "# position: 328, header: 4\n" +
-                "--- !!data #binary\n" +
-                "chronicle.append.lock: -9223372036854775808\n" +
-                "# position: 368, header: 5\n" +
-                "--- !!data #binary\n" +
-                "chronicle.lastIndexReplicated: -1\n" +
-                "# position: 416, header: 6\n" +
-                "--- !!data #binary\n" +
-                "chronicle.lastAcknowledgedIndexReplicated: -1\n" +
-                "...\n" +
-                "# 130596 bytes remaining\n" +
-                "--- !!meta-data #binary\n" +
-                "header: !SCQStore {\n" +
-                "  writePosition: [\n" +
-                "    792,\n" +
-                "    3401614098433\n" +
-                "  ],\n" +
-                "  indexing: !SCQSIndexing {\n" +
-                "    indexCount: 32,\n" +
-                "    indexSpacing: 4,\n" +
-                "    index2Index: 196,\n" +
-                "    lastIndex: 4\n" +
-                "  },\n" +
-                "  dataFormat: 1\n" +
-                "}\n" +
-                "# position: 196, header: -1\n" +
-                "--- !!meta-data #binary\n" +
-                "index2index: [\n" +
-                "  # length: 32, used: 1\n" +
-                "  488,\n" +
-                "  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0\n" +
-                "]\n" +
-                "# position: 488, header: -1\n" +
-                "--- !!meta-data #binary\n" +
-                "index: [\n" +
-                "  # length: 32, used: 1\n" +
-                "  776,\n" +
-                "  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0\n" +
-                "]\n" +
-                "# position: 776, header: 0\n" +
-                "--- !!data\n" +
-                "hello world\n" +
-                "# position: 792, header: 1\n" +
-                "--- !!data\n" +
-                "hello world2\n" +
-                "...\n" +
-                "# 130260 bytes remaining\n";
-        try (SingleChronicleQueue q = createQueue(tmpDir);
-             ExcerptAppender appender = q.createAppender()) {
-            appender.writeBytes(test);
-            appender.writeBytes(test2);
-            index = appender.lastIndexAppended();
-        }
-        assertEquals(1, index);
-
-        // has to be the same tmpDir
-        try (SingleChronicleQueue q = createQueue(tmpDir);
-             InternalAppender appender = (InternalAppender) q.createAppender()) {
-            appender.writeBytes(0, Bytes.from("HELLO WORLD"));
-            appender.writeBytes(1, Bytes.from("HELLO WORLD"));
-
-            ExcerptTailer tailer = q.createTailer();
-            tailer.readBytes(result);
-            assertEquals(test, result);
-            assertEquals(1, tailer.index());
-        }
-    }
-
-    @NotNull
-    private SingleChronicleQueue createQueue(File tmpDir) {
-        return SingleChronicleQueueBuilder.binary(tmpDir).timeProvider(() -> 0).testBlockSize().rollCycle(TEST4_DAILY).build();
+        final List<String> duplicateDebugMessages = debugMessages.stream()
+                .filter(message -> message.contains("duplicate matches published content and was ignored"))
+                .collect(Collectors.toList());
+        assertEquals(1, duplicateDebugMessages.size());
+        final List<String> duplicateWarningMessages = warningMessages.stream()
+                .filter(message -> message.contains("duplicate differs from published content and was ignored"))
+                .collect(Collectors.toList());
+        assertEquals(1, duplicateWarningMessages.size());
+        final String warning = duplicateWarningMessages.get(0);
+        Assert.assertTrue(warning.contains("duplicate differs from published content and was ignored"));
+        Assert.assertTrue(warning.contains("\nexisting:\n"));
+        Assert.assertTrue(warning.contains("68 65 6c 6c  6f 20 77 6f"));
+        Assert.assertTrue(warning.contains("\nsupplied:\n"));
+        Assert.assertTrue(warning.contains("48 45 4c 4c 4f 20 57 4f"));
     }
 
     @Test(expected = IllegalIndexException.class)
@@ -223,8 +322,8 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
         }
     }
 
-    @Test(expected = IllegalIndexException.class)
-    public void cannotWriteToNonZeroIndexOfNewRollCycle() {
+    @Test
+    public void cannotWriteToNonZeroIndexOfNewRollCycleWithoutMutation() {
         final RollCycle rollCycle = RollCycles.DEFAULT;
         try (SingleChronicleQueue q = binary(tempDir("q"))
                 .rollCycle(rollCycle)
@@ -232,37 +331,256 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
              ExcerptAppender appender = q.createAppender()) {
             appender.writeText("hello");    // cycle 0, sequence 0
 
+            final int cycleBefore = appender.cycle();
+            final long publishedMaximumBefore = q.tableStoreGet("listing.highestCycle");
+            final long normalisedBefore = q.tableStoreGet("normalisedEOFsTo");
+            final long rollCountBefore = Arrays.stream(q.file().listFiles())
+                    .filter(file -> file.getName().endsWith(SingleChronicleQueue.SUFFIX))
+                    .count();
+            Assert.assertFalse(hasEOF(q, cycleBefore));
+
             // attempt to write to cycle 1, sequence 1
-            ((InternalAppender) appender).writeBytes(rollCycle.toIndex(1, 1), Bytes.from("text"));
+            assertThrows(IllegalIndexException.class,
+                    () -> ((InternalAppender) appender).writeBytes(
+                            rollCycle.toIndex(cycleBefore + 1, 1), Bytes.from("text")));
+
+            Assert.assertEquals(cycleBefore, appender.cycle());
+            Assert.assertEquals(publishedMaximumBefore, q.tableStoreGet("listing.highestCycle"));
+            Assert.assertEquals(normalisedBefore, q.tableStoreGet("normalisedEOFsTo"));
+            Assert.assertEquals(rollCountBefore, Arrays.stream(q.file().listFiles())
+                    .filter(file -> file.getName().endsWith(SingleChronicleQueue.SUFFIX))
+                    .count());
+            Assert.assertFalse(hasEOF(q, cycleBefore));
         }
     }
 
     @Test
-    public void cannotAppendToPreviousCycle() {
+    public void canBackfillPreviousCycleAfterEOF() {
         @NotNull Bytes<byte[]> test = Bytes.from("hello world");
         @NotNull Bytes<byte[]> test1 = Bytes.from("hello world again cycle1");
+        @NotNull Bytes<byte[]> test1b = Bytes.from("second recovered entry cycle1");
         @NotNull Bytes<byte[]> test2 = Bytes.from("hello world cycle2");
+        Bytes<?> result = Bytes.elasticHeapByteBuffer();
         SetTimeProvider timeProvider = new SetTimeProvider();
         try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir()).timeProvider(timeProvider).rollCycle(TEST_HOURLY).build();
-             ExcerptAppender appender = q.createAppender()) {
-            appender.writeBytes(test);
-            long nextIndexInFirstCycle = appender.lastIndexAppended() + 1;
-            int firstCycle = q.rollCycle().toCycle(nextIndexInFirstCycle);
+             ExcerptTailer tailer = q.createTailer()) {
+            final int firstCycle;
+            try (ExcerptAppender appender = q.createAppender()) {
+                appender.writeBytes(test);
+                long nextIndexInFirstCycle = appender.lastIndexAppended() + 1;
+                firstCycle = q.rollCycle().toCycle(nextIndexInFirstCycle);
 
-            timeProvider.advanceMillis(TimeUnit.SECONDS.toMillis(65 * 60));
-            appender.writeBytes(test2);
+                timeProvider.advanceMillis(TimeUnit.SECONDS.toMillis(65 * 60));
+                appender.writeBytes(test2);
 
-            Assert.assertTrue(hasEOF(q, firstCycle));
-            // here we try and write to previous cycle file
-            assertThrows(WriteAfterEOFException.class, () -> ((InternalAppender) appender).writeBytes(nextIndexInFirstCycle, test1));
+                assertNextBytes(tailer, result, test);
+                assertNextBytes(tailer, result, test2);
+                Assert.assertFalse(tailer.readBytes(result.clear()));
+
+                Assert.assertTrue(hasEOF(q, firstCycle));
+                expectException("queue=" + q.fileAbsolutePath() + ", cycle=" + firstCycle
+                        + ", index=0x" + Long.toHexString(nextIndexInFirstCycle));
+                ((InternalAppender) appender).writeBytes(nextIndexInFirstCycle, test1);
+                Assert.assertFalse("indexed recovery must leave the roll open for the remaining backfill",
+                        hasEOF(q, firstCycle));
+
+                final long secondRecoveryIndex = nextIndexInFirstCycle + 1;
+                ((InternalAppender) appender).writeBytes(secondRecoveryIndex, test1b);
+                Assert.assertFalse("later entries must reuse the open recovery slot without another EOF warning",
+                        hasEOF(q, firstCycle));
+                appender.normaliseEOFs();
+            }
+            Assert.assertTrue("completion must reseal once after all backfill entries", hasEOF(q, firstCycle));
+            Assert.assertFalse("a live tailer that crossed the roll must not rewind implicitly",
+                    tailer.readBytes(result.clear()));
+
+            try (ExcerptTailer restartedTailer = q.createTailer()) {
+                assertNextBytes(restartedTailer, result, test);
+                assertNextBytes(restartedTailer, result, test1);
+                assertNextBytes(restartedTailer, result, test1b);
+                assertNextBytes(restartedTailer, result, test2);
+                Assert.assertFalse(restartedTailer.readBytes(result.clear()));
+            }
         }
     }
 
+    @Test
+    public void exactBackfillCanAddASecondaryIndexBeforeResealing() {
+        SetTimeProvider timeProvider = new SetTimeProvider();
+        final int entriesInFirstSecondaryIndex = TEST4_DAILY.defaultIndexCount()
+                * TEST4_DAILY.defaultIndexSpacing();
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir())
+                .timeProvider(timeProvider)
+                .rollCycle(TEST4_DAILY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            for (int i = 0; i < entriesInFirstSecondaryIndex; i++)
+                appender.writeText("entry-" + i);
+
+            final long recoveredIndex = appender.lastIndexAppended() + 1;
+            final int recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+            Assert.assertTrue(cycleDump(q, recoveredCycle)
+                    .contains("index2index: [\n  # length: 32, used: 1\n"));
+
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(25));
+            appender.writeText("next-cycle");
+            Assert.assertTrue(hasEOF(q, recoveredCycle));
+
+            expectException("queue=" + q.fileAbsolutePath() + ", cycle=" + recoveredCycle
+                    + ", index=0x" + Long.toHexString(recoveredIndex));
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("recovered"));
+
+            final String openCycleDump = cycleDump(q, recoveredCycle);
+            Assert.assertTrue("backfill must add the second secondary index while the roll is open",
+                    openCycleDump.contains("index2index: [\n  # length: 32, used: 2\n"));
+            Assert.assertFalse("the recovered cycle stays open until completion",
+                    openCycleDump.contains(" EOF"));
+
+            appender.normaliseEOFs();
+            Assert.assertTrue("completion must reseal the recovered cycle", hasEOF(q, recoveredCycle));
+        }
+    }
+
+    @Test
+    public void exactBackfillFindsEofAfterSecondaryIndexMetadata() {
+        final int entriesBeforeRecovery = TEST4_DAILY.defaultIndexCount()
+                * TEST4_DAILY.defaultIndexSpacing() + 1;
+
+        assertExactBackfillDoesNotRollForward(entriesBeforeRecovery, false);
+    }
+
+    @Test
+    public void exactBackfillFindsEofAfterTrailingUserMetadata() {
+        assertExactBackfillDoesNotRollForward(1, true);
+    }
+
+    @Test
+    public void exactBackfillFindsEofInEmptySealedCycle() {
+        assertExactBackfillDoesNotRollForward(0, true);
+    }
+
+    private void assertExactBackfillDoesNotRollForward(int initialEntries, boolean trailingMetadata) {
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        final Bytes<?> recovered = Bytes.from("recovered");
+        final Bytes<?> later = Bytes.from("later-cycle");
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir())
+                .timeProvider(timeProvider)
+                .rollCycle(TEST4_DAILY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            for (int i = 0; i < initialEntries; i++)
+                appender.writeBytes(Bytes.from("entry-" + i));
+
+            if (trailingMetadata) {
+                try (DocumentContext document = appender.writingDocument(true)) {
+                    document.wire().write("meta").text("trailing metadata");
+                }
+            }
+
+            final long recoveredIndex = initialEntries == 0
+                    ? q.rollCycle().toIndex(0, 0)
+                    : appender.lastIndexAppended() + 1;
+            final int recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(25));
+            appender.writeBytes(later);
+            final long laterIndex = appender.lastIndexAppended();
+            final int filesBeforeRecovery = queueFiles(q).length;
+            Assert.assertTrue(hasEOF(q, recoveredCycle));
+
+            Throwable failure = null;
+            try {
+                // Other focused tests assert the warning. Here the structural assertions must remain
+                // discriminating even when recovery fails before it reaches the warning site.
+                ignoreException("Exact-index recovery reopened end-of-data");
+                ((InternalAppender) appender).writeBytes(recoveredIndex, recovered);
+            } catch (Throwable t) {
+                failure = t;
+            }
+
+            Assert.assertEquals("exact recovery must not create another roll",
+                    filesBeforeRecovery, queueFiles(q).length);
+            assertBytesAtIndex(q, laterIndex, later);
+            assertNoDataAfter(q, laterIndex);
+            if (failure != null)
+                throw new AssertionError("exact recovery should succeed in its requested cycle", failure);
+            assertBytesAtIndex(q, recoveredIndex, recovered);
+            Assert.assertFalse("the recovered cycle must remain open until completion",
+                    hasEOF(q, recoveredCycle));
+            appender.normaliseEOFs();
+            Assert.assertTrue("completion must reseal the recovered cycle", hasEOF(q, recoveredCycle));
+        }
+    }
+
+    private static void assertBytesAtIndex(SingleChronicleQueue q, long index, Bytes<?> expected) {
+        try (ExcerptTailer tailer = q.createTailer()) {
+            Assert.assertTrue("unable to move to index 0x" + Long.toHexString(index), tailer.moveToIndex(index));
+            assertNextBytes(tailer, Bytes.elasticHeapByteBuffer(), expected);
+        }
+    }
+
+    private static void assertNoDataAfter(SingleChronicleQueue q, long index) {
+        try (ExcerptTailer tailer = q.createTailer()) {
+            Assert.assertTrue("unable to move to index 0x" + Long.toHexString(index), tailer.moveToIndex(index));
+            Assert.assertTrue(tailer.readBytes(Bytes.elasticHeapByteBuffer()));
+            Assert.assertFalse("exact recovery must not append data after the later-cycle entry",
+                    tailer.readBytes(Bytes.elasticHeapByteBuffer()));
+        }
+    }
+
+    private static File[] queueFiles(SingleChronicleQueue q) {
+        final File[] files = q.file().listFiles((directory, name) -> name.endsWith(SingleChronicleQueue.SUFFIX));
+        Assert.assertNotNull(files);
+        return files;
+    }
+
+    private static void putNextHeader(SingleChronicleQueue q, int cycle, int header) {
+        try (SingleChronicleQueueStore store = q.storeForCycle(cycle, 0, false, null);
+             MappedBytes bytes = store.bytes()) {
+            long position = store.writePosition();
+            position += lengthOf(bytes.readVolatileInt(position)) + SPB_HEADER_SIZE;
+            position += BytesUtil.padOffset(position);
+            Assert.assertEquals(NOT_INITIALIZED, bytes.readVolatileInt(position));
+            bytes.writeVolatileInt(position, header);
+        }
+    }
+
+    private static void removeEndOfData(SingleChronicleQueue q, int cycle) {
+        try (SingleChronicleQueueStore store = q.storeForCycle(cycle, 0, false, null);
+             MappedBytes bytes = store.bytes()) {
+            long position = store.writePosition();
+            position += lengthOf(bytes.readVolatileInt(position)) + SPB_HEADER_SIZE;
+            for (; ; ) {
+                if (store.dataVersion() > 0)
+                    position += BytesUtil.padOffset(position);
+                final int header = bytes.readVolatileInt(position);
+                if (header == END_OF_DATA) {
+                    Assert.assertTrue(bytes.compareAndSwapInt(position, END_OF_DATA, NOT_INITIALIZED));
+                    return;
+                }
+                Assert.assertTrue("expected metadata before EOF at position " + position,
+                        isReadyMetaData(header));
+                position += SPB_HEADER_SIZE + lengthOf(header);
+            }
+        }
+    }
+
+    private static void assertNextBytes(ExcerptTailer tailer, Bytes<?> result, Bytes<?> expected) {
+        result.clear();
+        Assert.assertTrue(tailer.readBytes(result));
+        assertEquals(expected, result);
+    }
+
     private boolean hasEOF(SingleChronicleQueue q, int cycle) {
+        String dump = cycleDump(q, cycle);
+        return dump.contains(" EOF") && dump.contains("--- !!not-ready-meta-data");
+    }
+
+    private String cycleDump(SingleChronicleQueue q, int cycle) {
         try (SingleChronicleQueueStore store = q.storeForCycle(cycle, 0, false, null)) {
-            String dump = store.dump(WireType.BINARY_LIGHT);
-            System.out.println(dump);
-            return dump.contains(" EOF") && dump.contains("--- !!not-ready-meta-data");
+            return store.dump(WireType.BINARY_LIGHT);
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
@@ -11,6 +11,7 @@ import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import org.junit.Test;
 
 import java.io.File;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -155,10 +156,16 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
                 RollCycles.WEEKLY, RollCycles.WEEKLY.defaultEpoch(), File::new, File::getName);
         final int current = RollCycles.WEEKLY.current(System::currentTimeMillis,
                 RollCycles.WEEKLY.defaultEpoch());
+        Long previousOrderingKey = null;
 
         for (int cycle = current - 10; cycle <= current + 10; cycle++) {
-            final String name = weeklyCache.resourceFor(cycle).text;
+            final RollingResourcesCache.Resource resource = weeklyCache.resourceFor(cycle);
+            final String name = resource.text;
             assertEquals("weekly filename " + name, cycle, weeklyCache.parseCount(name));
+            final Long orderingKey = weeklyCache.toLong(resource.path);
+            if (previousOrderingKey != null)
+                assertTrue("weekly ordering key " + name, orderingKey > previousOrderingKey);
+            previousOrderingKey = orderingKey;
         }
     }
 
@@ -174,12 +181,38 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
                 final int firstCycle = Math.toIntExact(Math.floorDiv(
                         firstMillis - RollCycles.WEEKLY.defaultEpoch(),
                         RollCycles.WEEKLY.lengthInMillis()));
+                Long previousOrderingKey = null;
 
                 for (int cycle = firstCycle; cycle < firstCycle + 170; cycle++) {
-                    final String name = weeklyCache.resourceFor(cycle).text;
+                    final RollingResourcesCache.Resource resource = weeklyCache.resourceFor(cycle);
+                    final String name = resource.text;
                     assertEquals(locale + " weekly filename " + name,
                             cycle, weeklyCache.parseCount(name));
+                    final Long orderingKey = weeklyCache.toLong(resource.path);
+                    if (previousOrderingKey != null)
+                        assertTrue(locale + " weekly ordering key " + name,
+                                orderingKey > previousOrderingKey);
+                    previousOrderingKey = orderingKey;
                 }
+            }
+        } finally {
+            Locale.setDefault(Locale.Category.FORMAT, originalFormatLocale);
+        }
+    }
+
+    @Test
+    public void nonCanonicalNamedWeeksAreRejected() {
+        final Locale originalFormatLocale = Locale.getDefault(Locale.Category.FORMAT);
+        try {
+            for (Locale locale : new Locale[]{Locale.US, Locale.UK}) {
+                Locale.setDefault(Locale.Category.FORMAT, locale);
+                final RollingResourcesCache weeklyCache = new RollingResourcesCache(
+                        RollCycles.WEEKLY, RollCycles.WEEKLY.defaultEpoch(), File::new, File::getName);
+
+                assertThrows(locale + " parseCount must reject a week alias",
+                        DateTimeException.class, () -> weeklyCache.parseCount("2021W53"));
+                assertThrows(locale + " ordering key must reject a week alias",
+                        DateTimeException.class, () -> weeklyCache.toLong(new File("2021W53")));
             }
         } finally {
             Locale.setDefault(Locale.Category.FORMAT, originalFormatLocale);

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/NormaliseEOFsTest.java
@@ -17,11 +17,15 @@ import net.openhft.chronicle.queue.rollcycles.TestRollCycles;
 import net.openhft.chronicle.testframework.exception.ExceptionTracker;
 import net.openhft.chronicle.wire.DocumentContext;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -122,6 +126,37 @@ public class NormaliseEOFsTest extends QueueTestCommon {
                 assertTrue(normalisedAfter > normalisedBefore,
                         "normaliseEOFs on a never-written appender should have advanced the watermark past "
                                 + normalisedBefore + " but it stayed at " + normalisedAfter);
+            }
+        }
+    }
+
+    @Test
+    public void deletingOldestPublishedRollDoesNotBlockAReusedQueue() throws Exception {
+        Assume.assumeFalse(OS.isWindows());
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        try (final SingleChronicleQueue queue = createQueue(timeProvider)) {
+            try (final ExcerptAppender writer = queue.createAppender()) {
+                writer.writeText("cycle-0");
+                timeProvider.advanceMillis(1_001);
+                writer.writeText("cycle-1");
+                timeProvider.advanceMillis(1_001);
+                writer.writeText("cycle-2");
+            }
+
+            final File[] rolls = queue.file().listFiles(
+                    (directory, name) -> name.endsWith(SingleChronicleQueue.SUFFIX));
+            assertTrue(rolls != null && rolls.length == 3);
+            Arrays.sort(rolls, Comparator.comparing(File::getName));
+
+            // Publish both cached boundaries before removing one behind this still-open Queue.
+            queue.firstCycle();
+            queue.lastCycle();
+            BackgroundResourceReleaser.releasePendingResources();
+            Files.delete(rolls[0].toPath());
+
+            try (final ExcerptAppender restarted = queue.createAppender()) {
+                restarted.normaliseEOFs();
+                restarted.writeText("after-boundary-deletion");
             }
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -2135,7 +2135,6 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 appender.writeDocument(w -> w.writeEventName("hello").int64(finalI));
                 long seq = chronicle.rollCycle().toSequenceNumber(appender.lastIndexAppended());
                 assertEquals(i, seq);
-                // System.out.println(chronicle.dump());
                 tailer.readDocument(w -> w.read().int64(finalI, (a, b) -> assertEquals((long) a, b)));
             }
         }
@@ -2150,7 +2149,6 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
             appender.writeDocument(w -> {
             });
-            // System.out.println(chronicle.dump());
             ExcerptTailer tailer = chronicle.createTailer(named ? "named" : null);
             try (DocumentContext dc = tailer.readingDocument()) {
                 assertFalse(dc.wire().hasMore());
@@ -2220,7 +2218,6 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             appender.writeDocument(w -> w.writeEventName("hello").text("world0"));
             final long nextIndexToWrite = appender.lastIndexAppended() + 1;
             appender.writeDocument(w -> w.getValueOut().bytes(new byte[0]));
-            // System.out.println(chronicle.dump());
             assertEquals(nextIndexToWrite,
                     appender.lastIndexAppended());
         }
@@ -2397,7 +2394,6 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 if (!executor.awaitTermination(10_000, TimeUnit.SECONDS))
                     executor.shutdownNow();
 
-                // System.out.println(". " + i);
                 Jvm.pause(1000);
             }
         }
@@ -2497,6 +2493,11 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             String expected = expectedMultipleAppenders();
             assertEquals(expected, tidyDump(syncQ));
         }
+    }
+
+    @NotNull
+    private static String withoutEofCursor(String dump) {
+        return dump.replaceAll("--- !!data #binary\\nnormalisedEOFsTo: \\d+\\n", "");
     }
 
     @NotNull
@@ -2781,7 +2782,6 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
             long[] indexs = new long[10];
             for (int i = 0; i < indexs.length; i++) {
-                // System.out.println(".");
                 try (DocumentContext writingContext = appender.writingDocument()) {
                     writingContext.wire().write().text("some-text-" + i);
                     indexs[i] = writingContext.index();
@@ -2797,7 +2797,6 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
 
             for (int lower = 0; lower < indexs.length; lower++) {
                 for (int upper = lower; upper < indexs.length; upper++) {
-                    // System.out.println("lower=" + lower + ",upper=" + upper);
                     assertEquals(upper - lower, queue.countExcerpts(indexs[lower],
                             indexs[upper]));
                 }
@@ -3276,7 +3275,6 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
             });
 
             f1.get(10, TimeUnit.SECONDS);
-            // System.out.println(queue.dump().replaceAll("(?m)^#.+$\\n", ""));
             f2.get(10, TimeUnit.SECONDS);
 
             executorService.shutdownNow();
@@ -3310,76 +3308,6 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
     }
 
     @Test
-    public void writeBytesAndIndexFiveTimesWithOverwriteTest() {
-        try (final ChronicleQueue sourceQueue =
-                     builder(getTmpDir(), wireType).
-                             testBlockSize().build();
-             final ExcerptAppender excerptAppender = sourceQueue.createAppender()) {
-
-            for (int i = 0; i < 5; i++) {
-                try (DocumentContext dc = excerptAppender.writingDocument()) {
-                    dc.wire().write("hello").text("world" + i);
-                }
-            }
-
-            try (ExcerptTailer tailer = sourceQueue.createTailer(named ? "named" : null);
-                 ChronicleQueue queue =
-                         builder(getTmpDir(), wireType).testBlockSize().build();
-                 ExcerptAppender appender0 = queue.createAppender()) {
-
-                assumeTrue(appender0 instanceof InternalAppender);
-                InternalAppender appender = (InternalAppender) appender0;
-                assumeTrue(appender instanceof StoreAppender);
-
-                List<BytesWithIndex> bytesWithIndies = new ArrayList<>();
-                try {
-                    for (int i = 0; i < 5; i++) {
-                        bytesWithIndies.add(bytes(tailer));
-                    }
-
-                    // ... and try and overwrite starting at beginning
-                    // NOTE: stepping here appears to overwrite
-                    // and DOES NOT output debug log "Trying to overwrite index..."
-                    for (int i = 0; i < 4; i++) {
-                        BytesWithIndex b = bytesWithIndies.get(i);
-                        appender.writeBytes(b.index, b.bytes);
-                    }
-
-                    // this will output debug log "Trying to overwrite index..." as expected
-                    for (int i = 0; i < 4; i++) {
-                        BytesWithIndex b = bytesWithIndies.get(i);
-                        appender.writeBytes(b.index, b.bytes);
-                    }
-
-                    BytesWithIndex b = bytesWithIndies.get(4);
-                    appender.writeBytes(b.index, b.bytes);
-
-                    ((StoreAppender) appender).checkWritePositionHeaderNumber();
-                    appender0.writeText("goodbye");
-                } finally {
-                    closeQuietly(bytesWithIndies);
-                }
-
-                String dump = tidyDump(queue);
-                assertTrue(dump, dump.contains(
-                        "--- !!data #binary\n" +
-                                "hello: world0\n" +
-                                "--- !!data #binary\n" +
-                                "hello: world1\n" +
-                                "--- !!data #binary\n" +
-                                "hello: world2\n" +
-                                "--- !!data #binary\n" +
-                                "hello: world3\n" +
-                                "--- !!data #binary\n" +
-                                "hello: world4\n" +
-                                "--- !!data #binary\n" +
-                                "goodbye\n"));
-
-            }
-        }
-    }
-
-    @Test
     public void writeBytesAndIndexFiveTimesTest() {
         try (final ChronicleQueue sourceQueue =
                      builder(getTmpDir(), wireType).
@@ -3392,7 +3320,7 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                 }
             }
 
-            String before = tidyDump(sourceQueue);
+            String before = withoutEofCursor(tidyDump(sourceQueue));
             try (ExcerptTailer tailer = sourceQueue.createTailer(named ? "named" : null);
                  ChronicleQueue queue =
                          builder(getTmpDir(), wireType).testBlockSize().build();
@@ -3407,7 +3335,9 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
                     }
                 }
 
-                String dump = tidyDump(queue);
+                // Exact-index recovery records its EOF-normalisation lower bound; compare payload
+                // and queue structure independently of that completion cursor.
+                String dump = withoutEofCursor(tidyDump(queue));
                 assertEquals(before, dump);
                 assertTrue(dump, dump.contains(
                         "--- !!data #binary\n" +

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderInternalWriteBytesTest.java
@@ -58,14 +58,9 @@ public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
     }
 
     private void testInternalWriteBytes(int numCopiers, boolean concurrent) throws InterruptedException {
+        ignoreException("Exact-index duplicate differs from published content and was ignored");
         final Path sourceDir = IOTools.createTempDirectory("sourceQueue");
         final Path destinationDir = IOTools.createTempDirectory("destinationQueue");
-        /**
-         final Path sourceDir = Paths.get("/dev/shm/sourceQueue");
-         final Path destinationDir = Paths.get("/dev/shm/destinationQueue");
-         IOTools.deleteDirWithFiles(sourceDir.toFile());
-         IOTools.deleteDirWithFiles(destinationDir.toFile());
-         */
 
         populateSourceQueue(sourceDir);
 
@@ -100,12 +95,7 @@ public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
     private void assertQueueContentsAreTheSame(Path sourceDir, Path destinationDir) {
         try (final ChronicleQueue sourceQueue = createQueue(sourceDir, null);
              final ChronicleQueue destinationQueue = createQueue(destinationDir)) {
-//            System.out.println(destinationQueue.dump());
-            /*
-             * Normalise destination EOFs first
-             *
-             * part of the contract with {@link net.openhft.chronicle.queue.impl.single.StoreAppender.writeBytes(long, net.openhft.chronicle.bytes.BytesStore)}
-             */
+            // Exact-index replication must normalise destination EOFs after replay completes.
             try (final ExcerptAppender appender = destinationQueue.createAppender()) {
                 appender.normaliseEOFs();
             }
@@ -143,7 +133,6 @@ public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
 
         @Override
         public void run() {
-//            LOGGER.info("Starting copier...");
             try (final ChronicleQueue sourceQueue = createQueue(sourceDir, null);
                  final ChronicleQueue destinationQueue = createQueue(destinationDir, null)) {
                 try (final ExcerptTailer sourceTailer = sourceQueue.createTailer();
@@ -173,17 +162,14 @@ public class StoreAppenderInternalWriteBytesTest extends QueueTestCommon {
                                 assertEquals(Long.toHexString(index), Long.toHexString(dtIndex));
                         }
                         prev.clear().append(buffer);
-//                        if (false && index %17 == 0) {
                         try (final ChronicleQueue dq = createQueue(destinationDir, null);
                              final ExcerptAppender da = dq.createAppender()) {
                             assumeNotNull(dq);
                             assumeNotNull(da);
                         }
-                        //                      }
                     }
                 }
             }
-//            LOGGER.info("Copier finished");
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -7,19 +7,29 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesUtil;
 import net.openhft.chronicle.bytes.MappedBytes;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
 import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
+import net.openhft.chronicle.core.values.LongValue;
+import net.openhft.chronicle.core.values.TwoLongValue;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.QueueSystemProperties;
 import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.RollCycle;
+import net.openhft.chronicle.queue.RollCycles;
 import net.openhft.chronicle.queue.impl.StoreFileListener;
+import net.openhft.chronicle.queue.rollcycles.RollCycleArithmetic;
 import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireType;
 import net.openhft.chronicle.wire.Wires;
 import net.openhft.chronicle.wire.WriteAfterEOFException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,7 +37,15 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.DateTimeException;
 import java.util.Arrays;
+import java.util.Locale;
+import java.util.TreeSet;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -39,21 +57,37 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST4_DAILY;
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_DAILY;
+import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_HOURLY;
+import static net.openhft.chronicle.wire.MarshallableOut.UNSET_CONTEXT;
+import static net.openhft.chronicle.wire.Wires.*;
 
 public class StoreAppenderTest extends QueueTestCommon {
 
     private static final String TEST_TEXT = "Some text some text some text";
     private static final long ONE_DAY = TimeUnit.DAYS.toMillis(1);
+    private static final RollCycle ALIASING_POSITION_ROLL_CYCLE =
+            new ConfigurableRollCycle("yyyyMMdd'A48'", (int) ONE_DAY, 512, 1 << 30);
+    private static final RollCycle TWO_DAY_DAILY_ROLL_CYCLE =
+            new ConfigurableRollCycle("yyyyMMdd'T2D'", (int) (2 * ONE_DAY), 8, 1);
 
     @Rule
     public final TemporaryFolder queueDirectory = new TemporaryFolder();
+
+    private boolean originalCheckIndex;
 
     @Override
     @Before
     public void threadDump() {
         super.threadDump();
+        originalCheckIndex = QueueSystemProperties.CHECK_INDEX;
+    }
+
+    @After
+    public void restoreIndexChecks() {
+        QueueSystemProperties.CHECK_INDEX = originalCheckIndex;
     }
 
     @Test
@@ -145,7 +179,8 @@ public class StoreAppenderTest extends QueueTestCommon {
             // must still open the published maximum as existing-only and fail if it disappeared.
             final IllegalStateException failure = assertThrows(IllegalStateException.class,
                     () -> stalledWriter.writeBytes(Bytes.from("must-fail")));
-            assertTrue(failure.getMessage().contains("Highest/current roll 1 disappeared"));
+            assertTrue(failure.toString(),
+                    failure.getMessage().contains("Highest/current roll 1 disappeared"));
             assertFalse("failed append must not recreate the removed generation", publishedFile.exists());
             assertEquals("failure must precede sealing the stalled roll",
                     stalledWritePositionBefore, ((StoreAppender) stalledWriter).store.writePosition());
@@ -180,7 +215,8 @@ public class StoreAppenderTest extends QueueTestCommon {
             // appender when its target is the published maximum.
             final IllegalStateException failure = assertThrows(IllegalStateException.class,
                     () -> unusedAppender.writeBytes(Bytes.from("must-fail")));
-            assertTrue(failure.getMessage().contains("Highest/current roll 1 disappeared"));
+            assertTrue(failure.toString(),
+                    failure.getMessage().contains("Highest/current roll 1 disappeared"));
             assertFalse("failed append must not recreate the removed generation", publishedFile.exists());
         }
     }
@@ -654,6 +690,973 @@ public class StoreAppenderTest extends QueueTestCommon {
     }
 
     @Test
+    public void exactRecoveryRejectsLegacyUnpaddedStore() throws Exception {
+        ignoreException("reading control code as text");
+        ignoreException("Unable to copy TimedStoreRecovery safely");
+        ignoreException("Unexpected field lastAcknowledgedIndexReplicated");
+
+        final File directory = queueDirectory.newFolder("legacy-unpadded");
+        final Path source = Paths.get(StoreAppenderTest.class
+                .getResource("/tr2/20170320.cq4").toURI());
+        final Path legacyFile = directory.toPath().resolve(source.getFileName());
+        Files.copy(source, legacyFile, StandardCopyOption.REPLACE_EXISTING);
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            final int legacyCycle = queue.lastCycle();
+            final long requestedIndex = queue.rollCycle().toIndex(legacyCycle, 0);
+            try (SingleChronicleQueueStore store =
+                         queue.storeForCycle(legacyCycle, queue.epoch(), false, null)) {
+                assertEquals("test fixture must be a legacy unpadded store", 0, store.dataVersion());
+            }
+
+            final UnsupportedOperationException failure = org.junit.Assert.assertThrows(
+                    UnsupportedOperationException.class,
+                    () -> ((InternalAppender) appender).writeBytes(
+                            requestedIndex, Bytes.from("must-not-be-written")));
+
+            assertTrue(failure.getMessage().contains("legacy unpadded queue stores"));
+        }
+    }
+
+    @Test
+    public void crossCycleExactRecoveryRejectsLegacyTargetBeforeRollover() throws Exception {
+        ignoreException("reading control code as text");
+        ignoreException("Unable to copy TimedStoreRecovery safely");
+        ignoreException("Unexpected field lastAcknowledgedIndexReplicated");
+
+        final File directory = queueDirectory.newFolder("legacy-target");
+        final Path source = Paths.get(StoreAppenderTest.class
+                .getResource("/tr2/20170320.cq4").toURI());
+        Files.copy(source, directory.toPath().resolve(source.getFileName()),
+                StandardCopyOption.REPLACE_EXISTING);
+
+        final int legacyCycle;
+        final long nextCycleTime;
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .testBlockSize()
+                .build()) {
+            legacyCycle = queue.lastCycle();
+            nextCycleTime = queue.epoch()
+                    + ((long) legacyCycle + 1) * queue.rollCycle().lengthInMillis();
+        }
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> nextCycleTime)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeText("padded current roll");
+            final int currentCycle = appender.cycle();
+            assertTrue(currentCycle > legacyCycle);
+            assertFalse(hasEOF(queue, currentCycle));
+
+            final long legacyIndex = queue.rollCycle().toIndex(legacyCycle, 0);
+            final UnsupportedOperationException failure = org.junit.Assert.assertThrows(
+                    UnsupportedOperationException.class,
+                    () -> ((InternalAppender) appender).writeBytes(
+                            legacyIndex, Bytes.from("must-not-be-written")));
+
+            assertTrue(failure.getMessage().contains("legacy unpadded queue stores"));
+            assertEquals("rejection must not move the appender", currentCycle, appender.cycle());
+            assertFalse("rejection must not seal the current roll", hasEOF(queue, currentCycle));
+        }
+    }
+
+    @Test
+    public void writeEofReplacementUsesStorePadding() throws IOException {
+        final Bytes<?> unavailableBytes = Bytes.allocateElasticOnHeap();
+        final Wire unavailableWire = WireType.BINARY.apply(unavailableBytes);
+        unavailableBytes.releaseLast();
+
+        try (MappedBytes mappedBytes = MappedBytes.mappedBytes(queueDirectory.newFile(), 64 << 10);
+             PaddingRecordingStore store = new PaddingRecordingStore(mappedBytes)) {
+            assertTrue(store.writeEOF(unavailableWire, 1));
+            assertTrue("replacement Wire must inherit the padded store format",
+                    store.replacementUsesPadding);
+        }
+    }
+
+    @Test
+    public void exactRecoveryRejectsUnsupportedSequenceBeforeCreatingRoll() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            final long unsupportedIndex = queue.rollCycle().toIndex(
+                    0, queue.rollCycle().maxMessagesPerCycle());
+
+            final IllegalArgumentException rejection = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+                    () -> ((InternalAppender) appender).writeBytes(
+                            unsupportedIndex, Bytes.from("unsupported")));
+            assertTrue(rejection.getMessage(), rejection.getMessage().contains("maxMessagesPerCycle"));
+
+            assertEquals("unsupported exact recovery must not commit a payload", 0, queue.entryCount());
+            assertEquals("unsupported exact recovery must not create a roll", 0, countQueueFiles(directory));
+        }
+    }
+
+    @Test
+    public void ordinaryAppenderRollsForwardAfterHistoricalIndexedRecovery() throws IOException {
+        final AtomicLong clock = new AtomicLong(System.currentTimeMillis());
+        clock.addAndGet(-clock.get() % ONE_DAY);
+        final Bytes<?> result = Bytes.elasticHeapByteBuffer();
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder())
+                .timeProvider(clock::get)
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender();
+             ExcerptAppender secondAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("initial"));
+
+            final int sealedCycle = appender.cycle();
+            final long recoveredIndex = appender.lastIndexAppended() + 1;
+            sealCurrentCycle(appender);
+
+            expectException("queue=" + queue.fileAbsolutePath() + ", cycle=" + sealedCycle
+                    + ", index=0x" + Long.toHexString(recoveredIndex));
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("recovered"));
+            assertEquals("exact-index recovery belongs to the sealed cycle",
+                    sealedCycle, appender.cycle());
+            assertFalse("the recovered cycle stays open for the rest of the backfill",
+                    hasEOF(queue, sealedCycle));
+            clock.addAndGet(ONE_DAY);
+            appender.normaliseEOFs();
+
+            appender.writeBytes(Bytes.from("following ordinary entry"));
+            assertEquals("ordinary append must roll past completion's restored EOF",
+                    sealedCycle + 1, appender.cycle());
+            final long firstIndexInNewCycle = appender.lastIndexAppended();
+
+            final long laterRecoveredIndex = recoveredIndex + 1;
+            expectException("queue=" + queue.fileAbsolutePath() + ", cycle=" + sealedCycle
+                    + ", index=0x" + Long.toHexString(laterRecoveredIndex));
+            ((InternalAppender) appender).writeBytes(laterRecoveredIndex, Bytes.from("later recovered"));
+            assertFalse(hasEOF(queue, sealedCycle));
+            appender.normaliseEOFs();
+
+            secondAppender.writeBytes(Bytes.from("second appender entry"));
+            assertEquals("the appender created before the roll must join the latest cycle",
+                    sealedCycle + 1, secondAppender.cycle());
+            assertEquals("the second appender must follow the existing new-cycle entry",
+                    firstIndexInNewCycle + 1, secondAppender.lastIndexAppended());
+
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                assertNextBytes(tailer, result, "initial");
+                assertNextBytes(tailer, result, "recovered");
+                assertNextBytes(tailer, result, "later recovered");
+                assertNextBytes(tailer, result, "following ordinary entry");
+                assertNextBytes(tailer, result, "second appender entry");
+            }
+        }
+    }
+
+    @Test
+    public void exactWriteAdoptsReadyFirstRecordRetryBeforeWritingNext() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final long firstIndex;
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("first"));
+            firstIndex = appender.lastIndexAppended();
+
+            // Simulate termination after publishing the ready data header but before publishing
+            // the store write position. Sequence zero uses zero as its write-position sentinel.
+            forceWritePosition(appender.store, 0);
+        }
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender();
+             ExcerptTailer tailer = queue.createTailer()) {
+            ((InternalAppender) appender).writeBytes(firstIndex, Bytes.from("retry-not-overwrite"));
+            assertEquals(firstIndex, appender.lastIndexAppended());
+            assertEquals(1, queue.entryCount());
+
+            ((InternalAppender) appender).writeBytes(firstIndex + 1, Bytes.from("second"));
+            assertEquals(firstIndex + 1, appender.lastIndexAppended());
+            assertEquals(2, queue.entryCount());
+
+            final Bytes<?> result = Bytes.elasticHeapByteBuffer();
+            assertNextBytes(tailer, result, "first");
+            assertNextBytes(tailer, result, "second");
+            assertFalse(tailer.readBytes(result.clear()));
+        }
+    }
+
+    @Test
+    public void exactPreflightScansPublishedBoundaryWhenEncodedSequenceWasLost() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("first"));
+            final long secondIndex = appender.lastIndexAppended() + 1;
+            clearEncodedSequence(appender.store);
+
+            ((InternalAppender) appender).writeBytes(secondIndex, Bytes.from("second"));
+
+            assertEquals(secondIndex, appender.lastIndexAppended());
+            assertQueueContents(queue, secondIndex - 1, "first", "second");
+        }
+    }
+
+    @Test
+    public void exactPreflightRejectsStaleAliasingEncodedSequence() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(ALIASING_POSITION_ROLL_CYCLE)
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.wrapForRead(new byte[(1 << 16) - SPB_HEADER_SIZE]));
+            final long firstPosition = appender.store.writePosition();
+            final TwoLongValue writePositionAndSequence = writePositionAndSequence(appender.store);
+            final long encodedFirstSequence = writePositionAndSequence.getVolatileValue2();
+
+            appender.writeBytes(Bytes.from("second"));
+            final long secondPosition = appender.store.writePosition();
+            assertEquals("test positions must alias in the paired encoding",
+                    1L << 16, secondPosition - firstPosition);
+            writePositionAndSequence.setValue2(encodedFirstSequence);
+            assertEquals("the stale pair must falsely identify the later position as sequence zero",
+                    0, new RollCycleEncodeSequence(writePositionAndSequence,
+                            ALIASING_POSITION_ROLL_CYCLE.defaultIndexCount(),
+                            ALIASING_POSITION_ROLL_CYCLE.defaultIndexSpacing()).getSequence(secondPosition));
+
+            final long sparseIndexBefore = appender.store.indexing.nextEntryToBeIndexed();
+            try (MappedBytes bytes = appender.store.bytes()) {
+                final Wire preflightWire = queue.wireType().apply(bytes);
+                preflightWire.usePadding(appender.store.dataVersion() > 0);
+                assertEquals("full-position preflight must recover the true published sequence",
+                        1, appender.store.lastPublishedSequenceNumber(preflightWire));
+            }
+            assertEquals("read-only preflight must retain the stale pair",
+                    encodedFirstSequence, writePositionAndSequence.getVolatileValue2());
+            assertEquals("read-only preflight must not repair the sparse index",
+                    sparseIndexBefore, appender.store.indexing.nextEntryToBeIndexed());
+
+            final long thirdIndex = ALIASING_POSITION_ROLL_CYCLE.toIndex(0, 2);
+            ((InternalAppender) appender).writeBytes(thirdIndex, Bytes.from("third"));
+
+            assertEquals(thirdIndex, appender.lastIndexAppended());
+            assertEquals(3, queue.entryCount());
+        }
+    }
+
+    @Test
+    public void restartScansCommittedRecordAfterSparseIndexPublicationWasLost() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final long lastCommittedIndex;
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            final int indexedSequence = queue.indexSpacing();
+            for (int i = 0; i <= indexedSequence; i++)
+                appender.writeBytes(Bytes.from("entry-" + i));
+            lastCommittedIndex = appender.lastIndexAppended();
+
+            // recordCommittedData publishes writePosition before the sparse index entry. Clearing
+            // that entry models a crash in that window without changing the committed record.
+            assertTrue(appender.store.writePosition() > 0);
+            appender.store.indexing.setPositionForSequenceNumber(
+                    appender, indexedSequence, 0);
+        }
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            assertEquals("restart must scan forward from the last published sparse index",
+                    lastCommittedIndex, queue.lastIndex());
+            ((InternalAppender) appender).writeBytes(
+                    lastCommittedIndex + 1, Bytes.from("after-crash"));
+            assertEquals(lastCommittedIndex + 1, queue.lastIndex());
+        }
+    }
+
+    @Test
+    public void eosOnlyRestartPreservesReadySequenceZeroBeforeOrdinaryAppend() throws IOException {
+        QueueSystemProperties.CHECK_INDEX = true;
+        final File directory = queueDirectory.newFolder();
+        final long firstIndex;
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("first"));
+            firstIndex = appender.lastIndexAppended();
+            forceWritePosition(appender.store, 0);
+        }
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST4_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+
+            // CQE may receive EOS without another exact-index event. Normalisation deliberately
+            // leaves the active cycle open; appender restart must still discover its ready record.
+            appender.normaliseEOFs();
+            appender.writeBytes(Bytes.from("second"));
+
+            assertEquals(firstIndex + 1, appender.lastIndexAppended());
+            assertQueueContents(queue, firstIndex, "first", "second");
+        }
+    }
+
+    @Test
+    public void historicalWriteAfterReadyInterruptedRecordNormalisesAtCompletion() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final SetTimeProvider time = new SetTimeProvider();
+        final long recoveredIndex;
+        final int recoveredCycle;
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time)
+                .rollCycle(TEST_HOURLY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("recovered"));
+            recoveredIndex = appender.lastIndexAppended();
+            recoveredCycle = appender.cycle();
+
+            // Simulate an already-advanced cursor, then a current-cycle sequence-zero recovery
+            // which publishes its ready header but crashes before its write position or EOF.
+            queue.tableStoreAcquire("normalisedEOFsTo", recoveredCycle + 1)
+                    .setValue(recoveredCycle + 1);
+            sealCurrentCycle(appender);
+            removeEndOfData(queue, recoveredCycle);
+            forceWritePosition(appender.store, 0);
+
+            assertTrue(queue.tableStoreGet("normalisedEOFsTo") > recoveredCycle);
+            assertFalse(hasEOF(queue, recoveredCycle));
+        }
+
+        time.advanceMillis(TimeUnit.MINUTES.toMillis(65));
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time)
+                .rollCycle(TEST_HOURLY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            ((InternalAppender) appender).writeBytes(recoveredIndex + 1, Bytes.from("following"));
+
+            assertTrue("adopting an interrupted ready record must lower the historical EOF cursor",
+                    queue.tableStoreGet("normalisedEOFsTo") <= recoveredCycle);
+            assertFalse("the adopted historical recovery stays open until completion",
+                    hasEOF(queue, recoveredCycle));
+            appender.normaliseEOFs();
+            assertTrue("completion must reseal the adopted historical recovery",
+                    hasEOF(queue, recoveredCycle));
+            assertQueueContents(queue, recoveredIndex, "recovered", "following");
+        }
+    }
+
+    @Test
+    public void futureExactWriteDoesNotAdvanceEofCursorAcrossTimestampCurrentCycle() throws IOException {
+        final SetTimeProvider time = new SetTimeProvider();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDirectory.newFolder())
+                .timeProvider(time)
+                .rollCycle(TEST_HOURLY)
+                .testBlockSize()
+                .build()) {
+            final int currentCycle;
+            try (ExcerptAppender writer = queue.createAppender()) {
+                writer.writeBytes(Bytes.from("timestamp-current"));
+                currentCycle = writer.cycle();
+            }
+            final int futureCycle = currentCycle + 2;
+
+            // A freshly created appender has released the store selected by its construction-time
+            // scan, so exact positioning reaches the private setWireIfNull normalization path.
+            try (ExcerptAppender freshAppender = queue.createAppender()) {
+                ((InternalAppender) freshAppender).writeBytes(
+                        queue.rollCycle().toIndex(futureCycle, 0), Bytes.from("future"));
+            }
+
+            assertTrue("positioning on a future cycle must not advance the EOF cursor past the "
+                            + "timestamp-current cycle",
+                    queue.tableStoreGet("normalisedEOFsTo") <= currentCycle);
+        }
+    }
+
+    @Test
+    public void backfillBelowRolledBackHighWaterIsNormalisedAtCompletion() throws IOException {
+        final SetTimeProvider time = new SetTimeProvider();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDirectory.newFolder())
+                .timeProvider(time)
+                .rollCycle(TEST_HOURLY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeBytes(Bytes.from("cycle-0"));
+            final long missingIndex = appender.lastIndexAppended() + 1;
+            final int recoveredCycle = queue.rollCycle().toCycle(missingIndex);
+
+            time.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("cycle-1"));
+            appender.normaliseEOFs();
+            assertTrue(hasEOF(queue, recoveredCycle));
+            assertTrue(queue.tableStoreGet("normalisedEOFsTo") > recoveredCycle);
+
+            time.advanceMillis(-TimeUnit.HOURS.toMillis(1));
+            assertEquals(recoveredCycle, queue.cycle());
+            removeEndOfData(queue, recoveredCycle);
+            ((InternalAppender) appender).writeBytes(missingIndex, Bytes.from("recovered"));
+            assertFalse("backfill remains open even below the published high-water",
+                    hasEOF(queue, recoveredCycle));
+            appender.normaliseEOFs();
+            assertTrue("completion uses the published high-water to seal the recovered cycle",
+                    hasEOF(queue, recoveredCycle));
+        }
+    }
+
+    @Test
+    public void dailyNonZeroEpochEnumeratesCycleZero() throws IOException {
+        assertNonZeroEpochCycleZero(TEST_DAILY, ONE_DAY);
+    }
+
+    @Test
+    public void hourlyNonZeroEpochEnumeratesCycleZero() throws IOException {
+        assertNonZeroEpochCycleZero(TEST_HOURLY, ONE_DAY);
+    }
+
+    @Test
+    public void weeklyNonZeroEpochEnumeratesCycleZero() throws IOException {
+        final long epoch = (long) RollCycles.WEEKLY.defaultEpoch()
+                + RollCycles.WEEKLY.lengthInMillis();
+        assertNonZeroEpochCycleZero(RollCycles.WEEKLY, epoch);
+    }
+
+    private void assertNonZeroEpochCycleZero(RollCycle rollCycle, long epoch) throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong(epoch);
+        final TreeSet<Long> cycleZero = new TreeSet<>(Arrays.asList(0L));
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .epoch(epoch)
+                .rollCycle(rollCycle)
+                .testBlockSize()
+                .build();
+             ExcerptAppender first = queue.createAppender()) {
+            first.writeText("first");
+            assertEquals(cycleZero, queue.listCyclesBetween(0, 0));
+
+            try (ExcerptAppender second = queue.createAppender()) {
+                second.normaliseEOFs();
+                second.writeText("second");
+                assertEquals(0, second.cycle());
+            }
+        }
+
+        try (SingleChronicleQueue reopened = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .epoch(epoch)
+                .rollCycle(rollCycle)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = reopened.createAppender()) {
+            assertEquals(cycleZero, reopened.listCyclesBetween(0, 0));
+            appender.normaliseEOFs();
+            appender.writeText("after restart");
+            assertEquals(0, appender.cycle());
+            assertEquals(3, reopened.entryCount());
+        }
+    }
+
+    @Test(timeout = 20_000)
+    public void sparseRollsAreTraversedByExistingCycle() throws IOException {
+        final int farCycle = 1_000_000;
+        final File directory = queueDirectory.newFolder();
+        final SetTimeProvider time = new SetTimeProvider();
+        final long recoveredIndex;
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time)
+                .rollCycle(TEST_HOURLY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeBytes(Bytes.from("cycle-zero"));
+            recoveredIndex = appender.lastIndexAppended() + 1;
+
+            time.currentTimeMillis((long) farCycle * TEST_HOURLY.lengthInMillis());
+            appender.writeBytes(Bytes.from("far-cycle"));
+            assertEquals(farCycle, appender.cycle());
+        }
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time)
+                .rollCycle(TEST_HOURLY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            expectException("queue=" + queue.fileAbsolutePath() + ", cycle=0, index=0x"
+                    + Long.toHexString(recoveredIndex));
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("backfilled"));
+            assertFalse(hasEOF(queue, 0));
+
+            appender.normaliseEOFs();
+
+            assertTrue(hasEOF(queue, 0));
+            assertEquals("completion must advance across the proven-empty sparse range",
+                    farCycle, queue.tableStoreGet("normalisedEOFsTo"));
+            final File[] rollFiles = directory.listFiles(
+                    ignored -> ignored.getName().endsWith(SingleChronicleQueue.SUFFIX));
+            assertEquals("normalisation must not create files for sparse gaps", 2,
+                    rollFiles == null ? 0 : rollFiles.length);
+        }
+    }
+
+    @Test
+    public void malformedPhysicalRollNameFailsNormalisationWithoutAdvancingCursor() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeText("cycle-zero");
+            time.set(TEST_DAILY.lengthInMillis());
+            appender.writeText("cycle-one");
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", 0);
+            cursor.setValue(0);
+
+            assertTrue(new File(directory, "not-a-roll" + SingleChronicleQueue.SUFFIX).createNewFile());
+            final IllegalStateException failure = assertThrows(
+                    IllegalStateException.class, appender::normaliseEOFs);
+
+            assertTrue("the physical filename parse failure must remain visible",
+                    containsCause(failure, DateTimeException.class));
+            assertEquals("failed enumeration must not advance completion", 0,
+                    cursor.getVolatileValue());
+        }
+    }
+
+    @Test
+    public void cachedCycleTreeDoesNotHideMalformedPhysicalRoll() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeText("cycle-zero");
+            time.set(TEST_DAILY.lengthInMillis());
+            appender.writeText("cycle-one");
+            assertEquals(2, queue.listCyclesBetween(0, 1).size());
+
+            final File malformed = new File(directory, "not-a-roll" + SingleChronicleQueue.SUFFIX);
+            assertTrue(malformed.createNewFile());
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", 0);
+            cursor.setValue(0);
+            final long currentWritePositionBefore = appender.store.writePosition();
+            final long historicalWritePositionBefore = writePosition(queue, 0);
+            final long listingModCountBefore = queue.tableStoreGet("listing.modCount");
+            final String[] cycleFileNamesBefore = cycleFileNames(directory);
+
+            final IllegalStateException failure = assertThrows(
+                    IllegalStateException.class, appender::normaliseEOFs);
+
+            assertTrue("the fresh scan must retain the filename parse failure",
+                    containsCause(failure, DateTimeException.class));
+            assertEquals(0, cursor.getVolatileValue());
+            assertEquals(currentWritePositionBefore, appender.store.writePosition());
+            assertEquals(historicalWritePositionBefore, writePosition(queue, 0));
+            assertEquals(listingModCountBefore, queue.tableStoreGet("listing.modCount"));
+            assertArrayEquals(cycleFileNamesBefore, cycleFileNames(directory));
+        }
+    }
+
+    @Test
+    public void duplicateLogicalCycleFilenameFailsNormalisationWithoutMutation() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final long epoch = java.time.Instant.parse("1970-01-02T00:00:00Z").toEpochMilli();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> epoch)
+                .epoch(epoch)
+                .rollCycle(TWO_DAY_DAILY_ROLL_CYCLE)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeText("canonical-cycle-zero");
+            assertTrue("test precondition: canonical cycle zero must exist", queue.cycleFileExists(0));
+            final File alias = new File(directory, "19700103T2D" + SingleChronicleQueue.SUFFIX);
+            assertTrue("test precondition: a second date must alias cycle zero", alias.createNewFile());
+
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", 0);
+            cursor.setValue(0);
+            final long writePositionBefore = appender.store.writePosition();
+            final int nextWordBefore = readWordAfterLastEntry(appender.store);
+            final long listingModCountBefore = queue.tableStoreGet("listing.modCount");
+            final String[] cycleFileNamesBefore = cycleFileNames(directory);
+
+            final IllegalStateException failure = assertThrows(
+                    IllegalStateException.class, appender::normaliseEOFs);
+
+            assertTrue("the non-canonical logical-cycle alias must remain visible",
+                    containsCause(failure, DateTimeException.class));
+            assertTrue(containsMessage(failure, "Non-canonical roll name 19700103T2D"));
+            assertTrue(containsMessage(failure, "cycle 0 is 19700102T2D"));
+            assertEquals(0, cursor.getVolatileValue());
+            assertEquals(writePositionBefore, appender.store.writePosition());
+            assertEquals(nextWordBefore, readWordAfterLastEntry(appender.store));
+            assertEquals(listingModCountBefore, queue.tableStoreGet("listing.modCount"));
+            assertArrayEquals(cycleFileNamesBefore, cycleFileNames(directory));
+        }
+    }
+
+    @Test
+    public void nonCanonicalWeeklyRollFailsNormalisationWithoutAdvancingCursor() throws IOException {
+        final Locale originalFormatLocale = Locale.getDefault(Locale.Category.FORMAT);
+        final long epoch = java.time.Instant.parse("2022-01-03T00:00:00Z").toEpochMilli();
+        try {
+            for (Locale locale : new Locale[]{Locale.US, Locale.UK}) {
+                Locale.setDefault(Locale.Category.FORMAT, locale);
+                final File directory = queueDirectory.newFolder();
+                try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                        .timeProvider(() -> epoch)
+                        .epoch(epoch)
+                        .rollCycle(RollCycles.WEEKLY)
+                        .testBlockSize()
+                        .build();
+                     ExcerptAppender excerptAppender = queue.createAppender()) {
+                    final StoreAppender appender = (StoreAppender) excerptAppender;
+                    appender.writeText("cycle-zero");
+                    final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", 0);
+                    cursor.setValue(0);
+                    assertTrue(new File(directory, "2021W53" + SingleChronicleQueue.SUFFIX).createNewFile());
+
+                    final IllegalStateException failure = assertThrows(
+                            IllegalStateException.class, appender::normaliseEOFs);
+
+                    assertTrue(locale + " non-canonical week must remain visible",
+                            containsCause(failure, DateTimeException.class));
+                    assertEquals("failed weekly enumeration must not advance completion",
+                            0, cursor.getVolatileValue());
+                }
+            }
+        } finally {
+            Locale.setDefault(Locale.Category.FORMAT, originalFormatLocale);
+        }
+    }
+
+    @Test
+    public void corruptedEofNormalisationCursorFailsBeforeMutation() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeText("cycle-zero");
+            final int historicalCycle = appender.cycle();
+            time.set(TEST_DAILY.lengthInMillis());
+            appender.writeText("cycle-one");
+            removeEndOfData(queue, historicalCycle);
+
+            final long corruptCursor = 0x1_0000_0005L;
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", historicalCycle);
+            cursor.setValue(corruptCursor);
+            final long writePositionBefore = appender.store.writePosition();
+            final long historicalWritePositionBefore = writePosition(queue, historicalCycle);
+            final long listingModCountBefore = queue.tableStoreGet("listing.modCount");
+            final String[] cycleFileNamesBefore = cycleFileNames(directory);
+
+            final IllegalStateException failure = assertThrows(
+                    IllegalStateException.class, appender::normaliseEOFs);
+
+            assertTrue(failure.getMessage().contains("Invalid EOF normalisation cycle"));
+            assertEquals(corruptCursor, cursor.getVolatileValue());
+            assertFalse("an invalid cursor must not reseal a historical roll",
+                    hasEOF(queue, historicalCycle));
+            assertEquals(writePositionBefore, appender.store.writePosition());
+            assertEquals(historicalWritePositionBefore, writePosition(queue, historicalCycle));
+            assertEquals(listingModCountBefore, queue.tableStoreGet("listing.modCount"));
+            assertArrayEquals(cycleFileNamesBefore, cycleFileNames(directory));
+        }
+    }
+
+    @Test
+    public void generationDisappearingAfterEnumerationDoesNotAdvanceCursor() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong();
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeText("cycle-zero");
+            time.set(TEST_DAILY.lengthInMillis());
+            appender.writeText("cycle-one");
+            final File cycleOneFile = appender.currentFile();
+            time.set(2L * TEST_DAILY.lengthInMillis());
+            appender.writeText("cycle-two");
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", 0);
+            cursor.setValue(0);
+
+            final IllegalStateException failure = assertThrows(
+                    IllegalStateException.class, () -> appender.normaliseEOFs(() ->
+                            assertTrue("test precondition: cycle one must be removed", cycleOneFile.delete())));
+
+            assertTrue(failure.getMessage().contains("Roll generation disappeared"));
+            assertEquals("a vanished generation must abort before cursor publication", 0,
+                    cursor.getVolatileValue());
+        }
+    }
+
+    @Test
+    public void currentMappedGenerationDisappearingAfterEnumerationDoesNotAdvanceCursor() throws IOException {
+        assumeFalse("Windows cannot unlink the appender's open mapping", OS.isWindows());
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong time = new AtomicLong();
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time::get)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("cycle-zero"));
+            final long recoveredIndex = appender.lastIndexAppended() + 1;
+            time.set(TEST_DAILY.lengthInMillis());
+            appender.writeBytes(Bytes.from("cycle-one"));
+            expectException("queue=" + queue.fileAbsolutePath() + ", cycle=0, index=0x"
+                    + Long.toHexString(recoveredIndex));
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("recovered-cycle-zero"));
+            assertEquals("test precondition: recovery must retain the historical mapping", 0, appender.cycle());
+            assertFalse("test precondition: recovered history remains open", hasEOF(queue, 0));
+
+            final File mappedHistoricalFile = appender.currentFile();
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", 0);
+            final long cursorBefore = cursor.getVolatileValue();
+            final long writePositionBefore = appender.store.writePosition();
+            final int nextWordBefore = readWordAfterLastEntry(appender.store);
+            final long headerNumberBefore = appender.wire().headerNumber();
+            final long lastIndexBefore = appender.lastIndexAppended();
+            final long listingModCountBefore = queue.tableStoreGet("listing.modCount");
+
+            final IllegalStateException failure = assertThrows(
+                    IllegalStateException.class, () -> appender.normaliseEOFs(() -> assertTrue(
+                            "test precondition: mapped history must be unlinked", mappedHistoricalFile.delete())));
+
+            assertTrue(failure.getMessage().contains("Roll generation disappeared"));
+            assertFalse(mappedHistoricalFile.exists());
+            assertEquals(cursorBefore, cursor.getVolatileValue());
+            assertEquals(writePositionBefore, appender.store.writePosition());
+            assertEquals(nextWordBefore, readWordAfterLastEntry(appender.store));
+            assertEquals(0, appender.cycle());
+            assertEquals(headerNumberBefore, appender.wire().headerNumber());
+            assertEquals(lastIndexBefore, appender.lastIndexAppended());
+            assertEquals(listingModCountBefore, queue.tableStoreGet("listing.modCount"));
+        }
+    }
+
+    @Test
+    public void refreshedEmptyPhysicalRangeFailsClosed() {
+        final IllegalStateException initialFailure = new IllegalStateException("stale initial bounds");
+        final StoreAppender.ExistingCycles empty = new StoreAppender.ExistingCycles(
+                UNSET_CONTEXT, UNSET_CONTEXT, new TreeSet<>());
+
+        final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                () -> StoreAppender.requireConsistentRefreshedRange(
+                        true, empty, "test-queue", initialFailure));
+
+        assertTrue(failure.getMessage().contains("remained inconsistent"));
+        assertEquals(initialFailure, failure.getSuppressed()[0]);
+    }
+
+    @Test(timeout = 20_000)
+    public void restartRetriesIncompleteHistoricalRecoveryAndNormalisesEof()
+            throws IOException, InterruptedException {
+        QueueSystemProperties.CHECK_INDEX = false;
+        final File directory = queueDirectory.newFolder();
+        final Process failedRecovery = JavaProcessBuilder.create(CrashDuringHistoricalRecovery.class)
+                .withProgramArguments(directory.getAbsolutePath())
+                .start();
+        assertTrue("recovery process did not exit",
+                failedRecovery.waitFor(10, TimeUnit.SECONDS));
+        assertEquals("child must stop without closing its Queue",
+                CrashDuringHistoricalRecovery.EXIT_CODE, failedRecovery.exitValue());
+
+        final SetTimeProvider time = new SetTimeProvider();
+        time.currentTimeMillis(TEST_HOURLY.lengthInMillis());
+        final long missingIndex = TEST_HOURLY.toIndex(0, 1);
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time)
+                .rollCycle(TEST_HOURLY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            expectException("Exact-index recovery replaced incomplete header");
+            ((InternalAppender) appender).writeBytes(missingIndex, Bytes.from("recovered-after-restart"));
+
+            assertFalse("the successful historical retry must stay open until completion",
+                    hasEOF(queue, 0));
+            appender.normaliseEOFs();
+            assertTrue("completion must restore every historical EOF",
+                    hasEOF(queue, 0));
+
+            assertEquals(3, queue.entryCount());
+            final Bytes<?> result = Bytes.elasticHeapByteBuffer();
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                assertNextBytes(tailer, result, "first");
+                assertNextBytes(tailer, result, "recovered-after-restart");
+                assertNextBytes(tailer, result, "current-cycle");
+                assertFalse(tailer.readBytes(result.clear()));
+            }
+        }
+    }
+
+    @Test(timeout = 20_000)
+    public void restartPublishesReadyRecordLeftBeyondWritePosition()
+            throws IOException, InterruptedException {
+        QueueSystemProperties.CHECK_INDEX = false;
+        final File directory = queueDirectory.newFolder();
+        final Process interruptedPublisher = JavaProcessBuilder.create(CrashAfterReadyHeader.class)
+                .withProgramArguments(directory.getAbsolutePath())
+                .start();
+        assertTrue("publisher process did not exit",
+                interruptedPublisher.waitFor(10, TimeUnit.SECONDS));
+        assertEquals("child must stop before publishing its write position",
+                CrashAfterReadyHeader.EXIT_CODE, interruptedPublisher.exitValue());
+
+        final long firstIndex = TEST_HOURLY.toIndex(0, 0);
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST_HOURLY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender appender = queue.createAppender()) {
+            assertEquals("the physical scan must retain the ready first-writer record",
+                    firstIndex + 1, queue.lastIndex());
+            ((InternalAppender) appender).writeBytes(firstIndex + 2, Bytes.from("third"));
+            assertQueueContents(queue, firstIndex, "first", "second", "third");
+        }
+    }
+
+    public static final class CrashDuringHistoricalRecovery {
+        private static final int EXIT_CODE = 17;
+
+        public static void main(String[] args) {
+            QueueSystemProperties.CHECK_INDEX = false;
+            final SetTimeProvider time = new SetTimeProvider();
+            try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(new File(args[0]))
+                    .timeProvider(time)
+                    .rollCycle(TEST_HOURLY)
+                    .testBlockSize()
+                    .build()) {
+                final ExcerptAppender appender = queue.createAppender();
+                appender.writeBytes(Bytes.from("first"));
+                time.currentTimeMillis(TEST_HOURLY.lengthInMillis());
+                appender.writeBytes(Bytes.from("current-cycle"));
+
+                // Persist the same state produced by termination after the shared lower bound,
+                // EOF CAS and a partial payload, but before the data header and EOF are committed.
+                queue.tableStoreAcquire("normalisedEOFsTo", 0).setValue(0);
+                leaveIncompleteRecordAtEof(queue, 0, Bytes.from("partial"));
+                Runtime.getRuntime().halt(EXIT_CODE);
+            }
+        }
+    }
+
+    public static final class CrashAfterReadyHeader {
+        private static final int EXIT_CODE = 18;
+
+        public static void main(String[] args) {
+            QueueSystemProperties.CHECK_INDEX = false;
+            try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(new File(args[0]))
+                    .timeProvider(() -> 0)
+                    .rollCycle(TEST_HOURLY)
+                    .testBlockSize()
+                    .build();
+                 ExcerptAppender appender = queue.createAppender()) {
+                appender.writeBytes(Bytes.from("first"));
+                commitRecordWithoutPublishing(queue, 0, Bytes.from("second"));
+                Runtime.getRuntime().halt(EXIT_CODE);
+            }
+        }
+    }
+
+    @Test
+    public void eofRestorationFailureIsNotReportedAsSuccess() throws IOException {
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder()).build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("current unsealed cycle"));
+            final SingleChronicleQueueStore realStore = appender.store;
+
+            try (MappedBytes fakeBytes = MappedBytes.mappedBytes(queueDirectory.newFile(), 64 << 10);
+                 SingleChronicleQueueStore failingStore = new FailingEofStore(fakeBytes)) {
+                appender.store = failingStore;
+                queue.writeLock().lock();
+                try {
+                    final IllegalStateException failure = org.junit.Assert.assertThrows(
+                            IllegalStateException.class,
+                            () -> appender.ensureEndOfData("simulated EOF restoration failure"));
+                    assertEquals("simulated EOF restoration failure", failure.getMessage());
+                } finally {
+                    queue.writeLock().unlock();
+                }
+            } finally {
+                appender.store = realStore;
+            }
+        }
+    }
+
+    @Test
     public void eofAdvanceRejectsCycleOverflowBeforeMutation() throws IOException {
         final long clock = (long) Integer.MAX_VALUE * TEST_DAILY.lengthInMillis();
         final File directory = queueDirectory.newFolder();
@@ -687,6 +1690,57 @@ public class StoreAppenderTest extends QueueTestCommon {
         }
     }
 
+    @Test
+    public void exactEofRecoveryAtMaximumCycleIsRejectedBeforeMutation() throws IOException {
+        final long clock = (long) Integer.MAX_VALUE * TEST_DAILY.lengthInMillis();
+        final File directory = queueDirectory.newFolder();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> clock)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            final long lastSupportedSequence = TEST_DAILY.maxMessagesPerCycle() - 1;
+            for (long sequence = 0; sequence < lastSupportedSequence; sequence++)
+                appender.writeText("entry-" + sequence);
+            assertEquals(Integer.MAX_VALUE, appender.cycle());
+            assertEquals(lastSupportedSequence - 1,
+                    queue.rollCycle().toSequenceNumber(appender.lastIndexAppended()));
+            sealCurrentCycle(appender);
+
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", Integer.MAX_VALUE);
+            final long writePositionBefore = appender.store.writePosition();
+            final long cursorBefore = cursor.getVolatileValue();
+            final long headerNumberBefore = appender.wire().headerNumber();
+            final long lastIndexBefore = appender.lastIndexAppended();
+            final long listingModCountBefore = queue.tableStoreGet("listing.modCount");
+            final String[] cycleFileNamesBefore = cycleFileNames(directory);
+            final long lastSupportedIndex = queue.rollCycle().toIndex(
+                    Integer.MAX_VALUE, lastSupportedSequence);
+
+            final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> ((InternalAppender) appender).writeBytes(
+                            lastSupportedIndex, Bytes.from("must remain sealed")));
+
+            assertTrue(failure.getMessage().contains("Cannot reopen end-of-data in the final UInt31 cycle"));
+            assertEquals(writePositionBefore, appender.store.writePosition());
+            assertEquals(cursorBefore, cursor.getVolatileValue());
+            assertEquals(headerNumberBefore, appender.wire().headerNumber());
+            assertEquals(lastIndexBefore, appender.lastIndexAppended());
+            assertEquals(listingModCountBefore, queue.tableStoreGet("listing.modCount"));
+            assertArrayEquals(cycleFileNamesBefore, cycleFileNames(directory));
+            assertEquals(END_OF_DATA, readWordAfterLastEntry(appender.store));
+
+            appender.normaliseEOFs();
+            assertEquals("completion must retain the final cycle's existing seal",
+                    END_OF_DATA, readWordAfterLastEntry(appender.store));
+            assertEquals(Integer.MAX_VALUE, queue.firstCycle());
+            assertEquals(Integer.MAX_VALUE, queue.lastCycle());
+            assertArrayEquals(cycleFileNamesBefore, cycleFileNames(directory));
+        }
+    }
+
     private static String[] cycleFileNames(File directory) {
         final String[] names = directory.list((ignored, name) -> name.endsWith(SingleChronicleQueue.SUFFIX));
         assertNotNull(names);
@@ -702,6 +1756,410 @@ public class StoreAppenderTest extends QueueTestCommon {
             if (store.dataVersion() > 0)
                 nextHeaderPosition += BytesUtil.padOffset(nextHeaderPosition);
             return bytes.readVolatileInt(nextHeaderPosition);
+        }
+    }
+
+    private static long writePosition(SingleChronicleQueue queue, int cycle) {
+        try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, queue.epoch(), false, null)) {
+            assertNotNull(store);
+            return store.writePosition();
+        }
+    }
+
+    @Test
+    public void exactRecoveryFailsIfTheEofMarkerChangesBeforeCas() {
+        final Bytes<?> bytes = Bytes.allocateElasticDirect();
+        try {
+            bytes.writeInt(0, Wires.NOT_INITIALIZED);
+
+            final IllegalStateException changed = org.junit.Assert.assertThrows(
+                    IllegalStateException.class,
+                    () -> StoreAppender.replaceEndOfDataMarkerForRecovery(bytes, 0));
+
+            assertEquals("End-of-data changed while starting exact-index recovery at 0",
+                    changed.getMessage());
+            assertEquals("failed CAS must not change the word", Wires.NOT_INITIALIZED,
+                    bytes.readVolatileInt(0));
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    private static void assertNextBytes(ExcerptTailer tailer, Bytes<?> result, String expected) {
+        result.clear();
+        assertTrue(tailer.readBytes(result));
+        assertEquals(expected, result.toString());
+    }
+
+    private static void commitRecordWithoutPublishing(SingleChronicleQueue queue,
+                                                       int cycle,
+                                                       Bytes<?> payload) {
+        try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, 0, false, null);
+             MappedBytes bytes = store.bytes()) {
+            long position = store.writePosition();
+            position += lengthOf(bytes.readVolatileInt(position)) + SPB_HEADER_SIZE;
+            for (; ; ) {
+                position += BytesUtil.padOffset(position);
+                final int header = bytes.readVolatileInt(position);
+                if (header == NOT_INITIALIZED)
+                    break;
+                assertTrue("expected metadata before the free slot at " + position,
+                        isReadyMetaData(header));
+                position += SPB_HEADER_SIZE + lengthOf(header);
+            }
+            final long length = payload.readRemaining();
+            bytes.write(position + SPB_HEADER_SIZE, payload, payload.readPosition(), length);
+            bytes.writeOrderedInt(position, (int) length);
+            assertTrue(isReadyData(bytes.readVolatileInt(position)));
+        }
+    }
+
+    private static void assertQueueContents(SingleChronicleQueue queue,
+                                            long firstIndex,
+                                            String... expected) {
+        assertEquals(expected.length, queue.entryCount());
+        final Bytes<?> result = Bytes.elasticHeapByteBuffer();
+        try (ExcerptTailer tailer = queue.createTailer()) {
+            for (int i = 0; i < expected.length; i++) {
+                assertTrue("sequential read of entry " + i, tailer.readBytes(result.clear()));
+                assertEquals(expected[i], result.toString());
+                assertEquals(firstIndex + i + 1, tailer.index());
+            }
+            assertFalse(tailer.readBytes(result.clear()));
+        }
+        for (int i = 0; i < expected.length; i++) {
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                assertTrue("moveToIndex " + i, tailer.moveToIndex(firstIndex + i));
+                assertTrue(tailer.readBytes(result.clear()));
+                assertEquals(expected[i], result.toString());
+            }
+        }
+    }
+
+    @Test
+    public void sameCycleGapDoesNotPublishReadyCrashRecord() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("published"));
+            final int cycle = appender.cycle();
+            commitRecordWithoutPublishing(queue, cycle, Bytes.from("ready but unpublished"));
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", cycle);
+
+            final long writePositionBefore = appender.store.writePosition();
+            final long nextIndexedSequenceBefore = appender.store.indexing.nextEntryToBeIndexed();
+            final long cursorBefore = cursor.getVolatileValue();
+            final long headerNumberBefore = appender.wire().headerNumber();
+            final long lastIndexBefore = appender.lastIndexAppended();
+            final long listingModCountBefore = queue.tableStoreGet("listing.modCount");
+            final String[] cycleFileNamesBefore = cycleFileNames(directory);
+            final long gapIndex = queue.rollCycle().toIndex(cycle, 3);
+
+            assertThrows(IllegalIndexException.class,
+                    () -> ((InternalAppender) appender).writeBytes(gapIndex, Bytes.from("gap")));
+
+            assertEquals(writePositionBefore, appender.store.writePosition());
+            assertEquals(nextIndexedSequenceBefore, appender.store.indexing.nextEntryToBeIndexed());
+            assertEquals(cursorBefore, cursor.getVolatileValue());
+            assertEquals(cycle, appender.cycle());
+            assertEquals(headerNumberBefore, appender.wire().headerNumber());
+            assertEquals(lastIndexBefore, appender.lastIndexAppended());
+            assertEquals(listingModCountBefore, queue.tableStoreGet("listing.modCount"));
+            assertArrayEquals(cycleFileNamesBefore, cycleFileNames(directory));
+        }
+    }
+
+    @Test
+    public void publishedDuplicateDoesNotAdoptLaterReadyCrashRecord() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("published"));
+            final long publishedIndex = appender.lastIndexAppended();
+            commitRecordWithoutPublishing(queue, appender.cycle(), Bytes.from("later ready record"));
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", appender.cycle());
+
+            final long writePositionBefore = appender.store.writePosition();
+            final long nextIndexedSequenceBefore = appender.store.indexing.nextEntryToBeIndexed();
+            final long cursorBefore = cursor.getVolatileValue();
+            final long headerNumberBefore = appender.wire().headerNumber();
+
+            expectException("Exact-index duplicate differs from published content and was ignored");
+            ((InternalAppender) appender).writeBytes(publishedIndex, Bytes.from("ignored duplicate"));
+
+            assertEquals(writePositionBefore, appender.store.writePosition());
+            assertEquals(nextIndexedSequenceBefore, appender.store.indexing.nextEntryToBeIndexed());
+            assertEquals(cursorBefore, cursor.getVolatileValue());
+            assertEquals(headerNumberBefore, appender.wire().headerNumber());
+            assertEquals(publishedIndex, appender.lastIndexAppended());
+        }
+    }
+
+    @Test
+    public void exactWriteDoesNotRecreateDeletedPublishedMaximum() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong stalledTime = new AtomicLong();
+        final AtomicLong publishingTime = new AtomicLong(TEST_DAILY.lengthInMillis());
+        try (SingleChronicleQueue stalledQueue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(stalledTime::get)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = stalledQueue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("cycle-zero"));
+
+            final File publishedFile;
+            try (SingleChronicleQueue publishingQueue = SingleChronicleQueueBuilder.binary(directory)
+                    .timeProvider(publishingTime::get)
+                    .rollCycle(TEST_DAILY)
+                    .testBlockSize()
+                    .build();
+                 SingleChronicleQueueStore publishedStore = publishingQueue.storeForCycle(
+                         1, publishingQueue.epoch(), true, null)) {
+                assertNotNull(publishedStore);
+                publishedFile = publishedStore.file();
+            }
+            BackgroundResourceReleaser.releasePendingResources();
+            assertEquals(1, stalledQueue.lastPublishedCycle());
+            assertTrue("test precondition: published maximum must be deleted", publishedFile.delete());
+
+            final LongValue cursor = stalledQueue.tableStoreAcquire("normalisedEOFsTo", 0);
+            final long sourceWritePositionBefore = appender.store.writePosition();
+            final int sourceNextWordBefore = readWordAfterLastEntry(appender.store);
+            final long cursorBefore = cursor.getVolatileValue();
+            final long headerNumberBefore = appender.wire().headerNumber();
+            final long lastIndexBefore = appender.lastIndexAppended();
+            final long listingModCountBefore = stalledQueue.tableStoreGet("listing.modCount");
+            final String[] cycleFileNamesBefore = cycleFileNames(directory);
+            final long missingIndex = stalledQueue.rollCycle().toIndex(1, 0);
+
+            final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> ((InternalAppender) appender).writeBytes(missingIndex, Bytes.from("must-fail")));
+
+            assertTrue(failure.getMessage().contains("Highest/current roll 1 disappeared"));
+            assertFalse("the exact request must not recreate the authoritative roll", publishedFile.exists());
+            assertEquals(sourceWritePositionBefore, appender.store.writePosition());
+            assertEquals(sourceNextWordBefore, readWordAfterLastEntry(appender.store));
+            assertEquals(cursorBefore, cursor.getVolatileValue());
+            assertEquals(0, appender.cycle());
+            assertEquals(headerNumberBefore, appender.wire().headerNumber());
+            assertEquals(lastIndexBefore, appender.lastIndexAppended());
+            assertEquals(1, stalledQueue.lastPublishedCycle());
+            assertEquals(listingModCountBefore, stalledQueue.tableStoreGet("listing.modCount"));
+            assertArrayEquals(cycleFileNamesBefore, cycleFileNames(directory));
+        }
+    }
+
+    @Test
+    public void exactWriteRejectsAbsentCycleWithinPublishedRange() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("cycle-zero"));
+            try (SingleChronicleQueue publisher = SingleChronicleQueueBuilder.binary(directory)
+                    .timeProvider(() -> 2L * TEST_DAILY.lengthInMillis())
+                    .rollCycle(TEST_DAILY)
+                    .testBlockSize()
+                    .build();
+                 SingleChronicleQueueStore publishedStore = publisher.storeForCycle(
+                         2, publisher.epoch(), true, null)) {
+                assertNotNull(publishedStore);
+            }
+            BackgroundResourceReleaser.releasePendingResources();
+            assertEquals(2, queue.lastPublishedCycle());
+            assertFalse("test precondition: the interior cycle must be absent", queue.cycleFileExists(1));
+
+            final LongValue cursor = queue.tableStoreAcquire("normalisedEOFsTo", 0);
+            final long sourceWritePositionBefore = appender.store.writePosition();
+            final int sourceNextWordBefore = readWordAfterLastEntry(appender.store);
+            final long cursorBefore = cursor.getVolatileValue();
+            final long headerNumberBefore = appender.wire().headerNumber();
+            final long lastIndexBefore = appender.lastIndexAppended();
+            final long listingModCountBefore = queue.tableStoreGet("listing.modCount");
+            final String[] cycleFileNamesBefore = cycleFileNames(directory);
+            final long missingInteriorIndex = queue.rollCycle().toIndex(1, 0);
+
+            final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> ((InternalAppender) appender).writeBytes(
+                            missingInteriorIndex, Bytes.from("ambiguous-interior")));
+
+            assertTrue(failure.getMessage().contains("within retained published range 0..2"));
+            assertFalse(queue.cycleFileExists(1));
+            assertEquals(sourceWritePositionBefore, appender.store.writePosition());
+            assertEquals(sourceNextWordBefore, readWordAfterLastEntry(appender.store));
+            assertEquals(cursorBefore, cursor.getVolatileValue());
+            assertEquals(0, appender.cycle());
+            assertEquals(headerNumberBefore, appender.wire().headerNumber());
+            assertEquals(lastIndexBefore, appender.lastIndexAppended());
+            assertEquals(listingModCountBefore, queue.tableStoreGet("listing.modCount"));
+            assertArrayEquals(cycleFileNamesBefore, cycleFileNames(directory));
+        }
+    }
+
+    @Test
+    public void rejectedExactGapIntoExistingLaterRollDoesNotSealTheCurrentRoll() throws IOException {
+        final AtomicLong clock = new AtomicLong();
+        final File directory = queueDirectory.newFolder();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(clock::get)
+                .rollCycle(TEST_DAILY)
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeText("cycle-0 entry");
+            final int currentCycle = appender.cycle();
+            // The next roll exists (e.g. created by another node's backfill) but holds no entry yet.
+            try (SingleChronicleQueueStore next = queue.storeForCycle(currentCycle + 1, queue.epoch(), true, null)) {
+                assertNotNull(next);
+            }
+            final long gapIndex = queue.rollCycle().toIndex(currentCycle + 1, 5);
+            assertTrue("precondition: the current roll is open before the exact write", rollIsOpen(queue, currentCycle));
+
+            assertThrows(IllegalIndexException.class, () -> appender.writeBytes(gapIndex, Bytes.from("gap")));
+
+            // Nothing may have changed: the appender must not have moved and the current roll must not
+            // have been sealed.
+            assertEquals("a rejected exact write must not move the appender", currentCycle, appender.cycle());
+            assertTrue("a rejected exact write must not seal the current roll", rollIsOpen(queue, currentCycle));
+        }
+    }
+
+    @Test(timeout = 60_000)
+    public void independentQueueExactWritersReplayAcrossCyclesAndRestart() throws Exception {
+        ignoreException("Exact-index duplicate differs from published content and was ignored");
+        final File directory = queueDirectory.newFolder();
+        final SetTimeProvider time = new SetTimeProvider();
+        final int entriesPerCycle = 4;
+
+        replayRangeFromIndependentQueues(directory, time, 0, entriesPerCycle);
+        // Closing both Queue object graphs and constructing two more supplies the restart/mapping boundary.
+        replayRangeFromIndependentQueues(directory, time, 2, entriesPerCycle);
+
+        time.currentTimeMillis(3L * TEST_DAILY.lengthInMillis());
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             ExcerptAppender completion = queue.createAppender()) {
+            completion.normaliseEOFs();
+            assertEquals(2, queue.lastCycle());
+            assertEquals(entriesPerCycle * 2L, queue.entryCount());
+            assertTrue(hasEOF(queue, 0));
+            assertTrue(hasEOF(queue, 2));
+            assertEquals("sparse exact replay must create only its two named rolls",
+                    2, cycleFileNames(directory).length);
+
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                final Bytes<?> read = Bytes.allocateElasticOnHeap();
+                for (int cycle : new int[]{0, 2}) {
+                    for (int sequence = 0; sequence < entriesPerCycle; sequence++) {
+                        final long index = queue.rollCycle().toIndex(cycle, sequence);
+                        assertTrue("missing index 0x" + Long.toHexString(index), tailer.moveToIndex(index));
+                        assertTrue(tailer.readBytes(read.clear()));
+                        assertTrue(read.toString(), read.toString().startsWith(
+                                "cycle-" + cycle + "-entry-" + sequence + "-writer-"));
+                    }
+                }
+            }
+        }
+    }
+
+    private void replayRangeFromIndependentQueues(File directory,
+                                                   SetTimeProvider time,
+                                                   int cycle,
+                                                   int entries) throws Exception {
+        final int writers = 2;
+        final java.util.concurrent.ExecutorService executor =
+                java.util.concurrent.Executors.newFixedThreadPool(writers);
+        final java.util.concurrent.CyclicBarrier replayStep = new java.util.concurrent.CyclicBarrier(writers);
+        try (SingleChronicleQueue firstQueue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(time)
+                .rollCycle(TEST_DAILY)
+                .testBlockSize()
+                .build();
+             SingleChronicleQueue secondQueue = SingleChronicleQueueBuilder.binary(directory)
+                     .timeProvider(time)
+                     .rollCycle(TEST_DAILY)
+                     .testBlockSize()
+                     .build()) {
+            final SingleChronicleQueue[] queues = {firstQueue, secondQueue};
+            final java.util.List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>();
+            for (int writer = 0; writer < writers; writer++) {
+                final int writerId = writer;
+                futures.add(executor.submit(() -> {
+                    try (ExcerptAppender appender = queues[writerId].createAppender()) {
+                        for (int sequence = 0; sequence < entries; sequence++) {
+                            replayStep.await(10, TimeUnit.SECONDS);
+                            final long index = TEST_DAILY.toIndex(cycle, sequence);
+                            ((InternalAppender) appender).writeBytes(index, Bytes.from(
+                                    "cycle-" + cycle + "-entry-" + sequence + "-writer-" + writerId));
+                        }
+                    }
+                    return null;
+                }));
+            }
+            for (java.util.concurrent.Future<?> future : futures)
+                future.get();
+        } finally {
+            executor.shutdownNow();
+            assertTrue("exact replay workers did not stop",
+                    executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    /** True when the roll has no end-of-data marker yet; checks without writing one (a probe read of the header scan). */
+    private static boolean rollIsOpen(SingleChronicleQueue queue, int cycle) {
+        try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, queue.epoch(), false, null);
+             MappedBytes bytes = store.bytes()) {
+            final Wire wire = queue.wireType().apply(bytes);
+            wire.usePadding(store.dataVersion() > 0);
+            long position = store.writePosition();
+            position += net.openhft.chronicle.wire.Wires.lengthOf(bytes.readVolatileInt(position)) + 4;
+            for (; ; ) {
+                position += net.openhft.chronicle.bytes.BytesUtil.padOffset(position);
+                final int header = bytes.readVolatileInt(position);
+                if (header == net.openhft.chronicle.wire.Wires.NOT_INITIALIZED)
+                    return true;
+                if (header == net.openhft.chronicle.wire.Wires.END_OF_DATA)
+                    return false;
+                position += 4 + net.openhft.chronicle.wire.Wires.lengthOf(header);
+            }
+        }
+    }
+
+    @Test
+    public void constructionSealsEveryRollBelowTheFirstSealedRoll() throws IOException {
+        final AtomicLong clock = new AtomicLong();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDirectory.newFolder())
+                .timeProvider(clock::get)
+                .rollCycle(TEST_DAILY)
+                .build()) {
+            try (ExcerptAppender first = queue.createAppender()) {
+                first.writeText("roll 0 is left open");
+            }
+            sealCycle(queue, 1);
+            assertFalse("precondition: roll 0 is open while roll 1 exists and is sealed", hasEOF(queue, 0));
+
+            clock.set(2L * TEST_DAILY.lengthInMillis());
+            queue.createAppender().close();
+            assertTrue("construction must seal roll 0, which lies below the sealed roll 1", hasEOF(queue, 0));
         }
     }
 
@@ -725,6 +2183,197 @@ public class StoreAppenderTest extends QueueTestCommon {
             wire.usePadding(store.dataVersion() > 0);
             assertTrue("test precondition: next roll must be sealed",
                     store.writeEOF(wire, queue.timeoutMS));
+        }
+    }
+
+    private static void forceWritePosition(SingleChronicleQueueStore store, long newWritePosition) {
+        try {
+            final Field field = store.getClass().getDeclaredField("writePosition");
+            field.setAccessible(true);
+            ((LongValue) field.get(store)).setValue(newWritePosition);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unable to simulate interrupted write-position publication", e);
+        }
+    }
+
+    private static void clearEncodedSequence(SingleChronicleQueueStore store) {
+        writePositionAndSequence(store).setValue2(0);
+    }
+
+    private static TwoLongValue writePositionAndSequence(SingleChronicleQueueStore store) {
+        try {
+            final Field field = store.getClass().getDeclaredField("writePosition");
+            field.setAccessible(true);
+            return (TwoLongValue) field.get(store);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unable to access the paired write-position publication", e);
+        }
+    }
+
+    private static void removeEndOfData(SingleChronicleQueue queue, int cycle) {
+        try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, 0, false, null);
+             MappedBytes bytes = store.bytes()) {
+            long position = store.writePosition();
+            position += lengthOf(bytes.readVolatileInt(position)) + SPB_HEADER_SIZE;
+            for (; ; ) {
+                if (store.dataVersion() > 0)
+                    position += BytesUtil.padOffset(position);
+                final int header = bytes.readVolatileInt(position);
+                if (header == END_OF_DATA) {
+                    assertTrue(bytes.compareAndSwapInt(position, END_OF_DATA, NOT_INITIALIZED));
+                    return;
+                }
+                assertTrue("expected metadata before EOF at position " + position,
+                        isReadyMetaData(header));
+                position += SPB_HEADER_SIZE + lengthOf(header);
+            }
+        }
+    }
+
+    private static void leaveIncompleteRecordAtEof(SingleChronicleQueue queue,
+                                                    int cycle,
+                                                    Bytes<?> partialPayload) {
+        try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, 0, false, null);
+             MappedBytes bytes = store.bytes()) {
+            long position = store.writePosition();
+            position += lengthOf(bytes.readVolatileInt(position)) + SPB_HEADER_SIZE;
+            for (; ; ) {
+                position += BytesUtil.padOffset(position);
+                final int header = bytes.readVolatileInt(position);
+                if (header == END_OF_DATA) {
+                    StoreAppender.replaceEndOfDataMarkerForRecovery(bytes, position);
+                    final int length = Math.toIntExact(partialPayload.readRemaining());
+                    bytes.write(position + SPB_HEADER_SIZE, partialPayload,
+                            partialPayload.readPosition(), length);
+                    bytes.writeVolatileInt(position, NOT_COMPLETE | length);
+                    return;
+                }
+                assertTrue("expected metadata before EOF at position " + position,
+                        isReadyMetaData(header));
+                position += SPB_HEADER_SIZE + lengthOf(header);
+            }
+        }
+    }
+
+    private static boolean hasEOF(SingleChronicleQueue queue, int cycle) {
+        try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, 0, false, null)) {
+            final String dump = store.dump(WireType.BINARY_LIGHT);
+            return dump.contains(" EOF") && dump.contains("--- !!not-ready-meta-data");
+        }
+    }
+
+    private static int countQueueFiles(File directory) {
+        final File[] queueFiles = directory.listFiles(
+                (ignored, name) -> name.endsWith(SingleChronicleQueue.SUFFIX));
+        return queueFiles == null ? 0 : queueFiles.length;
+    }
+
+    private static boolean containsCause(Throwable failure, Class<? extends Throwable> type) {
+        for (Throwable current = failure; current != null; current = current.getCause()) {
+            if (type.isInstance(current))
+                return true;
+            for (Throwable suppressed : current.getSuppressed()) {
+                if (containsCause(suppressed, type))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsMessage(Throwable failure, String fragment) {
+        for (Throwable current = failure; current != null; current = current.getCause()) {
+            if (current.getMessage() != null && current.getMessage().contains(fragment))
+                return true;
+            for (Throwable suppressed : current.getSuppressed()) {
+                if (containsMessage(suppressed, fragment))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static final class PaddingRecordingStore extends SingleChronicleQueueStore {
+        private boolean replacementUsesPadding;
+
+        PaddingRecordingStore(MappedBytes bytes) {
+            super(TEST4_DAILY, WireType.BINARY, bytes, 8, 1);
+        }
+
+        @Override
+        boolean writeEOFAndShrink(Wire wire, long timeoutMS) {
+            replacementUsesPadding = wire.usePadding();
+            return true;
+        }
+    }
+
+    private static final class FailingEofStore extends SingleChronicleQueueStore {
+        FailingEofStore(MappedBytes bytes) {
+            super(TEST4_DAILY, WireType.BINARY, bytes, 8, 1);
+        }
+
+        @Override
+        public boolean writeEOF(Wire wire, long timeoutMS) {
+            return false;
+        }
+
+        @Override
+        public long writePosition() {
+            return 0;
+        }
+    }
+
+    private static final class ConfigurableRollCycle implements RollCycle {
+        private final String format;
+        private final int lengthInMillis;
+        private final RollCycleArithmetic arithmetic;
+
+        private ConfigurableRollCycle(String format,
+                                      int lengthInMillis,
+                                      int indexCount,
+                                      int indexSpacing) {
+            this.format = format;
+            this.lengthInMillis = lengthInMillis;
+            this.arithmetic = RollCycleArithmetic.of(indexCount, indexSpacing);
+        }
+
+        @Override
+        public String format() {
+            return format;
+        }
+
+        @Override
+        public int lengthInMillis() {
+            return lengthInMillis;
+        }
+
+        @Override
+        public int defaultIndexCount() {
+            return arithmetic.indexCount();
+        }
+
+        @Override
+        public int defaultIndexSpacing() {
+            return arithmetic.indexSpacing();
+        }
+
+        @Override
+        public long toIndex(int cycle, long sequenceNumber) {
+            return arithmetic.toIndex(cycle, sequenceNumber);
+        }
+
+        @Override
+        public long toSequenceNumber(long index) {
+            return arithmetic.toSequenceNumber(index);
+        }
+
+        @Override
+        public int toCycle(long index) {
+            return arithmetic.toCycle(index);
+        }
+
+        @Override
+        public long maxMessagesPerCycle() {
+            return arithmetic.maxMessagesPerCycle();
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -10,6 +10,7 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
 import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.core.onoes.ExceptionHandler;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
 import net.openhft.chronicle.core.values.LongValue;
@@ -34,6 +35,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +45,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.DateTimeException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
 import java.util.concurrent.Semaphore;
@@ -885,6 +889,7 @@ public class StoreAppenderTest extends QueueTestCommon {
                 .build();
              ExcerptAppender appender = queue.createAppender();
              ExcerptTailer tailer = queue.createTailer()) {
+            expectException("Exact-index duplicate differs from ready content and was ignored");
             ((InternalAppender) appender).writeBytes(firstIndex, Bytes.from("retry-not-overwrite"));
             assertEquals(firstIndex, appender.lastIndexAppended());
             assertEquals(1, queue.entryCount());
@@ -897,6 +902,103 @@ public class StoreAppenderTest extends QueueTestCommon {
             assertNextBytes(tailer, result, "first");
             assertNextBytes(tailer, result, "second");
             assertFalse(tailer.readBytes(result.clear()));
+        }
+    }
+
+    @Test
+    public void readyCrashDuplicatesCompareMatchingAndDifferentPayloads() throws IOException {
+        for (boolean publishedPrefix : new boolean[]{false, true}) {
+            assertReadyCrashDuplicateDiagnostic(publishedPrefix, true, true);
+            assertReadyCrashDuplicateDiagnostic(publishedPrefix, false, true);
+        }
+    }
+
+    @Test
+    public void readyCrashDuplicateEqualityIsSilentWhenDebugDisabled() throws IOException {
+        assertReadyCrashDuplicateDiagnostic(false, true, false);
+        assertReadyCrashDuplicateDiagnostic(false, false, false);
+    }
+
+    private void assertReadyCrashDuplicateDiagnostic(boolean publishedPrefix, boolean matching, boolean debugEnabled) throws IOException {
+        // As in restartPublishesReadyRecordLeftBeyondWritePosition, model interrupted publication rather than
+        // the fully published state assumed by the optional acquisition-time index consistency diagnostic.
+        QueueSystemProperties.CHECK_INDEX = false;
+        final File directory = queueDirectory.newFolder();
+        final long requestedIndex = TEST4_DAILY.toIndex(0, publishedPrefix ? 1 : 0);
+        final long requestedPosition;
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0).rollCycle(TEST4_DAILY).testBlockSize().build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            if (publishedPrefix) {
+                appender.writeBytes(Bytes.from("published prefix"));
+            } else {
+                try (SingleChronicleQueueStore empty = queue.storeForCycle(0, queue.epoch(), true, null)) {
+                    assertNotNull(empty);
+                }
+            }
+            requestedPosition = commitRecordWithoutPublishing(queue, 0, Bytes.from("hello world"));
+            commitRecordWithoutPublishing(queue, 0, Bytes.from("later ready record"));
+        }
+
+        final List<String> debugMessages = new ArrayList<>();
+        final List<String> warningMessages = new ArrayList<>();
+        final ExceptionHandler debugHandler = new ExceptionHandler() {
+            @Override
+            public void on(Logger logger, String message, Throwable thrown) {
+                debugMessages.add(message);
+            }
+
+            @Override
+            public boolean isEnabled(Class<?> type) {
+                return debugEnabled;
+            }
+        };
+        final Bytes<?> supplied = Bytes.from(matching ? "hello world" : "HELLO WORLD");
+        final Bytes<?> result = Bytes.elasticHeapByteBuffer();
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(() -> 0).rollCycle(TEST4_DAILY).testBlockSize().build();
+             ExcerptAppender excerptAppender = queue.createAppender();
+             ExcerptTailer tailer = queue.createTailer()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            final long readPosition = supplied.readPosition();
+            final long readLimit = supplied.readLimit();
+            final long writePosition = supplied.writePosition();
+            final long writeLimit = supplied.writeLimit();
+            Jvm.setThreadLocalExceptionHandlers(null,
+                    (logger, message, thrown) -> warningMessages.add(message), debugHandler);
+            try {
+                appender.writeBytes(requestedIndex, supplied);
+            } finally {
+                Jvm.setThreadLocalExceptionHandlers(null, null, null);
+            }
+            assertEquals(readPosition, supplied.readPosition());
+            assertEquals(readLimit, supplied.readLimit());
+            assertEquals(writePosition, supplied.writePosition());
+            assertEquals(writeLimit, supplied.writeLimit());
+            assertEquals("only the requested ready record is adopted", requestedPosition, appender.store.writePosition());
+            assertEquals(requestedIndex, appender.lastIndexAppended());
+            assertTrue(tailer.moveToIndex(requestedIndex));
+            assertNextBytes(tailer, result, "hello world");
+            assertNextBytes(tailer, result, "later ready record");
+        } finally {
+            supplied.releaseLast();
+            result.releaseLast();
+        }
+
+        debugMessages.removeIf(message -> !message.contains("Exact-index duplicate"));
+        assertEquals(matching && debugEnabled ? 1 : 0, debugMessages.size());
+        assertEquals(matching ? 0 : 1, warningMessages.size());
+        if (matching && debugEnabled)
+            assertTrue(debugMessages.get(0).contains("duplicate matches ready content and was ignored"));
+        if (!matching) {
+            final String warning = warningMessages.get(0);
+            assertTrue(warning.contains("duplicate differs from ready content and was ignored"));
+            assertTrue(warning.contains("\nexisting:\n"));
+            assertTrue(warning.contains("\nsupplied:\n"));
+            final String normalisedHex = warning.replaceAll("\\s+", " ");
+            assertTrue(normalisedHex.contains("68 65 6c 6c 6f 20 77 6f"));
+            assertTrue(normalisedHex.contains("48 45 4c 4c 4f 20 57 4f"));
         }
     }
 
@@ -1309,6 +1411,36 @@ public class StoreAppenderTest extends QueueTestCommon {
             assertEquals(historicalWritePositionBefore, writePosition(queue, 0));
             assertEquals(listingModCountBefore, queue.tableStoreGet("listing.modCount"));
             assertArrayEquals(cycleFileNamesBefore, cycleFileNames(directory));
+        }
+    }
+
+    @Test
+    public void cachedCycleEnumerationRejectsDeletedBoundaries() throws IOException {
+        assumeFalse(OS.isWindows());
+        for (int deletedCycle : new int[]{0, 1}) {
+            final File directory = queueDirectory.newFolder();
+            final AtomicLong clock = new AtomicLong();
+            try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                    .timeProvider(clock::get).rollCycle(TEST4_DAILY).testBlockSize().build();
+                 ExcerptAppender excerptAppender = queue.createAppender()) {
+                final StoreAppender appender = (StoreAppender) excerptAppender;
+                appender.writeText("cycle-zero");
+                final File cycleZero = appender.store.file();
+                clock.set(TEST4_DAILY.lengthInMillis());
+                appender.writeText("cycle-one");
+                final File boundary = deletedCycle == 0 ? cycleZero : appender.store.file();
+                assertEquals(2, queue.listCyclesBetween(0, 1).size());
+                final long modCount = queue.tableStoreGet("listing.modCount");
+                Files.delete(boundary.toPath());
+
+                final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                        () -> queue.listCyclesBetween(0, 1));
+
+                assertTrue(failure.getMessage().contains("file not found"));
+                assertFalse(boundary.exists());
+                assertEquals(modCount, queue.tableStoreGet("listing.modCount"));
+                assertEquals(1, queue.lastPublishedCycle());
+            }
         }
     }
 
@@ -1791,7 +1923,7 @@ public class StoreAppenderTest extends QueueTestCommon {
         assertEquals(expected, result.toString());
     }
 
-    private static void commitRecordWithoutPublishing(SingleChronicleQueue queue,
+    private static long commitRecordWithoutPublishing(SingleChronicleQueue queue,
                                                        int cycle,
                                                        Bytes<?> payload) {
         try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, 0, false, null);
@@ -1803,14 +1935,15 @@ public class StoreAppenderTest extends QueueTestCommon {
                 final int header = bytes.readVolatileInt(position);
                 if (header == NOT_INITIALIZED)
                     break;
-                assertTrue("expected metadata before the free slot at " + position,
-                        isReadyMetaData(header));
+                assertTrue("expected a ready record before the free slot at " + position,
+                        isReadyData(header) || isReadyMetaData(header));
                 position += SPB_HEADER_SIZE + lengthOf(header);
             }
             final long length = payload.readRemaining();
             bytes.write(position + SPB_HEADER_SIZE, payload, payload.readPosition(), length);
             bytes.writeOrderedInt(position, (int) length);
             assertTrue(isReadyData(bytes.readVolatileInt(position)));
+            return position;
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/WriteBytesIndexTest.java
@@ -41,7 +41,6 @@ public class WriteBytesIndexTest extends QueueTestCommon {
                         ((InternalAppender) a0).writeBytes(index, bytes);
                     }
 
-                    // try a1
                     ((InternalAppender) a1).writeBytes(index, bytes);
                     assertTrue(t1.readBytes(bytes2.clear()));
                     if (!bytes.contentEquals(bytes2)) {


### PR DESCRIPTION
**Hold for final stack review. Keep this PR in draft until the repaired #1739 -> #1740 -> #1741 stack has fresh review and CI.**

## Purpose

Q3 of QUEUE-146: recover validated exact-index replication writes across sealed cycles, with CQE responsible for completion ordering and maintenance exclusion.

## Contract

- Ordinary writes retain Q1 publication selection and Q2's one-advance EOF behavior.
- Every exact request receives read-only physical/publication classification before roll, EOF, cursor or appender mutation. Gaps are rejected; old published duplicates do not adopt unrelated later crash records.
- An existing requested index is compared with the supplied payload, whether the original is already published or is a ready crash-written record beyond publication. Equal content is debug-only and silent when debug is disabled. Different content warns with both hex dumps; the supplied message is ignored without throwing for the mismatch or overwriting the original.
- Valid ready crash records are adopted only through the requested sequence. Exact-next requests may adopt their contiguous predecessors.
- Preflight derives the published sequence from the full write position, not a lossy paired sequence that may be stale yet alias the later position. General sparse-index repair is not provided.
- Incomplete exact-next records may be recovered in place. EOF reopening uses expected-value CAS; legacy unpadded stores and terminal maximum-cycle EOF reopening are rejected before mutation.
- Absence is not an empty existing store. Missing authoritative maxima and absent targets inside retained published bounds fail closed; creation outside those bounds follows the documented recovery policy.
- Completion validates the shared cursor, takes a fresh physical snapshot, requires canonical one-to-one cycle filenames, and strictly reacquires surviving pathnames before sealing. It cannot certify an unlinked cached mapping.
- Historical deletion has one refresh/retry. The current/highest roll is not a supported deletion target. Public cached range enumeration retains action-time endpoint existence checks.
- Recovery lowers the normalization cursor; CQE must call the implementing appender's `normaliseEOFs()` before acknowledgement/completion and exclude destructive maintenance. The interface default remains a compatibility no-op.

## Review corrections and evidence

- `readyCrashDuplicatesCompareMatchingAndDifferentPayloads` covers matching and differing requested crash records, both with and without a published prefix, after reopening. `readyCrashDuplicateEqualityIsSilentWhenDebugDisabled` checks the disabled-debug behavior and retained mismatch warning. Tests assert both hex dumps, original contents, input cursor/limit preservation and adoption capped at the requested record.
- These fixtures write genuinely ready records without publishing the store position. Like the existing interrupted-publication regression, they disable the optional acquisition-time `CHECK_INDEX` diagnostic, which assumes fully published state. They do not claim general index-repair coverage.
- `cachedCycleEnumerationRejectsDeletedBoundaries` primes the cache and then deletes each endpoint without changing mapped metadata. It proves the old absent-path failure is preserved. The mapped-unlink case is POSIX-specific.
- Existing regressions cover missing/ambiguous targets, stale aliased sequence publication, fresh enumeration after cache priming, non-canonical/duplicate cycle filenames, non-zero daily/hourly/weekly epochs, and disappearance of the currently mapped generation.
- `StoreAppenderInternalWriteBytesTest` and `WriteBytesIndexTest` remain present, preserving cross-instance replay, reopen and live-tailer integration evidence.
- Adjacent `//!` notes distinguish behavioral discriminators, retained integration evidence and precisely stated defensive branches without current discriminators. AsciiDoc uses direct `//!` comments.

## Current ancestry and validation

- Base: `9bd9b7e6db80b7d037a4f4a0f52f976c7dd4a4fe` (`fix/QUEUE-143-ordinary-append-rolls-past-eof`).
- Head: `d1d639b7b190506a5175e078ead8b29af24c2108`.
- Base equals merge base; 20 changed files and no POM delta.
- Existing branch history is preserved with a merge commit and a normal fast-forward push. The tree matches tested candidate `905a5440713a8d91753f51d3069ed396891938e7`.
- A fresh appender replaying a published second record could try to map the logical read limit near 128 TiB during duplicate-comparison cleanup. Restoring the read limit already restores the shared cursor; removing the redundant write-position setter avoids growing the file. `publishedDuplicateAfterTwoRecordsDoesNotMapLogicalCapacity` failed on the preceding code and passes here, checking unchanged file length/count and a subsequent append.
- Full verification and local installation: **1,212 tests, zero failures/errors, 52 skipped**. The initial run exposed a pre-existing tailer test race; the test now waits for its producer before checking later records. The full run then passed with retries disabled.
- Linux amd64/OpenJDK 21.0.12, Maven 3.9.11, offline isolated Maven repository, `-Dsurefire.rerunFailingTestsCount=0`. Required build checks passed.
- Wire runtime `2026.10-SNAPSHOT` was rebuilt from merged #1280 commit `3dd7fe5983c0133703ee72f57bced9a25270eb6f`; JAR SHA-256 `92803fb011f5071900f5c3b1b637cf39f6254e86b4e29f77f1256ecc96dde755`. This is source-build evidence for the local run; released immutable coordinates remain a gate.
- No Windows, macOS or ARM execution is claimed.

## Stack and review gates

The repaired order is `staged/develop` -> #1739 -> #1740 -> #1741. #1741 remains draft for final-stack review. The coordinate work in #1750 and follow-ups #1745/#1746 are unchanged.

Wire #1280 merged on 2026-09-07. Successful CI on the published heads, independent review and immutable release/BOM coordinates remain outstanding. Previous-head results do not qualify the new heads.
