### PR TITLE
QUEUE-143: finish interrupted indexed recovery after restart

### DIFF
--- a/docs/antora/modules/replication/pages/replication.adoc
+++ b/docs/antora/modules/replication/pages/replication.adoc
@@ -52,10 +52,23 @@ proof that a roll can never be reopened.
 
 Queue inspects the requested exact index, skipping user and sparse-index
 metadata because metadata does not consume an index. If the slot contains EOF,
-Queue replaces that word with one compare-and-swap, commits the data and any
-addressable sparse-index entry, and then restores EOF. An existing index remains
-authoritative: Queue compares a duplicate payload with it, returns silently
-when they match, and warns with bounded readable hex dumps when they differ.
+Queue first records the exact recovery index in its table store, replaces that
+word with one compare-and-swap, commits the data and any addressable sparse-index
+entry, records the indexed phase, and then restores EOF and clears both markers.
+An existing index remains authoritative: Queue compares a duplicate payload
+with it, returns silently when they match, and warns with bounded readable hex
+dumps when they differ.
+
+If a process stops during recovery, back-fill retries an incomplete entry. At
+back-fill completion, `normaliseEOFs()` inspects the pending index. If the
+first-writer-wins data record is ready, Queue adopts a stale write position if
+necessary, repeats the monotonic sparse-index update, records the indexed phase,
+restores EOF, and clears the recovery markers. This also completes recovery when
+the process stopped after the data and index were durable but before the indexed
+phase was recorded, even if the peer does not send the index again. An incomplete
+record remains fail-closed until an exact retry completes it. Each replication
+handler normalises its own back-fill appender before publishing that sink as
+complete.
 
 The Wire supplied to exact-index recovery cannot be unpadded. For queues that
 support this recovery path, `StoreAppender` establishes padding when it

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/InternalAppender.java
@@ -21,6 +21,10 @@ public interface InternalAppender extends ExcerptAppender {
      * missing index. Replacing the marker is logged as a warning and the cycle is resealed only after
      * the data record and any addressable sparse-index metadata are committed. Entries beyond the
      * sparse-index capacity remain valid and are found by scanning from the final indexed entry.
+     * Queue records the recovery phase in its table store before replacing the marker, so
+     * {@link #normaliseEOFs()} can repeat monotonic completion updates and reseal a committed
+     * recovery after restart even when that index is not sent again. An incomplete recovery must
+     * be retried before normalisation can complete.
      * <p>
      * For queues that support this path, {@code StoreAppender} establishes padding when it
      * constructs the Wire. Exact-index recovery has no unpadded mode.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueStore.java
@@ -264,6 +264,11 @@ public class SingleChronicleQueueStore extends AbstractCloseable implements Wire
         return this;
     }
 
+    /** Simulates process loss before write-position publication in package-local recovery tests. */
+    void writePositionForTesting(long position) {
+        writePosition.setVolatileValue(position);
+    }
+
     /**
      * Moves the excerpt context to the specified index for reading.
      *

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -49,6 +49,8 @@ class StoreAppender extends AbstractCloseable
      */
     private static final String NORMALISED_EOFS_TO_TABLESTORE_KEY = "normalisedEOFsTo";
     private static final long MAX_MISMATCH_DUMP_BYTES = 256;
+    private static final String RECOVERY_IN_PROGRESS_TABLESTORE_KEY = "recoveryInProgress";
+    private static final String RECOVERY_INDEXED_TABLESTORE_KEY = "recoveryIndexed";
 
     @NotNull
     private final SingleChronicleQueue queue;
@@ -72,6 +74,7 @@ class StoreAppender extends AbstractCloseable
     private Wire wireForIndex;
     private long positionOfHeader = 0;
     private long lastIndex = Long.MIN_VALUE;
+    private long activeRecoveryIndex = Long.MIN_VALUE;
     @Nullable
     private Pretoucher pretoucher = null;
     private MicroToucher microtoucher = null;
@@ -489,7 +492,11 @@ class StoreAppender extends AbstractCloseable
 
             bytes.writeLimit(bytes.capacity());
 
-            assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
+            // A durable recovery intent permits a ready record to exist beyond a stale persisted
+            // write position. Reconciliation adopts it before normal appends are accepted.
+            assert !QueueSystemProperties.CHECK_INDEX
+                    || existingTableStoreValue(RECOVERY_IN_PROGRESS_TABLESTORE_KEY) != Long.MIN_VALUE
+                    || checkWritePositionHeaderNumber();
             return originalHeaderNumber != wire.headerNumber();
 
         } catch (@NotNull BufferOverflowException | StreamCorruptedException e) {
@@ -625,9 +632,21 @@ class StoreAppender extends AbstractCloseable
         final WriteLock writeLock = queue.writeLock();
         writeLock.lock();
         try {
-            // use the getter, not the raw field: after the construction-time back-scan releases its
-            // parked store the field is Integer.MIN_VALUE, and the getter resolves that to lastCycle
-            normaliseEOFs0(cycle());
+            // Preserve the caller's original completion bound: resolving a persisted recovery can
+            // temporarily select an older cycle.
+            final int appenderCycle = cycle();
+            normalisePendingRecovery();
+
+            // Recovery can select a cycle below the monotonic normalisation watermark. Seal that
+            // selected store directly rather than rewinding or scanning a sparse cycle range.
+            if (cycle != Integer.MIN_VALUE
+                    && cycle < queue.cycle()
+                    && wire != null) {
+                ensureEndOfData("Unable to normalise selected historical cycle " + cycle);
+                return;
+            }
+
+            normaliseEOFs0(appenderCycle);
         } finally {
             writeLock.unlock();
             long tookMillis = (System.nanoTime() - start) / 1_000_000;
@@ -658,7 +677,7 @@ class StoreAppender extends AbstractCloseable
             setCycle2(eofCycle, WireStoreSupplier.CreateStrategy.REINITIALIZE_EXISTING);
             if (wire != null) {
                 assert queue.writeLock().locked();
-                store.writeEOF(wire, timeoutMS());
+                ensureEndOfData("Unable to normalise cycle " + eofCycle);
                 normalisedEOFsTo.setMaxValue(eofCycle);
             }
         }
@@ -792,6 +811,7 @@ class StoreAppender extends AbstractCloseable
             switch (action) {
                 case WRITE_AND_RESEAL:
                     bytes.writePosition(recoveryPosition);
+                    beginRecovery(recoveryIndex);
                     replaceEndOfDataMarkerForRecovery(bytes, recoveryPosition);
                     warnExactIndexRecovery("reopened end-of-data", recoveryIndex,
                             recoveryPosition, header);
@@ -799,10 +819,12 @@ class StoreAppender extends AbstractCloseable
 
                 case WRITE:
                     bytes.writePosition(recoveryPosition);
+                    resumeRecoveryIfPending(recoveryIndex);
                     return action;
 
                 case WARN_AND_WRITE:
                     bytes.writePosition(recoveryPosition);
+                    resumeRecoveryIfPending(recoveryIndex);
                     warnExactIndexRecovery("replaced incomplete header", recoveryIndex,
                             recoveryPosition, header);
                     // Clear the failed header here so Wire.enterHeader does not emit a second warning.
@@ -810,6 +832,7 @@ class StoreAppender extends AbstractCloseable
                     return action;
 
                 case ALREADY_PRESENT:
+                    resumeRecoveryIfPending(recoveryIndex);
                     positionOfHeader = recoveryPosition;
                     // A ready header may have survived a failure before the store write position
                     // was published. Expose exactly this complete record so it can be validated.
@@ -825,6 +848,11 @@ class StoreAppender extends AbstractCloseable
                     throw new AssertionError(action);
             }
         }
+    }
+
+    private void resumeRecoveryIfPending(final long recoveryIndex) {
+        if (existingTableStoreValue(RECOVERY_IN_PROGRESS_TABLESTORE_KEY) == recoveryIndex)
+            beginRecovery(recoveryIndex);
     }
 
     private void warnExactIndexRecovery(final String action, final long recoveryIndex,
@@ -975,12 +1003,139 @@ class StoreAppender extends AbstractCloseable
                 + queue.fileAbsolutePath()
                 + ", cycle=" + recoveredCycle
                 + ", index=0x" + Long.toHexString(index));
+        completeRecovery(index);
     }
 
     void ensureEndOfData(final String failureMessage) {
         if (store.writeEOF(wire, timeoutMS()) || cycleHasEOF())
             return;
         throw new IllegalStateException(failureMessage);
+    }
+
+    private void beginRecovery(final long index) {
+        final LongValue recoveryInProgress = queue.tableStoreAcquire(
+                RECOVERY_IN_PROGRESS_TABLESTORE_KEY, Long.MIN_VALUE);
+        final LongValue recoveryIndexed = queue.tableStoreAcquire(
+                RECOVERY_INDEXED_TABLESTORE_KEY, Long.MIN_VALUE);
+
+        final long existingIndex = recoveryInProgress.getVolatileValue();
+        if (existingIndex == Long.MIN_VALUE) {
+            recoveryIndexed.setVolatileValue(Long.MIN_VALUE);
+            recoveryInProgress.setVolatileValue(index);
+        } else if (existingIndex != index) {
+            throw new IllegalStateException("Recovery for index 0x" + Long.toHexString(existingIndex)
+                    + " must complete before index 0x" + Long.toHexString(index));
+        }
+        activeRecoveryIndex = index;
+    }
+
+    private void markRecoveryIndexed(final long index) {
+        if (activeRecoveryIndex != index)
+            return;
+        final LongValue recoveryIndexed = queue.tableStoreAcquire(
+                RECOVERY_INDEXED_TABLESTORE_KEY, Long.MIN_VALUE);
+        recoveryIndexed.setVolatileValue(index);
+    }
+
+    private void completeRecovery(final long index) {
+        final LongValue recoveryInProgress = queue.tableStoreAcquire(
+                RECOVERY_IN_PROGRESS_TABLESTORE_KEY, Long.MIN_VALUE);
+        final LongValue recoveryIndexed = queue.tableStoreAcquire(
+                RECOVERY_INDEXED_TABLESTORE_KEY, Long.MIN_VALUE);
+        if (recoveryInProgress.getVolatileValue() == index) {
+            recoveryInProgress.setVolatileValue(Long.MIN_VALUE);
+            recoveryIndexed.setVolatileValue(Long.MIN_VALUE);
+        }
+        if (activeRecoveryIndex == index)
+            activeRecoveryIndex = Long.MIN_VALUE;
+    }
+
+    private void normalisePendingRecovery() {
+        final long recoveryIndex = existingTableStoreValue(RECOVERY_IN_PROGRESS_TABLESTORE_KEY);
+        if (recoveryIndex == Long.MIN_VALUE)
+            return;
+        final long indexedRecovery = existingTableStoreValue(RECOVERY_INDEXED_TABLESTORE_KEY);
+        if (indexedRecovery == recoveryIndex) {
+            selectRecoveryCycle(recoveryIndex);
+            ensureEndOfData("Unable to normalise persisted recovery at index 0x"
+                    + Long.toHexString(recoveryIndex));
+            completeRecovery(recoveryIndex);
+            return;
+        }
+        if (!reconcilePendingRecovery(recoveryIndex))
+            throw new IllegalStateException("Exact-index recovery remains incomplete at index 0x"
+                    + Long.toHexString(recoveryIndex));
+
+    }
+
+    private boolean reconcilePendingRecovery(final long recoveryIndex) {
+        selectRecoveryCycle(recoveryIndex);
+
+        try {
+            final long recoveryPosition = committedRecoveryPosition(recoveryIndex);
+            if (recoveryPosition == Long.MIN_VALUE)
+                return false;
+
+            // A process can stop after publishing the data header or write position but before the
+            // sparse index and indexed phase. Repeating these monotonic updates adopts the first ready
+            // record and repairs whichever part of completion was missed.
+            activeRecoveryIndex = recoveryIndex;
+            lastPosition = recoveryPosition;
+            lastIndex(recoveryIndex);
+            store.writePosition(recoveryPosition);
+            writeIndexForPosition(recoveryIndex, recoveryPosition);
+        } catch (StreamCorruptedException e) {
+            throw new IllegalStateException("Unable to reconcile persisted recovery at index 0x"
+                    + Long.toHexString(recoveryIndex), e);
+        }
+        markRecoveryIndexed(recoveryIndex);
+        ensureEndOfData("Unable to normalise persisted recovery at index 0x"
+                + Long.toHexString(recoveryIndex));
+        completeRecovery(recoveryIndex);
+        return true;
+    }
+
+    private void selectRecoveryCycle(final long recoveryIndex) {
+        final int recoveryCycle = queue.rollCycle().toCycle(recoveryIndex);
+        if (cycle != recoveryCycle)
+            setCycle2(recoveryCycle, WireStoreSupplier.CreateStrategy.REINITIALIZE_EXISTING);
+        if (wire == null)
+            throw new IllegalStateException("Recovery cycle " + recoveryCycle + " is not available");
+    }
+
+    private long committedRecoveryPosition(final long recoveryIndex) throws StreamCorruptedException {
+        final long recoverySequence = queue.rollCycle().toSequenceNumber(recoveryIndex);
+        final long persistedPosition = store.writePosition();
+        final Bytes<?> bytes = wire.bytes();
+        final int persistedHeader = bytes.readVolatileInt(persistedPosition);
+        final long persistedSequence = store.sequenceForPosition(this, persistedPosition, true);
+
+        if (persistedSequence == recoverySequence
+                && !isNotComplete(persistedHeader)
+                && Wires.isData(persistedHeader))
+            return persistedPosition;
+        if (persistedSequence != recoverySequence - 1)
+            return Long.MIN_VALUE;
+
+        long position = persistedPosition + SPB_HEADER_SIZE + lengthOf(persistedHeader);
+        for (; ; ) {
+            position += BytesUtil.padOffset(position);
+            final int header = bytes.readVolatileInt(position);
+            if (header == END_OF_DATA || isNotComplete(header))
+                return Long.MIN_VALUE;
+            if (Wires.isData(header))
+                return position;
+            position += SPB_HEADER_SIZE + lengthOf(header);
+        }
+    }
+
+    private long existingTableStoreValue(final String expectedKey) {
+        final long[] result = {Long.MIN_VALUE};
+        queue.metaStore().forEachKey(result, (value, key, valueIn) -> {
+            if (expectedKey.contentEquals(key))
+                value[0] = valueIn.int64();
+        });
+        return result[0];
     }
 
     /**
@@ -1007,6 +1162,10 @@ class StoreAppender extends AbstractCloseable
         // in case our cached headerNumber is incorrect.
         resetPosition();
 
+        if (existingTableStoreValue(RECOVERY_IN_PROGRESS_TABLESTORE_KEY) == index
+                && reconcilePendingRecovery(index))
+            return;
+
         long headerNumber = wire.headerNumber();
 
         final RecoveryAction recoveryAction;
@@ -1021,6 +1180,8 @@ class StoreAppender extends AbstractCloseable
         if (recoveryAction == RecoveryAction.ALREADY_PRESENT) {
             compareExistingEntry(index, bytes);
             adoptExistingEntry(index);
+            if (activeRecoveryIndex == index)
+                resealRecoveredCycle(index);
             return;
         }
 
@@ -1033,7 +1194,7 @@ class StoreAppender extends AbstractCloseable
             throw new IllegalStateException("index: " + index + ", header: " + headerNumber);
         }
 
-        if (recoveryAction == RecoveryAction.WRITE_AND_RESEAL)
+        if (activeRecoveryIndex == index)
             resealRecoveredCycle(index);
     }
 
@@ -1272,6 +1433,7 @@ class StoreAppender extends AbstractCloseable
         lastIndex(index);
         store.writePosition(position);
         writeIndexForPosition(index, position);
+        markRecoveryIndexed(index);
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/InternalAppenderWriteBytesTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import java.io.File;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static net.openhft.chronicle.queue.DirectoryUtils.tempDir;
 import static net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder.binary;
@@ -30,6 +31,9 @@ import static net.openhft.chronicle.wire.Wires.*;
 import static org.junit.Assert.assertEquals;
 
 public class InternalAppenderWriteBytesTest extends QueueTestCommon {
+
+    private static final String RECOVERY_IN_PROGRESS = "recoveryInProgress";
+    private static final String RECOVERY_INDEXED = "recoveryIndexed";
 
     @Before
     public void before() {
@@ -581,6 +585,421 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
         }
     }
 
+    @Test
+    public void normaliseResealsMarkerlessHistoricalCycle() {
+        final File directory = getTmpDir();
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        final long recoveredIndex;
+        final int recoveredCycle;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first-cycle"));
+            recoveredIndex = appender.lastIndexAppended() + 1;
+            recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("intermediate-cycle"));
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("later-cycle"));
+        }
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            // Advance the persisted normalisation watermark beyond the cycle that recovery reopens.
+            appender.writeBytes(Bytes.from("later-cycle-2"));
+            Assert.assertTrue(hasEOF(q, recoveredCycle));
+
+            simulateInterruptedEofRecovery(q, recoveredCycle);
+            Assert.assertFalse(hasEOF(q, recoveredCycle));
+        }
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            Assert.assertFalse("restart must observe the interrupted unsealed cycle",
+                    hasEOF(q, recoveredCycle));
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("retried"));
+            Assert.assertFalse("a retry that did not replace EOF must remain open until backfill completes",
+                    hasEOF(q, recoveredCycle));
+            appender.normaliseEOFs();
+            Assert.assertTrue("completed backfill must normalise its selected historical cycle",
+                    hasEOF(q, recoveredCycle));
+
+            // Also model death after the recovered entry committed but before replacement EOF.
+            simulateInterruptedEofRecovery(q, recoveredCycle);
+            Assert.assertFalse(hasEOF(q, recoveredCycle));
+        }
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender();
+             ExcerptTailer tailer = q.createTailer()) {
+            expectException("Exact-index recovery found different content for existing entry");
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("conflicting retry"));
+            Assert.assertFalse("a duplicate retry does not itself alter the roll",
+                    hasEOF(q, recoveredCycle));
+            appender.normaliseEOFs();
+            Assert.assertTrue("normalisation after a duplicate retry must reseal the historical cycle",
+                    hasEOF(q, recoveredCycle));
+
+            final Bytes<?> result = Bytes.elasticHeapByteBuffer();
+            assertNextBytes(tailer, result, Bytes.from("first-cycle"));
+            assertNextBytes(tailer, result, Bytes.from("retried"));
+            assertNextBytes(tailer, result, Bytes.from("intermediate-cycle"));
+            assertNextBytes(tailer, result, Bytes.from("later-cycle"));
+            assertNextBytes(tailer, result, Bytes.from("later-cycle-2"));
+            Assert.assertFalse(tailer.readBytes(result.clear()));
+        }
+    }
+
+    @Test
+    public void restartNormalisesCommittedRecoveryWithoutDuplicateRetry() {
+        final File directory = getTmpDir();
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        final AtomicBoolean failAfterIndexUpdate = new AtomicBoolean();
+        final long recoveredIndex;
+        final int recoveredCycle;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .appenderListener((wire, index) -> {
+                    if (failAfterIndexUpdate.get())
+                        throw new IllegalStateException("simulated failure after index update");
+                })
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first-cycle"));
+            recoveredIndex = appender.lastIndexAppended() + 1;
+            recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("intermediate-cycle"));
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("later-cycle"));
+            appender.normaliseEOFs();
+
+            failAfterIndexUpdate.set(true);
+            expectException("queue=" + q.fileAbsolutePath() + ", cycle=" + recoveredCycle
+                    + ", index=0x" + Long.toHexString(recoveredIndex));
+            final IllegalStateException failure = Assert.assertThrows(IllegalStateException.class,
+                    () -> ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("recovered")));
+            Assert.assertEquals("simulated failure after index update", failure.getMessage());
+            Assert.assertFalse("failure after commit must leave recovery visibly incomplete",
+                    hasEOF(q, recoveredCycle));
+            assertBytesAtIndex(q, recoveredIndex, Bytes.from("recovered"));
+        }
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.normaliseEOFs();
+            Assert.assertTrue("restart must reseal committed recovery without relying on a duplicate retry",
+                    hasEOF(q, recoveredCycle));
+        }
+    }
+
+    @Test
+    public void restartReconcilesCommittedRecoveryWithoutIndexedPhaseMarker() {
+        final File directory = getTmpDir();
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        final long recoveredIndex;
+        final int recoveredCycle;
+        final long writePositionBeforeRecovery;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first-cycle"));
+            recoveredIndex = appender.lastIndexAppended() + 1;
+            recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+            writePositionBeforeRecovery = writePosition(q, recoveredCycle);
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("later-cycle"));
+
+            expectException("queue=" + q.fileAbsolutePath() + ", cycle=" + recoveredCycle
+                    + ", index=0x" + Long.toHexString(recoveredIndex));
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("recovered"));
+            modelCommittedRecoveryWithoutIndexedMarker(q, recoveredIndex, recoveredCycle);
+            setWritePosition(q, recoveredCycle, writePositionBeforeRecovery);
+        }
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.normaliseEOFs();
+
+            Assert.assertTrue("restart must reconstruct the missed indexed phase and restore EOF",
+                    hasEOF(q, recoveredCycle));
+            assertBytesAtIndex(q, recoveredIndex, Bytes.from("recovered"));
+            Assert.assertEquals(Long.MIN_VALUE, q.tableStoreGet(RECOVERY_IN_PROGRESS));
+            Assert.assertEquals(Long.MIN_VALUE, q.tableStoreGet(RECOVERY_INDEXED));
+        }
+    }
+
+    @Test
+    public void duplicateRetryReconcilesCommittedRecoveryWithoutIndexedPhaseMarker() {
+        final File directory = getTmpDir();
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        final long recoveredIndex;
+        final int recoveredCycle;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first-cycle"));
+            recoveredIndex = appender.lastIndexAppended() + 1;
+            recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("later-cycle"));
+
+            expectException("queue=" + q.fileAbsolutePath() + ", cycle=" + recoveredCycle
+                    + ", index=0x" + Long.toHexString(recoveredIndex));
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("first-writer"));
+            modelCommittedRecoveryWithoutIndexedMarker(q, recoveredIndex, recoveredCycle);
+        }
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("ignored-duplicate"));
+
+            Assert.assertTrue("duplicate retry must reconcile and reseal the first committed record",
+                    hasEOF(q, recoveredCycle));
+            assertBytesAtIndex(q, recoveredIndex, Bytes.from("first-writer"));
+            Assert.assertEquals(Long.MIN_VALUE, q.tableStoreGet(RECOVERY_IN_PROGRESS));
+            Assert.assertEquals(Long.MIN_VALUE, q.tableStoreGet(RECOVERY_INDEXED));
+        }
+    }
+
+    @Test
+    public void retryCompletesAnInterruptedRecoveryHeader() {
+        final File directory = getTmpDir();
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        final long recoveredIndex;
+        final int recoveredCycle;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first-cycle"));
+            recoveredIndex = appender.lastIndexAppended() + 1;
+            recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("later-cycle"));
+
+            q.tableStorePut(RECOVERY_IN_PROGRESS, recoveredIndex);
+            q.tableStorePut(RECOVERY_INDEXED, Long.MIN_VALUE);
+            simulateInterruptedRecoveryHeader(q, recoveredCycle);
+        }
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            expectException("Exact-index recovery replaced incomplete header");
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("retried"));
+
+            Assert.assertTrue("retry must complete the interrupted header and restore EOF",
+                    hasEOF(q, recoveredCycle));
+            assertBytesAtIndex(q, recoveredIndex, Bytes.from("retried"));
+        }
+    }
+
+    @Test
+    public void pendingRecoveryNormalisationDoesNotSealUnrelatedSparseCycle() {
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        final long recoveredIndex;
+        final int recoveredCycle;
+        final int unrelatedCycle = 500;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir())
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first-cycle"));
+            recoveredIndex = appender.lastIndexAppended() + 1;
+            recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(unrelatedCycle));
+            appender.writeBytes(Bytes.from("unrelated-middle-cycle"));
+            expectException("queue=" + q.fileAbsolutePath() + ", cycle=" + recoveredCycle
+                    + ", index=0x" + Long.toHexString(recoveredIndex));
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("recovered"));
+
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(500));
+            appender.writeBytes(Bytes.from("latest-cycle"));
+            modelCommittedRecoveryWithoutIndexedMarker(q, recoveredIndex, recoveredCycle);
+            simulateInterruptedEofRecovery(q, unrelatedCycle);
+            Assert.assertFalse(hasEOF(q, unrelatedCycle));
+
+            appender.normaliseEOFs();
+
+            Assert.assertTrue(hasEOF(q, recoveredCycle));
+            Assert.assertFalse("recovery completion must not scan and seal unrelated sparse cycles",
+                    hasEOF(q, unrelatedCycle));
+        }
+    }
+
+    @Test
+    public void interruptedRecoveryBeforeIndexingFailsClosedAndCanBeRetried() {
+        final File directory = getTmpDir();
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+        final long recoveredIndex;
+        final int recoveredCycle;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first-cycle"));
+            recoveredIndex = appender.lastIndexAppended() + 1;
+            recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("later-cycle"));
+            Assert.assertTrue(hasEOF(q, recoveredCycle));
+
+            // Model process death after persisting intent and removing EOF, but before committing
+            // and indexing the recovered record.
+            q.tableStorePut(RECOVERY_IN_PROGRESS, recoveredIndex);
+            q.tableStorePut(RECOVERY_INDEXED, Long.MIN_VALUE);
+            simulateInterruptedEofRecovery(q, recoveredCycle);
+        }
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            final IllegalStateException incomplete = Assert.assertThrows(IllegalStateException.class,
+                    appender::normaliseEOFs);
+            Assert.assertTrue(incomplete.getMessage(),
+                    incomplete.getMessage().contains("recovery remains incomplete"));
+            Assert.assertFalse("an unindexed recovery must not be sealed as complete",
+                    hasEOF(q, recoveredCycle));
+
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("retried"));
+            Assert.assertTrue("retry must finish indexing before restoring EOF",
+                    hasEOF(q, recoveredCycle));
+            assertBytesAtIndex(q, recoveredIndex, Bytes.from("retried"));
+            Assert.assertEquals(Long.MIN_VALUE, q.tableStoreGet(RECOVERY_IN_PROGRESS));
+            Assert.assertEquals(Long.MIN_VALUE, q.tableStoreGet(RECOVERY_INDEXED));
+        }
+    }
+
+    @Test
+    public void aDifferentPersistedRecoveryMustCompleteBeforeReplacingEof() {
+        final SetTimeProvider timeProvider = new SetTimeProvider();
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir())
+                .timeProvider(timeProvider)
+                .rollCycle(TEST_HOURLY)
+                .build();
+             ExcerptAppender appender = q.createAppender()) {
+            appender.writeBytes(Bytes.from("first-cycle"));
+            final long recoveredIndex = appender.lastIndexAppended() + 1;
+            final int recoveredCycle = q.rollCycle().toCycle(recoveredIndex);
+            timeProvider.advanceMillis(TimeUnit.HOURS.toMillis(1));
+            appender.writeBytes(Bytes.from("later-cycle"));
+            Assert.assertTrue(hasEOF(q, recoveredCycle));
+
+            q.tableStorePut(RECOVERY_IN_PROGRESS, recoveredIndex + 1);
+            final IllegalStateException conflict = Assert.assertThrows(IllegalStateException.class,
+                    () -> ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("recovered")));
+            Assert.assertTrue(conflict.getMessage(), conflict.getMessage().contains(
+                    "must complete before index 0x" + Long.toHexString(recoveredIndex)));
+            Assert.assertTrue("a conflicting recovery must leave EOF untouched", hasEOF(q, recoveredCycle));
+
+            q.tableStorePut(RECOVERY_IN_PROGRESS, Long.MIN_VALUE);
+            q.tableStorePut(RECOVERY_INDEXED, Long.MIN_VALUE);
+        }
+    }
+
+    @Test
+    public void persistedRecoveryForUnavailableCycleFailsClosed() {
+        final int unavailableCycle = 7;
+
+        try (SingleChronicleQueue q = SingleChronicleQueueBuilder.binary(getTmpDir())
+                .timeProvider(() -> 0)
+                .rollCycle(TEST_HOURLY)
+                .build()) {
+            final long unavailableIndex = q.rollCycle().toIndex(unavailableCycle, 0);
+            q.tableStorePut(RECOVERY_IN_PROGRESS, unavailableIndex);
+            q.tableStorePut(RECOVERY_INDEXED, unavailableIndex);
+
+            try (ExcerptAppender appender = q.createAppender()) {
+                final IllegalStateException unavailable = Assert.assertThrows(IllegalStateException.class,
+                        appender::normaliseEOFs);
+                Assert.assertEquals("Recovery cycle " + unavailableCycle + " is not available",
+                        unavailable.getMessage());
+            } finally {
+                q.tableStorePut(RECOVERY_IN_PROGRESS, Long.MIN_VALUE);
+                q.tableStorePut(RECOVERY_INDEXED, Long.MIN_VALUE);
+            }
+        }
+    }
+
+    private static void simulateInterruptedEofRecovery(SingleChronicleQueue q, int cycle) {
+        replaceEndOfData(q, cycle, NOT_INITIALIZED);
+    }
+
+    private static void simulateInterruptedRecoveryHeader(SingleChronicleQueue q, int cycle) {
+        replaceEndOfData(q, cycle, NOT_COMPLETE);
+    }
+
+    private static void modelCommittedRecoveryWithoutIndexedMarker(SingleChronicleQueue q,
+                                                                    long recoveryIndex,
+                                                                    int recoveryCycle) {
+        q.tableStorePut(RECOVERY_IN_PROGRESS, recoveryIndex);
+        q.tableStorePut(RECOVERY_INDEXED, Long.MIN_VALUE);
+        simulateInterruptedEofRecovery(q, recoveryCycle);
+    }
+
+    private static void replaceEndOfData(SingleChronicleQueue q, int cycle, int replacement) {
+        try (SingleChronicleQueueStore store = q.storeForCycle(cycle, 0, false, null);
+             MappedBytes mappedBytes = store.bytes()) {
+            long position = store.writePosition();
+            position += lengthOf(mappedBytes.readVolatileInt(position)) + SPB_HEADER_SIZE;
+            for (; ; ) {
+                if (store.dataVersion() > 0)
+                    position += BytesUtil.padOffset(position);
+                final int header = mappedBytes.readVolatileInt(position);
+                if (header == END_OF_DATA) {
+                    Assert.assertTrue(mappedBytes.compareAndSwapInt(position, END_OF_DATA, replacement));
+                    return;
+                }
+                Assert.assertNotEquals("reached an uninitialised header before EOF", NOT_INITIALIZED, header);
+                Assert.assertFalse("reached an incomplete header before EOF: " + Integer.toHexString(header),
+                        isNotComplete(header));
+                position += lengthOf(header) + SPB_HEADER_SIZE;
+            }
+        }
+    }
+
     private static void assertBytesAtIndex(SingleChronicleQueue q, long index, Bytes<?> expected) {
         try (ExcerptTailer tailer = q.createTailer()) {
             Assert.assertTrue("unable to move to index 0x" + Long.toHexString(index), tailer.moveToIndex(index));
@@ -617,6 +1036,12 @@ public class InternalAppenderWriteBytesTest extends QueueTestCommon {
             position += BytesUtil.padOffset(position);
             Assert.assertEquals(NOT_INITIALIZED, bytes.readVolatileInt(position));
             bytes.writeVolatileInt(position, header);
+        }
+    }
+
+    private static void setWritePosition(SingleChronicleQueue q, int cycle, long position) {
+        try (SingleChronicleQueueStore store = q.storeForCycle(cycle, 0, false, null)) {
+            store.writePosition(position);
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/StoreAppenderTest.java
@@ -7,11 +7,11 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.MappedBytes;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
-import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.impl.ExcerptContext;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
@@ -23,7 +23,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
+import java.io.StreamCorruptedException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -393,7 +393,7 @@ public class StoreAppenderTest extends QueueTestCommon {
 
             // Simulate termination after publishing the ready data header but before publishing
             // the store write position. Sequence zero uses zero as its write-position sentinel.
-            forceWritePosition(appender.store, 0);
+            appender.store.writePositionForTesting(0);
         }
 
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
@@ -463,6 +463,115 @@ public class StoreAppenderTest extends QueueTestCommon {
         }
     }
 
+    @Test
+    public void restartAdoptsReadyRecoveryBeyondAStaleWritePosition() throws IOException {
+        final File directory = queueDirectory.newFolder();
+        final AtomicLong clock = new AtomicLong();
+        final long recoveredIndex;
+        final int recoveredCycle;
+        final long writePositionBeforeRecovery;
+        final long recoveredWritePosition;
+        final long eofPosition;
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(clock::get)
+                .rollCycle(TEST4_DAILY)
+                .build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("first-cycle"));
+            recoveredIndex = appender.lastIndexAppended() + 1;
+            recoveredCycle = queue.rollCycle().toCycle(recoveredIndex);
+            writePositionBeforeRecovery = appender.store.writePosition();
+            try (DocumentContext metadata = appender.writingDocument(true)) {
+                metadata.wire().write("recovery-context").text("metadata-before-eof");
+            }
+
+            clock.addAndGet(TimeUnit.HOURS.toMillis(25));
+            appender.writeBytes(Bytes.from("later-cycle"));
+            expectException("queue=" + queue.fileAbsolutePath() + ", cycle=" + recoveredCycle
+                    + ", index=0x" + Long.toHexString(recoveredIndex));
+            ((InternalAppender) appender).writeBytes(recoveredIndex, Bytes.from("recovered"));
+            recoveredWritePosition = appender.store.writePosition();
+
+            queue.tableStorePut("recoveryInProgress", recoveredIndex);
+            queue.tableStorePut("recoveryIndexed", Long.MIN_VALUE);
+            eofPosition = endOfDataPosition(queue, recoveredCycle);
+            replaceEndOfData(queue, recoveredCycle, eofPosition);
+            try (SingleChronicleQueueStore store = queue.storeForCycle(recoveredCycle, 0, false, null)) {
+                store.writePositionForTesting(writePositionBeforeRecovery);
+            }
+        }
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(directory)
+                .timeProvider(clock::get)
+                .rollCycle(TEST4_DAILY)
+                .build();
+             ExcerptAppender appender = queue.createAppender();
+             ExcerptTailer tailer = queue.createTailer()) {
+            appender.normaliseEOFs();
+
+            assertEquals("restart must restore EOF after adopting the ready record",
+                    Wires.END_OF_DATA, readHeader(firstQueueFile(directory), eofPosition));
+            try (SingleChronicleQueueStore store = queue.storeForCycle(recoveredCycle, 0, false, null)) {
+                assertEquals("restart must publish the adopted record as the store write position",
+                        recoveredWritePosition, store.writePosition());
+            }
+            assertTrue(tailer.moveToIndex(recoveredIndex));
+            assertNextBytes(tailer, Bytes.elasticHeapByteBuffer(), "recovered");
+            assertEquals(Long.MIN_VALUE, queue.tableStoreGet("recoveryInProgress"));
+            assertEquals(Long.MIN_VALUE, queue.tableStoreGet("recoveryIndexed"));
+        }
+    }
+
+    @Test
+    public void recoveryInspectionFailureKeepsTheDurableIntent() throws IOException {
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder()).build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("existing"));
+            final long recoveryIndex = appender.lastIndexAppended() + 1;
+            queue.tableStorePut("recoveryInProgress", recoveryIndex);
+            queue.tableStorePut("recoveryIndexed", Long.MIN_VALUE);
+            final SingleChronicleQueueStore realStore = appender.store;
+
+            try (MappedBytes fakeBytes = MappedBytes.mappedBytes(queueDirectory.newFile(), 64 << 10);
+                 SingleChronicleQueueStore failingStore = new FailingSequenceStore(fakeBytes)) {
+                appender.store = failingStore;
+                final IllegalStateException failure = org.junit.Assert.assertThrows(
+                        IllegalStateException.class, appender::normaliseEOFs);
+                assertTrue(failure.getMessage().contains("Unable to reconcile persisted recovery"));
+                assertTrue(failure.getCause() instanceof StreamCorruptedException);
+                assertEquals("failed inspection must retain recovery intent",
+                        recoveryIndex, queue.tableStoreGet("recoveryInProgress"));
+            } finally {
+                appender.store = realStore;
+                queue.tableStorePut("recoveryInProgress", Long.MIN_VALUE);
+                queue.tableStorePut("recoveryIndexed", Long.MIN_VALUE);
+            }
+        }
+    }
+
+    @Test
+    public void normalisationDoesNotAdoptDataForANonNextPendingIndex() throws IOException {
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.single(queueDirectory.newFolder()).build();
+             ExcerptAppender excerptAppender = queue.createAppender()) {
+            final StoreAppender appender = (StoreAppender) excerptAppender;
+            appender.writeBytes(Bytes.from("existing"));
+            final long nonNextRecoveryIndex = appender.lastIndexAppended() + 2;
+            queue.tableStorePut("recoveryInProgress", nonNextRecoveryIndex);
+            queue.tableStorePut("recoveryIndexed", Long.MIN_VALUE);
+
+            final IllegalStateException failure = org.junit.Assert.assertThrows(
+                    IllegalStateException.class, appender::normaliseEOFs);
+
+            assertTrue(failure.getMessage().contains("recovery remains incomplete"));
+            assertEquals(nonNextRecoveryIndex, queue.tableStoreGet("recoveryInProgress"));
+            queue.tableStorePut("recoveryInProgress", Long.MIN_VALUE);
+            queue.tableStorePut("recoveryIndexed", Long.MIN_VALUE);
+        }
+    }
+
     private static void assertNextBytes(ExcerptTailer tailer, Bytes<?> result, String expected) {
         result.clear();
         assertTrue(tailer.readBytes(result));
@@ -482,14 +591,43 @@ public class StoreAppenderTest extends QueueTestCommon {
         }
     }
 
-    private static void forceWritePosition(SingleChronicleQueueStore store, long newWritePosition) {
-        try {
-            final Field field = store.getClass().getDeclaredField("writePosition");
-            field.setAccessible(true);
-            ((LongValue) field.get(store)).setValue(newWritePosition);
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError("Unable to simulate interrupted write-position publication", e);
+    private static void replaceEndOfData(SingleChronicleQueue queue, int cycle, long position) {
+        try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, 0, false, null);
+             MappedBytes bytes = store.bytes()) {
+            assertTrue(bytes.compareAndSwapInt(position, Wires.END_OF_DATA, Wires.NOT_INITIALIZED));
         }
+    }
+
+    private static long endOfDataPosition(SingleChronicleQueue queue, int cycle) {
+        try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, 0, false, null);
+             MappedBytes bytes = store.bytes()) {
+            long position = store.writePosition();
+            position += Wires.lengthOf(bytes.readVolatileInt(position)) + Wires.SPB_HEADER_SIZE;
+            for (; ; ) {
+                position += net.openhft.chronicle.bytes.BytesUtil.padOffset(position);
+                final int header = bytes.readVolatileInt(position);
+                if (header == Wires.END_OF_DATA)
+                    return position;
+                if (Wires.isNotComplete(header))
+                    throw new AssertionError("Reached an incomplete header before EOF");
+                position += Wires.SPB_HEADER_SIZE + Wires.lengthOf(header);
+            }
+        }
+    }
+
+    private static int readHeader(File queueFile, long position) throws IOException {
+        try (MappedBytes bytes = MappedBytes.mappedBytes(queueFile, 64 << 10)) {
+            return bytes.readVolatileInt(position);
+        }
+    }
+
+    private static File firstQueueFile(File directory) {
+        final File[] queueFiles = directory.listFiles(
+                (ignored, name) -> name.endsWith(SingleChronicleQueue.SUFFIX));
+        if (queueFiles == null || queueFiles.length == 0)
+            throw new AssertionError("No queue files in " + directory);
+        java.util.Arrays.sort(queueFiles);
+        return queueFiles[0];
     }
 
     private static final class FailingEofStore extends SingleChronicleQueueStore {
@@ -500,6 +638,23 @@ public class StoreAppenderTest extends QueueTestCommon {
         @Override
         public boolean writeEOF(Wire wire, long timeoutMS) {
             return false;
+        }
+
+        @Override
+        public long writePosition() {
+            return 0;
+        }
+    }
+
+    private static final class FailingSequenceStore extends SingleChronicleQueueStore {
+        FailingSequenceStore(MappedBytes bytes) {
+            super(TEST4_DAILY, WireType.BINARY, bytes, 8, 1);
+        }
+
+        @Override
+        public long sequenceForPosition(ExcerptContext ec, long position, boolean inclusive)
+                throws StreamCorruptedException {
+            throw new StreamCorruptedException("simulated corrupt recovery position");
         }
 
         @Override


### PR DESCRIPTION
## Purpose

Make exact-index EOF recovery restart-safe without appender-local dirty-cycle state, high-water
rewinds or integer-range scans of unrelated cycles.

This is Q4 of the focused successor stack extracted from #1732 and is based on corrected Q3.

## Contract

* recovery intent is persisted before EOF mutation;
* successful data and sparse-index completion is persisted as a distinct indexed phase;
* restart reconciliation can adopt a ready exact-next record beyond a stale write position, repeat
  monotonic write-position/index updates and publish a missing indexed phase;
* if a complete exact-next record cannot be proved, recovery fails closed until retry;
* committed recovery can be resealed without depending on a duplicate resend;
* pending or selected historical recovery is handled directly and returns without scanning
  unrelated integer cycles;
* EOF is verified before recovery markers are cleared.

## Product boundary

CQE is the active consumer in scope and its completion ordering is supplied by #956/#957. CQE
depends on Chronicle Network, which does not call Queue's internal exact-index API. Chronicle
Network Enterprise is a separate unused product; its legacy UDP caller is not a release gate.

## Validation

Tests cover all durable marker/physical-record combinations, incomplete-header retry, ready data
beyond stale write position, metadata before recovery, missing indexed phase, unavailable cycles,
inspection corruption, non-next intent, sparse cycle gaps and EOF restoration failure.

After the Q2 sparse-cycle correction and Q3/Q4 rebase, all 38 affected `StoreAppenderTest` and
`InternalAppenderWriteBytesTest` tests pass under Java 8, 11 and 21. The sparse-cycle regression
fails under the old N+1 selector. Earlier aggregate coverage/full-suite and recovery mutation
receipts remain historical evidence for the predecessor stack; refreshed exact-head CI is pending.

This PR remains draft until its Queue artifact is coordinated with CQE and the supported BOM/release
path is recorded. Cross-repository TeamCity failures are informational until that artifact exists.
