### PR TITLE
QUEUE-144: rebuild Queue context listeners after QUEUE-143

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1868,6 +1868,7 @@ For comparison see http://kafka.apache.org/documentation.html[Kafka Documentatio
 * https://github.com/OpenHFT/Chronicle-Queue/tree/develop/docs/FAQ.adoc[FAQ] - questions asked by customers
 * https://github.com/OpenHFT/Chronicle-Queue/tree/develop/docs/How_it_works.adoc[How it works] - more depth on how Chronicle Queue is implemented
 * https://github.com/OpenHFT/Chronicle-Queue/tree/develop/docs/utilities.adoc[Utilities] - lists some useful utilities for working with queue files
+* link:docs/context-listeners.adoc[Queue context listeners] - writes roll-level context and handles reader restarts
 
 ==== Online support
 

--- a/README.adoc
+++ b/README.adoc
@@ -1868,7 +1868,7 @@ For comparison see http://kafka.apache.org/documentation.html[Kafka Documentatio
 * https://github.com/OpenHFT/Chronicle-Queue/tree/develop/docs/FAQ.adoc[FAQ] - questions asked by customers
 * https://github.com/OpenHFT/Chronicle-Queue/tree/develop/docs/How_it_works.adoc[How it works] - more depth on how Chronicle Queue is implemented
 * https://github.com/OpenHFT/Chronicle-Queue/tree/develop/docs/utilities.adoc[Utilities] - lists some useful utilities for working with queue files
-* link:docs/context-listeners.adoc[Queue context listeners] - writes roll-level context and handles reader restarts
+* link:docs/context-listeners.adoc[Queue context listeners] - writes roll-level context before application data
 
 ==== Online support
 

--- a/README.adoc
+++ b/README.adoc
@@ -1868,6 +1868,7 @@ For comparison see http://kafka.apache.org/documentation.html[Kafka Documentatio
 * https://github.com/OpenHFT/Chronicle-Queue/tree/develop/docs/FAQ.adoc[FAQ] - questions asked by customers
 * https://github.com/OpenHFT/Chronicle-Queue/tree/develop/docs/How_it_works.adoc[How it works] - more depth on how Chronicle Queue is implemented
 * https://github.com/OpenHFT/Chronicle-Queue/tree/develop/docs/utilities.adoc[Utilities] - lists some useful utilities for working with queue files
+//! The Queue-specific guide records roll, EOF, lock and recovery constraints beyond Wire's generic lifecycle.
 * link:docs/context-listeners.adoc[Queue context listeners] - writes roll-level context before application data
 
 ==== Online support

--- a/docs/context-listeners.adoc
+++ b/docs/context-listeners.adoc
@@ -1,0 +1,65 @@
+= Queue Context Listeners
+
+A context listener writes ordinary method-writer records before an appender's first data document
+in each roll cycle. This is useful for snapshots, definitions or checkpoints that readers need
+before processing that cycle's data.
+
+[source,java]
+----
+SingleChronicleQueue queue = builder.build();
+ExcerptAppender appender = queue.acquireAppender();
+appender.contextListener(Events.class, events -> events.context(contextSnapshot));
+Events events = appender.methodWriter(Events.class);
+----
+
+The listener runs under the queue write lock. It must write through the supplied method writer and
+must be configured before the appender is first used. The writer may be retained for normal use.
+The listener is appender-local, is not retried after failure, and remains owned by the caller.
+Use the thread-local appender returned by `acquireAppender()` when its method writer must share an
+appender-local listener. Alternatively, configure the default listener on the queue builder.
+
+A new appender has no record of context written by an earlier appender. It can therefore write the
+context again when it starts in an existing roll cycle. Context records should be complete and
+idempotent.
+
+== Progressive context
+
+An application that already holds a document can write context without configuring a listener.
+The context DTO can keep its last written count in a transient field and report when it needs
+resending:
+
+[source,java]
+----
+final class ContextSnapshot extends SelfDescribingMarshallable implements ProgressiveContext {
+    private String definition;
+    private transient int lastContextCount = -1;
+
+    @Override
+    public boolean needsResending(int contextCount) {
+        if (contextCount <= lastContextCount)
+            return false;
+        lastContextCount = contextCount;
+        return true;
+    }
+}
+
+try (DocumentContext document = events.writingDocument()) {
+    if (contextSnapshot.needsResending(document.contextCount()))
+        events.context(contextSnapshot);
+    events.event(data);
+}
+----
+
+For Queue, the context count is the roll cycle. The context and data calls above are committed in
+one document. This pattern is not supported with double buffering.
+
+== Named tailer restarts
+
+A named tailer persists its next read position. After a restart it may resume in the middle of a
+cycle and will not reread context stored earlier in that cycle. A context listener does not restore
+the reader's in-memory state.
+
+Applications that require this state must either persist it separately or replay the current cycle
+up to the named tailer's saved index with a temporary unnamed tailer. Replay handlers must rebuild
+context without business side effects, and the temporary tailer must not advance the named tailer.
+If the required roll file has already been removed, recovery needs another durable source.

--- a/docs/context-listeners.adoc
+++ b/docs/context-listeners.adoc
@@ -1,8 +1,11 @@
 = Queue Context Listeners
 
+//! ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter establishes Queue's
+//! appender/roll mapping; Wire owns only the generic output-context lifecycle.
 A context listener writes ordinary method-writer records before an appender's first data document
-in each roll cycle. This is useful for snapshots, definitions or checkpoints that readers need
-before processing that cycle's data.
+in each actual ordinary roll cycle. Queue adds destination, EOF and write-lock constraints to
+Wire's generic output-context lifecycle. This is useful for snapshots, definitions or checkpoints
+that readers need before processing that cycle's data.
 
 [source,java]
 ----
@@ -12,36 +15,50 @@ appender.contextListener(Events.class, events -> events.context(contextSnapshot)
 Events events = appender.methodWriter(Events.class);
 ----
 
-The listener runs under the queue write lock. Queue first applies its monotonic/high-water cycle
+//! sealedHighestRollIsResolvedBeforeDocumentListener and secondEofLeavesListenerRegistrationOpen
+//! require ordinary destination and EOF preflight before callback state changes.
+The listener runs under the Queue write lock. Queue first applies its monotonic/high-water cycle
 selection and its single permitted advance past EOF, then invokes the listener for that actual
 writable cycle. The listener's records and the triggering document are therefore written to the
-same cycle. Exact-index recovery does not invoke the listener or change the appender's ordinary
-context count.
+same cycle. Metadata and exact-index recovery do not invoke the listener or consume its registration;
+exact recovery also does not change the appender's ordinary context count.
 
+//! listenerRemainsCallerOwned and writesContextBeforeDataAndAllowsRetainingWriter require caller
+//! ownership and retained-writer delegation after the callback succeeds.
 The listener must write through the supplied method writer and must be configured before the
 appender is first used for ordinary output. The writer may be retained for normal use. The listener
 is appender-local and remains owned by the caller.
 Use the thread-local appender returned by `acquireAppender()` when its method writer must share an
 appender-local listener. Alternatively, configure the default listener on the queue builder.
 
-Listener failure is fail-closed. Queue does not retry a callback which may already have committed
+//! listenerFailureAfterWritingContextIsNotRetriedInTheSameRoll pins per-appender failure state;
+//! same-path and symlink-alias tests pin only JVM-wide canonical-real-path callback ownership.
+Listener failure is fail-closed for that appender's current listener lifecycle. Queue does not retry
+a callback which may already have committed
 partial context. A thrown exception or a callback returning with an unclosed document poisons the
-current cycle: later application writes fail until a later roll rearms the listener. Calls back into
-the appender, including through a second appender for the same Queue, fail immediately. A rejected
-append-lock preflight does not consume listener registration or state.
+current cycle for that appender: its later application writes fail until a later roll rearms the
+listener. During a callback, a JVM-wide guard keyed by the Queue directory's canonical real path
+rejects appender entry through another appender, Queue instance, thread or symlink alias. This guard
+prevents same-JVM re-entry; cross-process writers remain coordinated by the Queue write lock. A
+rejected append-lock preflight does not consume listener registration or state.
 
 A new appender has no record of context written by an earlier appender. It can therefore write the
 context again when it starts in an existing roll cycle. Context records should be complete and
 idempotent.
 
+//! rolledBackClockDoesNotRepeatAnOlderContext and exactHistoricalRecoveryDoesNotChangeOrdinaryContext
+//! pin ordinary-cycle identity; rejectsDoubleBuffering pins the separate availability restriction.
 For Queue, `ExcerptAppender.contextCount()` is `-1` before the first ordinary destination is
 selected and after close; otherwise it is the last actual ordinary destination cycle. It never
 moves backwards when an exact recovery temporarily positions the appender on a historical cycle.
-Context listeners and context counts are unsupported with double buffering, asynchronous write
-buffers, encoding or encryption.
+Context listener registration is unsupported with double buffering, asynchronous write buffers,
+encoding or encryption. Independently, `contextCount()` is unavailable with double buffering
+because the destination cycle is selected only when the buffer is flushed.
 
 == Named tailer restarts
 
+//! tailerDocumentsExposeTheirActualCycle establishes document identity but cannot reconstruct
+//! application state skipped when a named tailer resumes within an existing cycle.
 A named tailer persists its next read position. After a restart it may resume in the middle of a
 cycle and will not reread context stored earlier in that cycle. A context listener does not restore
 the reader's in-memory state.

--- a/docs/context-listeners.adoc
+++ b/docs/context-listeners.adoc
@@ -12,46 +12,33 @@ appender.contextListener(Events.class, events -> events.context(contextSnapshot)
 Events events = appender.methodWriter(Events.class);
 ----
 
-The listener runs under the queue write lock. It must write through the supplied method writer and
-must be configured before the appender is first used. The writer may be retained for normal use.
-The listener is appender-local, is not retried after failure, and remains owned by the caller.
+The listener runs under the queue write lock. Queue first applies its monotonic/high-water cycle
+selection and its single permitted advance past EOF, then invokes the listener for that actual
+writable cycle. The listener's records and the triggering document are therefore written to the
+same cycle. Exact-index recovery does not invoke the listener or change the appender's ordinary
+context count.
+
+The listener must write through the supplied method writer and must be configured before the
+appender is first used for ordinary output. The writer may be retained for normal use. The listener
+is appender-local and remains owned by the caller.
 Use the thread-local appender returned by `acquireAppender()` when its method writer must share an
 appender-local listener. Alternatively, configure the default listener on the queue builder.
+
+Listener failure is fail-closed. Queue does not retry a callback which may already have committed
+partial context. A thrown exception or a callback returning with an unclosed document poisons the
+current cycle: later application writes fail until a later roll rearms the listener. Calls back into
+the appender, including through a second appender for the same Queue, fail immediately. A rejected
+append-lock preflight does not consume listener registration or state.
 
 A new appender has no record of context written by an earlier appender. It can therefore write the
 context again when it starts in an existing roll cycle. Context records should be complete and
 idempotent.
 
-== Progressive context
-
-An application that already holds a document can write context without configuring a listener.
-The context DTO can keep its last written count in a transient field and report when it needs
-resending:
-
-[source,java]
-----
-final class ContextSnapshot extends SelfDescribingMarshallable implements ProgressiveContext {
-    private String definition;
-    private transient int lastContextCount = -1;
-
-    @Override
-    public boolean needsResending(int contextCount) {
-        if (contextCount <= lastContextCount)
-            return false;
-        lastContextCount = contextCount;
-        return true;
-    }
-}
-
-try (DocumentContext document = events.writingDocument()) {
-    if (contextSnapshot.needsResending(document.contextCount()))
-        events.context(contextSnapshot);
-    events.event(data);
-}
-----
-
-For Queue, the context count is the roll cycle. The context and data calls above are committed in
-one document. This pattern is not supported with double buffering.
+For Queue, `ExcerptAppender.contextCount()` is `-1` before the first ordinary destination is
+selected and after close; otherwise it is the last actual ordinary destination cycle. It never
+moves backwards when an exact recovery temporarily positions the appender on a historical cycle.
+Context listeners and context counts are unsupported with double buffering, asynchronous write
+buffers, encoding or encryption.
 
 == Named tailer restarts
 
@@ -59,7 +46,6 @@ A named tailer persists its next read position. After a restart it may resume in
 cycle and will not reread context stored earlier in that cycle. A context listener does not restore
 the reader's in-memory state.
 
-Applications that require this state must either persist it separately or replay the current cycle
-up to the named tailer's saved index with a temporary unnamed tailer. Replay handlers must rebuild
-context without business side effects, and the temporary tailer must not advance the named tailer.
-If the required roll file has already been removed, recovery needs another durable source.
+Applications that require this state must persist it separately or implement application-specific
+reconstruction. If the required roll file has already been removed, recovery needs another durable
+source.

--- a/docs/context-listeners.adoc
+++ b/docs/context-listeners.adoc
@@ -47,7 +47,8 @@ context again when it starts in an existing roll cycle. Context records should b
 idempotent.
 
 //! rolledBackClockDoesNotRepeatAnOlderContext and exactHistoricalRecoveryDoesNotChangeOrdinaryContext
-//! pin ordinary-cycle identity; rejectsDoubleBuffering pins the separate availability restriction.
+//! pin ordinary-cycle identity; doubleBufferedAppenderAndDocumentContextCountsAreUnavailable pins
+//! the separate count-availability restriction at both public surfaces.
 For Queue, `ExcerptAppender.contextCount()` is `-1` before the first ordinary destination is
 selected and after close; otherwise it is the last actual ordinary destination cycle. It never
 moves backwards when an exact recovery temporarily positions the appender on a historical cycle.

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
@@ -77,6 +77,22 @@ public interface ExcerptAppender extends ExcerptCommon<ExcerptAppender>, Marshal
     }
 
     /**
+     * {@inheritDoc}
+     * <p>
+     * For Queue, an output context is a roll cycle. Each appender's listener runs under the queue
+     * write lock before that appender's first data document in a cycle. It is not called for
+     * metadata, explicit-index writes or append-locked queues. A restarted appender can therefore
+     * write context again in an existing cycle. Context listeners are not supported with double
+     * buffering, and the caller retains ownership of the listener.
+     */
+    @NotNull
+    @Override
+    default <T> ExcerptAppender contextListener(@NotNull Class<T> writerType,
+                                                @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Creates and returns a new writer proxy for the given interface {@code tclass} and the given {@code additional }
      * interfaces.
      * <p>

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
@@ -83,10 +83,11 @@ public interface ExcerptAppender extends ExcerptCommon<ExcerptAppender>, Marshal
      * write lock before that appender's first data document in a cycle. Queue resolves the actual
      * monotonic destination, including one permitted advance past EOF, before the callback. It is
      * not called for metadata, explicit-index writes or append-locked queues. Callback failure
-     * poisons the current cycle until a later roll; it is never retried in place. A restarted
-     * appender can write context again in an existing cycle. Context listeners are not supported
-     * with double buffering, asynchronous output, encoding or encryption, and the caller retains
-     * ownership of the listener.
+     * poisons this appender's current listener lifecycle until a later roll; it is never retried in
+     * place. During a callback, appender entry through the same canonical Queue path is rejected in
+     * this JVM. A restarted appender can write context again in an existing cycle. Context listeners
+     * are not supported with double buffering, asynchronous output, encoding or encryption, and the
+     * caller retains ownership of the listener.
      */
     @NotNull
     @Override

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
@@ -92,6 +92,8 @@ public interface ExcerptAppender extends ExcerptCommon<ExcerptAppender>, Marshal
     @Override
     default <T> ExcerptAppender contextListener(@NotNull Class<T> writerType,
                                                 @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        //! The default keeps third-party ExcerptAppender implementations source-compatible while
+        //! StoreAppender supplies Queue's concrete listener lifecycle.
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/ExcerptAppender.java
@@ -80,10 +80,13 @@ public interface ExcerptAppender extends ExcerptCommon<ExcerptAppender>, Marshal
      * {@inheritDoc}
      * <p>
      * For Queue, an output context is a roll cycle. Each appender's listener runs under the queue
-     * write lock before that appender's first data document in a cycle. It is not called for
-     * metadata, explicit-index writes or append-locked queues. A restarted appender can therefore
-     * write context again in an existing cycle. Context listeners are not supported with double
-     * buffering, and the caller retains ownership of the listener.
+     * write lock before that appender's first data document in a cycle. Queue resolves the actual
+     * monotonic destination, including one permitted advance past EOF, before the callback. It is
+     * not called for metadata, explicit-index writes or append-locked queues. Callback failure
+     * poisons the current cycle until a later roll; it is never retried in place. A restarted
+     * appender can write context again in an existing cycle. Context listeners are not supported
+     * with double buffering, asynchronous output, encoding or encryption, and the caller retains
+     * ownership of the listener.
      */
     @NotNull
     @Override

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -147,8 +147,9 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         try {
             try {
                 notifyListener();
-                //! Explicit rollback or an open document means no complete context was published;
-                //! the rollback/unclosed regressions require fail-closed state, never success.
+                //! ContextListenerCoreTest#unclosedListenerDocumentPoisonsOnlyTheCurrentRoll and
+                //! #listenerRollbackThenResetPoisonsContextAndAutomaticCloseIsHarmless require
+                //! incomplete or explicitly rolled-back context to fail closed, never report success.
                 if (listenerRolledBack)
                     throw new IllegalStateException("Queue context listener rolled back its output document");
                 if (listenerDocumentIsOpen())
@@ -220,6 +221,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @NotNull
     @Override
     public <T> MethodWriterBuilder<T> methodWriterBuilder(boolean metaData, @NotNull Class<T> type) {
+        //! ContextListenerCoreTest#encodesContextWithQueueWireType distinguishes the Queue's
+        //! configured Wire type from a hard-coded listener format while retaining this locked output.
         VanillaMethodWriterBuilder<T> builder = new VanillaMethodWriterBuilder<>(type,
                 appender.queue().wireType(),
                 () -> new BinaryMethodWriterInvocationHandler(type, metaData,
@@ -298,7 +301,9 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         nesting = 0;
         // reset() has already closed the shared underlying document. Each outstanding
         // try-with-resources scope still invokes close(), which must now be harmless.
-        //! Sequential resets leave closes pending from every earlier try-with-resources scope.
+        //! ContextListenerCoreTest#sequentialResetsPreserveAutomaticClosesForQueueListener and
+        //! #sequentialResetsPreserveAutomaticClosesForAppenderListener require accumulation: each
+        //! reset satisfies a document now, but every enclosing try-with-resources scope closes later.
         closesAfterReset += outstandingCloses;
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -4,6 +4,7 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.bytes.MethodWriterBuilder;
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.wire.BinaryMethodWriterInvocationHandler;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.DocumentContextHolder;
@@ -30,9 +31,18 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @Nullable
     private final Object methodWriter;
     private boolean started;
-    private boolean notifying;
-    private int lastContextCount = -1;
+    private Status status = Status.READY;
+    private int contextCount = -1;
+    @Nullable
+    private Throwable failure;
     private int nesting;
+
+    private enum Status {
+        READY,
+        IN_PROGRESS,
+        SUCCEEDED,
+        FAILED
+    }
 
     private ContextListenerState(boolean started) {
         this.appender = null;
@@ -86,44 +96,69 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     void onWriteAttempt() {
         if (listener == null)
             return;
-        if (notifying)
+        if (status == Status.IN_PROGRESS)
             throw new IllegalStateException("Cannot write to the appender from within a ContextListener; " +
                     "write through the supplied method writer instead");
         started = true;
     }
 
-    boolean beforeDocument(boolean metaData) {
+    boolean beforeDocument(boolean metaData, int actualContextCount) {
         if (listener == null || metaData)
             return false;
-        return notifyIfNeeded();
+        return notifyIfNeeded(actualContextCount);
     }
 
-    boolean beforeRawDocument() {
+    boolean beforeRawDocument(int actualContextCount) {
         if (listener == null)
             return false;
-        appender.resetPositionForContextListener();
-        return notifyIfNeeded();
+        return notifyIfNeeded(actualContextCount);
     }
 
-    private boolean notifyIfNeeded() {
+    private boolean notifyIfNeeded(int actualContextCount) {
         StoreAppender appender = this.appender;
-        int contextCount = appender.cycle();
-        if (contextCount <= lastContextCount)
+        if (actualContextCount < contextCount)
+            throw new IllegalStateException("Queue context count moved backwards from " +
+                    contextCount + " to " + actualContextCount);
+        if (actualContextCount > contextCount) {
+            contextCount = actualContextCount;
+            status = Status.READY;
+            failure = null;
+        }
+        if (status == Status.SUCCEEDED)
             return false;
-        lastContextCount = contextCount;
+        if (status == Status.FAILED)
+            throw new IllegalStateException("The Queue context listener failed for context " +
+                    contextCount + "; a later roll is required before application data can be written", failure);
+        if (status == Status.IN_PROGRESS)
+            throw new IllegalStateException("Queue context listener recursion is not permitted");
 
-        notifying = true;
+        status = Status.IN_PROGRESS;
+        appender.queue().enterContextListenerCallback();
         try {
             try {
                 notifyListener();
-            } finally {
-                rollbackIfNotComplete();
+                if (listenerDocumentIsOpen())
+                    throw new IllegalStateException("Queue context listener returned with an unclosed document");
+                status = Status.SUCCEEDED;
+                return true;
+            } catch (Throwable callbackFailure) {
+                try {
+                    rollbackIfNotComplete();
+                } catch (Throwable rollbackFailure) {
+                    callbackFailure.addSuppressed(rollbackFailure);
+                }
+                status = Status.FAILED;
+                failure = callbackFailure;
+                throw Jvm.rethrow(callbackFailure);
             }
-            return true;
         } finally {
             nesting = 0;
-            notifying = false;
+            appender.queue().exitContextListenerCallback();
         }
+    }
+
+    private boolean listenerDocumentIsOpen() {
+        return nesting > 0 && context.isOpen();
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -133,14 +168,14 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
 
     @Override
     public DocumentContext writingDocument(boolean metaData) {
-        return notifying
+        return status == Status.IN_PROGRESS
                 ? acquireWritingDocument(metaData)
                 : appender.writingDocument(metaData);
     }
 
     @Override
     public DocumentContext acquireWritingDocument(boolean metaData) {
-        if (!notifying)
+        if (status != Status.IN_PROGRESS)
             return appender.acquireWritingDocument(metaData);
 
         StoreAppender.StoreAppenderContext context = this.context;
@@ -171,7 +206,7 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
 
     @Override
     public void rollbackIfNotComplete() {
-        if (!notifying) {
+        if (status != Status.IN_PROGRESS) {
             appender.rollbackIfNotComplete();
             return;
         }
@@ -186,7 +221,7 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
 
     @Override
     public boolean writingIsComplete() {
-        return notifying
+        return status == Status.IN_PROGRESS
                 ? context.writingIsComplete()
                 : appender.writingIsComplete();
     }
@@ -221,7 +256,7 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     }
 
     private void requireCallback() {
-        if (!notifying)
+        if (status != Status.IN_PROGRESS)
             throw new IllegalStateException("ContextListener document is not active");
     }
 }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -267,6 +267,14 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @Override
     public void reset() {
         requireCallback();
+        // DocumentContext.reset() means close/commit the active document and then discard the
+        // holder state. Clearing the underlying context while it is still open would let the
+        // triggering application write overwrite an uncommitted listener record.
+        if (nesting > 0 && context.isOpen()) {
+            context.chainedElement(false);
+            nesting = 1;
+            close();
+        }
         context.reset();
         nesting = 0;
     }

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -153,6 +153,12 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
                 }
                 status = Status.FAILED;
                 failure = callbackFailure;
+                Jvm.warn().on(ContextListenerState.class,
+                        "Queue context listener failed: listenerType=" + listener.getClass().getName()
+                                + ", appenderIdentity=0x"
+                                + Integer.toHexString(System.identityHashCode(appender))
+                                + ", contextCount=" + contextCount,
+                        callbackFailure);
                 throw Jvm.rethrow(callbackFailure);
             }
         } finally {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -298,7 +298,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         nesting = 0;
         // reset() has already closed the shared underlying document. Each outstanding
         // try-with-resources scope still invokes close(), which must now be harmless.
-        closesAfterReset = outstandingCloses;
+        //! Sequential resets leave closes pending from every earlier try-with-resources scope.
+        closesAfterReset += outstandingCloses;
     }
 
     private void requireCallback() {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -102,6 +102,9 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     void onWriteAttempt() {
         if (listener == null)
             return;
+        //! metadataDoesNotConsumeAppenderListenerRegistration and
+        //! appendLockRejectionDoesNotConsumeListenerRegistration require registration to close only
+        //! after an ordinary write has passed its non-mutating append-lock preflight.
         if (status == Status.IN_PROGRESS)
             throw new IllegalStateException("Cannot write to the appender from within a ContextListener; " +
                     "write through the supplied method writer instead");
@@ -122,6 +125,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
 
     private boolean notifyIfNeeded(int actualContextCount) {
         StoreAppender appender = this.appender;
+        //! Defensive invariant: Queue's monotonic destination selector should make this unreachable;
+        //! accepting a backwards value would attach application data to context from a later cycle.
         if (actualContextCount < contextCount)
             throw new IllegalStateException("Queue context count moved backwards from " +
                     contextCount + " to " + actualContextCount);
@@ -192,6 +197,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
 
     @Override
     public DocumentContext writingDocument(boolean metaData) {
+        //! writesContextBeforeDataAndAllowsRetainingWriter requires callback-time writes to use the
+        //! held Queue document, then retained-writer calls to delegate to ordinary appender output.
         return status == Status.IN_PROGRESS
                 ? acquireWritingDocument(metaData)
                 : appender.writingDocument(metaData);
@@ -260,6 +267,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @Override
     public void rollbackOnClose() {
         requireCallback();
+        //! listenerRollbackThenResetPoisonsContextAndAutomaticCloseIsHarmless requires rollback
+        //! intent to survive the later reset and automatic close bookkeeping.
         listenerRolledBack = true;
         context.rollbackOnClose();
     }
@@ -276,6 +285,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         if (nesting == 0)
             throw new IllegalStateException("No ContextListener document is open");
         StoreAppender.StoreAppenderContext context = this.context;
+        //! listenerClosePreservesNestingForDocumentWrite and listenerCanHoldOneDocumentWhileWritingContext
+        //! require chained and nested closes to retain the one held document until its outer close.
         if (context.chainedElement())
             return;
         if (nesting > 1) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -159,6 +159,10 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
                     throw new IllegalStateException("Queue context listener rolled back its output document");
                 if (listenerDocumentIsOpen())
                     throw new IllegalStateException("Queue context listener returned with an unclosed document");
+                //! ContextListenerCoreTest#documentApplicationHeaderFailureDoesNotRepeatSuccessfulListener and
+                //! #rawApplicationHeaderFailureDoesNotRepeatSuccessfulListener require committed context to remain
+                //! successful if the subsequent application header cannot be acquired. Rearming on that outer
+                //! failure would repeat already-committed context when the application retries in the same cycle.
                 status = Status.SUCCEEDED;
                 return true;
             } catch (Throwable callbackFailure) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -93,6 +93,10 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         return started;
     }
 
+    boolean requiresDestinationPreflight(boolean metaData) {
+        return listener != null && !metaData;
+    }
+
     void onWriteAttempt() {
         if (listener == null)
             return;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -36,6 +36,7 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @Nullable
     private Throwable failure;
     private int nesting;
+    private boolean listenerRolledBack;
 
     private enum Status {
         READY,
@@ -137,10 +138,13 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
             throw new IllegalStateException("Queue context listener recursion is not permitted");
 
         status = Status.IN_PROGRESS;
+        listenerRolledBack = false;
         appender.queue().enterContextListenerCallback();
         try {
             try {
                 notifyListener();
+                if (listenerRolledBack)
+                    throw new IllegalStateException("Queue context listener rolled back its output document");
                 if (listenerDocumentIsOpen())
                     throw new IllegalStateException("Queue context listener returned with an unclosed document");
                 status = Status.SUCCEEDED;
@@ -223,6 +227,7 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         StoreAppender.StoreAppenderContext context = this.context;
         if (nesting == 0 || !context.isOpen())
             return;
+        listenerRolledBack = true;
         context.chainedElement(false);
         context.rollbackOnClose();
         nesting = 1;
@@ -239,6 +244,7 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @Override
     public void rollbackOnClose() {
         requireCallback();
+        listenerRolledBack = true;
         context.rollbackOnClose();
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -36,6 +36,7 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @Nullable
     private Throwable failure;
     private int nesting;
+    private int closesAfterReset;
     private boolean listenerRolledBack;
 
     private enum Status {
@@ -139,6 +140,7 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
 
         status = Status.IN_PROGRESS;
         listenerRolledBack = false;
+        closesAfterReset = 0;
         appender.queue().enterContextListenerCallback();
         try {
             try {
@@ -167,6 +169,7 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
             }
         } finally {
             nesting = 0;
+            closesAfterReset = 0;
             appender.queue().exitContextListenerCallback();
         }
     }
@@ -251,6 +254,10 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @Override
     public void close() {
         requireCallback();
+        if (nesting == 0 && closesAfterReset > 0) {
+            closesAfterReset--;
+            return;
+        }
         if (nesting == 0)
             throw new IllegalStateException("No ContextListener document is open");
         StoreAppender.StoreAppenderContext context = this.context;
@@ -270,13 +277,17 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         // DocumentContext.reset() means close/commit the active document and then discard the
         // holder state. Clearing the underlying context while it is still open would let the
         // triggering application write overwrite an uncommitted listener record.
-        if (nesting > 0 && context.isOpen()) {
+        final int outstandingCloses = nesting;
+        if (outstandingCloses > 0 && context.isOpen()) {
             context.chainedElement(false);
             nesting = 1;
             close();
         }
         context.reset();
         nesting = 0;
+        // reset() has already closed the shared underlying document. Each outstanding
+        // try-with-resources scope still invokes close(), which must now be harmless.
+        closesAfterReset = outstandingCloses;
     }
 
     private void requireCallback() {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -125,6 +125,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         if (actualContextCount < contextCount)
             throw new IllegalStateException("Queue context count moved backwards from " +
                     contextCount + " to " + actualContextCount);
+        //! ContextListenerCoreTest#notifiesEachAppenderWithItsOwnContextOncePerRoll mutation-pins
+        //! the cycle transition as the only automatic rearm boundary.
         if (actualContextCount > contextCount) {
             contextCount = actualContextCount;
             status = Status.READY;
@@ -145,6 +147,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         try {
             try {
                 notifyListener();
+                //! Explicit rollback or an open document means no complete context was published;
+                //! the rollback/unclosed regressions require fail-closed state, never success.
                 if (listenerRolledBack)
                     throw new IllegalStateException("Queue context listener rolled back its output document");
                 if (listenerDocumentIsOpen())
@@ -157,6 +161,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
                 } catch (Throwable rollbackFailure) {
                     callbackFailure.addSuppressed(rollbackFailure);
                 }
+                //! listenerFailureAfterWritingContextIsNotRetriedInTheSameRoll mutation-fails if
+                //! this returns to READY and invokes an invalid serializer again.
                 status = Status.FAILED;
                 failure = callbackFailure;
                 Jvm.warn().on(ContextListenerState.class,
@@ -196,6 +202,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
             return appender.acquireWritingDocument(metaData);
 
         StoreAppender.StoreAppenderContext context = this.context;
+        //! writesContextBeforeHeldDataDocument and listenerCanHoldOneDocumentWhileWritingContext
+        //! require nested supplied-writer calls to share the one locked Queue document.
         if (nesting > 0 && context.wire() != null && context.isOpen()) {
             if (!context.chainedElement()) {
                 assert metaData == context.isMetaData();
@@ -230,6 +238,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
         StoreAppender.StoreAppenderContext context = this.context;
         if (nesting == 0 || !context.isOpen())
             return;
+        //! listenerRollbackThenResetPoisonsContextAndAutomaticCloseIsHarmless requires rollback
+        //! intent to survive reset/close bookkeeping and poison this cycle.
         listenerRolledBack = true;
         context.chainedElement(false);
         context.rollbackOnClose();
@@ -254,6 +264,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @Override
     public void close() {
         requireCallback();
+        //! listenerDocumentResetMakesNestedAutomaticClosesHarmless mutation-fails when reset's
+        //! already-satisfied try-with-resources closes are treated as new close operations.
         if (nesting == 0 && closesAfterReset > 0) {
             closesAfterReset--;
             return;
@@ -274,9 +286,8 @@ final class ContextListenerState extends DocumentContextHolder implements Marsha
     @Override
     public void reset() {
         requireCallback();
-        // DocumentContext.reset() means close/commit the active document and then discard the
-        // holder state. Clearing the underlying context while it is still open would let the
-        // triggering application write overwrite an uncommitted listener record.
+        //! listenerDocumentResetCommitsContextBeforeApplicationData requires reset to commit the
+        //! active supplied document before clearing holder state; otherwise application data can overwrite it.
         final int outstandingCloses = nesting;
         if (outstandingCloses > 0 && context.isOpen()) {
             context.chainedElement(false);

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/ContextListenerState.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.bytes.MethodWriterBuilder;
+import net.openhft.chronicle.wire.BinaryMethodWriterInvocationHandler;
+import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.DocumentContextHolder;
+import net.openhft.chronicle.wire.MarshallableOut;
+import net.openhft.chronicle.wire.VanillaMethodWriterBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/** Queue configuration, appender state and locked output used by context listeners. */
+final class ContextListenerState extends DocumentContextHolder implements MarshallableOut {
+    static final ContextListenerState UNSET = new ContextListenerState(false);
+    static final ContextListenerState NONE = new ContextListenerState(true);
+
+    @Nullable
+    private final StoreAppender appender;
+    @Nullable
+    private final StoreAppender.StoreAppenderContext context;
+    @Nullable
+    private final Class<?> writerType;
+    @Nullable
+    private final MarshallableOut.ContextListener<?> listener;
+    @Nullable
+    private final Object methodWriter;
+    private boolean started;
+    private boolean notifying;
+    private int lastContextCount = -1;
+    private int nesting;
+
+    private ContextListenerState(boolean started) {
+        this.appender = null;
+        this.context = null;
+        this.writerType = null;
+        this.listener = null;
+        this.methodWriter = null;
+        this.started = started;
+    }
+
+    ContextListenerState(@Nullable Class<?> writerType,
+                         @Nullable MarshallableOut.ContextListener<?> listener) {
+        this.appender = null;
+        this.context = null;
+        this.writerType = writerType;
+        this.listener = listener;
+        this.methodWriter = null;
+    }
+
+    private ContextListenerState(@NotNull StoreAppender appender,
+                                 @NotNull StoreAppender.StoreAppenderContext context,
+                                 @NotNull Class<?> writerType,
+                                 @NotNull MarshallableOut.ContextListener<?> listener) {
+        this.appender = requireNonNull(appender, "appender");
+        this.context = requireNonNull(context, "context");
+        this.writerType = null;
+        this.listener = requireNonNull(listener, "listener");
+        documentContext(context);
+        this.methodWriter = methodWriter(requireNonNull(writerType, "writerType"));
+    }
+
+    ContextListenerState forAppender(@NotNull StoreAppender appender,
+                                     @NotNull StoreAppender.StoreAppenderContext context) {
+        return listener == null
+                ? UNSET
+                : forAppender(appender, context, writerType, listener);
+    }
+
+    static ContextListenerState forAppender(@NotNull StoreAppender appender,
+                                            @NotNull StoreAppender.StoreAppenderContext context,
+                                            @NotNull Class<?> writerType,
+                                            @NotNull MarshallableOut.ContextListener<?> listener) {
+        return new ContextListenerState(
+                appender, context, writerType, listener);
+    }
+
+    boolean started() {
+        return started;
+    }
+
+    void onWriteAttempt() {
+        if (listener == null)
+            return;
+        if (notifying)
+            throw new IllegalStateException("Cannot write to the appender from within a ContextListener; " +
+                    "write through the supplied method writer instead");
+        started = true;
+    }
+
+    boolean beforeDocument(boolean metaData) {
+        if (listener == null || metaData)
+            return false;
+        return notifyIfNeeded();
+    }
+
+    boolean beforeRawDocument() {
+        if (listener == null)
+            return false;
+        appender.resetPositionForContextListener();
+        return notifyIfNeeded();
+    }
+
+    private boolean notifyIfNeeded() {
+        StoreAppender appender = this.appender;
+        int contextCount = appender.cycle();
+        if (contextCount <= lastContextCount)
+            return false;
+        lastContextCount = contextCount;
+
+        notifying = true;
+        try {
+            try {
+                notifyListener();
+            } finally {
+                rollbackIfNotComplete();
+            }
+            return true;
+        } finally {
+            nesting = 0;
+            notifying = false;
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void notifyListener() {
+        ((MarshallableOut.ContextListener) listener).onNewContext(methodWriter);
+    }
+
+    @Override
+    public DocumentContext writingDocument(boolean metaData) {
+        return notifying
+                ? acquireWritingDocument(metaData)
+                : appender.writingDocument(metaData);
+    }
+
+    @Override
+    public DocumentContext acquireWritingDocument(boolean metaData) {
+        if (!notifying)
+            return appender.acquireWritingDocument(metaData);
+
+        StoreAppender.StoreAppenderContext context = this.context;
+        if (nesting > 0 && context.wire() != null && context.isOpen()) {
+            if (!context.chainedElement()) {
+                assert metaData == context.isMetaData();
+                nesting++;
+            }
+            return this;
+        }
+
+        appender.openContextForContextListener(metaData);
+        nesting = 1;
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public <T> MethodWriterBuilder<T> methodWriterBuilder(boolean metaData, @NotNull Class<T> type) {
+        VanillaMethodWriterBuilder<T> builder = new VanillaMethodWriterBuilder<>(type,
+                appender.queue().wireType(),
+                () -> new BinaryMethodWriterInvocationHandler(type, metaData,
+                        () -> ContextListenerState.this));
+        builder.marshallableOut(this);
+        builder.metaData(metaData);
+        return builder;
+    }
+
+    @Override
+    public void rollbackIfNotComplete() {
+        if (!notifying) {
+            appender.rollbackIfNotComplete();
+            return;
+        }
+        StoreAppender.StoreAppenderContext context = this.context;
+        if (nesting == 0 || !context.isOpen())
+            return;
+        context.chainedElement(false);
+        context.rollbackOnClose();
+        nesting = 1;
+        close();
+    }
+
+    @Override
+    public boolean writingIsComplete() {
+        return notifying
+                ? context.writingIsComplete()
+                : appender.writingIsComplete();
+    }
+
+    @Override
+    public void rollbackOnClose() {
+        requireCallback();
+        context.rollbackOnClose();
+    }
+
+    @Override
+    public void close() {
+        requireCallback();
+        if (nesting == 0)
+            throw new IllegalStateException("No ContextListener document is open");
+        StoreAppender.StoreAppenderContext context = this.context;
+        if (context.chainedElement())
+            return;
+        if (nesting > 1) {
+            nesting--;
+            return;
+        }
+        nesting = 0;
+        appender.closeContextForContextListener();
+    }
+
+    @Override
+    public void reset() {
+        requireCallback();
+        context.reset();
+        nesting = 0;
+    }
+
+    private void requireCallback() {
+        if (!notifying)
+            throw new IllegalStateException("ContextListener document is not active");
+    }
+}

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -1030,8 +1030,9 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
                 if (sequence == Sequence.NOT_FOUND)
                     break;
                 try {
-                    //! The sparse-index fallback is also internal indexing, so it needs the same
-                    //! guard-free view exercised by ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter.
+                    //! ContextListenerCoreTest#notifiesEachAppenderWithItsOwnContextOncePerRoll and
+                    //! #sequentialResetsPreserveAutomaticClosesForAppenderListener fail if this fallback re-enters
+                    //! the guarded public accessor while another listener record uses the held Queue write lock.
                     Wire wireForIndex = wireForIndex(ec);
                     return wireForIndex == null ? sequence : linearScanByPosition(wireForIndex, Long.MAX_VALUE, sequence, address, true);
                 } catch (EOFException e) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -350,6 +350,9 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
         if (index2Index.getVolatileValue() == NOT_INITIALIZED)
             return null;
 
+        //! Internal index traversal may run while a context callback owns the Queue write lock.
+        //! Use the private appender view: ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter
+        //! would otherwise re-enter the guarded public mutable-Wire accessor.
         Wire wireForIndex = wireForIndex(ec);
         LongArrayValues index2index = getIndex2index(wireForIndex);
         long primaryOffset = toAddress0(index);
@@ -751,7 +754,10 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
     long sequenceForPosition(@NotNull ExcerptContext ec,
                              final long position,
                              boolean inclusive) throws StreamCorruptedException {
-        return sequenceForPosition(ec.wireForIndex(), position, inclusive, true);
+        //! Sequence lookup is Queue-internal and must remain available while public mutable-Wire
+        //! access is rejected; ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter
+        //! exercises this indexing work during listener-backed publication.
+        return sequenceForPosition(wireForIndex(ec), position, inclusive, true);
     }
 
     long sequenceForPositionWithoutSequenceShortcut(@NotNull Wire wire,
@@ -921,6 +927,9 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
             return;
         }
 
+        //! Index publication must use the private appender view so the callback guard protects only
+        //! callers, not Queue internals; ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter
+        //! fails if publication re-enters StoreAppender#wireForIndex().
         Wire wire = wireForIndex(ec);
         Bytes<?> bytes = wire.bytes();
         if (position > bytes.capacity())
@@ -1024,6 +1033,8 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
                 if (sequence == Sequence.NOT_FOUND)
                     break;
                 try {
+                    //! The sparse-index fallback is also internal indexing, so it needs the same
+                    //! guard-free view exercised by ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter.
                     Wire wireForIndex = wireForIndex(ec);
                     return wireForIndex == null ? sequence : linearScanByPosition(wireForIndex, Long.MAX_VALUE, sequence, address, true);
                 } catch (EOFException e) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -350,10 +350,7 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
         if (index2Index.getVolatileValue() == NOT_INITIALIZED)
             return null;
 
-        //! Internal index traversal may run while a context callback owns the Queue write lock.
-        //! Use the private appender view: ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter
-        //! would otherwise re-enter the guarded public mutable-Wire accessor.
-        Wire wireForIndex = wireForIndex(ec);
+        Wire wireForIndex = ec.wireForIndex();
         LongArrayValues index2index = getIndex2index(wireForIndex);
         long primaryOffset = toAddress0(index);
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -1036,6 +1036,8 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
     }
 
     private static Wire wireForIndex(@NotNull ExcerptContext context) {
+        //! ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter mutation-fails
+        //! if Queue's internal index publication re-enters the guarded public appender wire accessor.
         return context instanceof StoreAppender
                 ? ((StoreAppender) context).wireForIndexInternal()
                 : context.wireForIndex();

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SCQIndexing.java
@@ -350,7 +350,7 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
         if (index2Index.getVolatileValue() == NOT_INITIALIZED)
             return null;
 
-        Wire wireForIndex = ec.wireForIndex();
+        Wire wireForIndex = wireForIndex(ec);
         LongArrayValues index2index = getIndex2index(wireForIndex);
         long primaryOffset = toAddress0(index);
 
@@ -921,7 +921,7 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
             return;
         }
 
-        Wire wire = ec.wireForIndex();
+        Wire wire = wireForIndex(ec);
         Bytes<?> bytes = wire.bytes();
         if (position > bytes.capacity())
             throw new IllegalArgumentException("pos: " + position);
@@ -1024,7 +1024,7 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
                 if (sequence == Sequence.NOT_FOUND)
                     break;
                 try {
-                    Wire wireForIndex = ec.wireForIndex();
+                    Wire wireForIndex = wireForIndex(ec);
                     return wireForIndex == null ? sequence : linearScanByPosition(wireForIndex, Long.MAX_VALUE, sequence, address, true);
                 } catch (EOFException e) {
                     throw new UncheckedIOException(e);
@@ -1033,6 +1033,12 @@ class SCQIndexing extends AbstractCloseable implements Indexing, Demarshallable,
         }
 
         return sequenceForPosition(ec, Long.MAX_VALUE, false);
+    }
+
+    private static Wire wireForIndex(@NotNull ExcerptContext context) {
+        return context instanceof StoreAppender
+                ? ((StoreAppender) context).wireForIndexInternal()
+                : context.wireForIndex();
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -97,9 +97,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @NotNull
     final File path;
     final String fileAbsolutePath;
-    //! ContextListenerCoreTest#symlinkAliasCannotBypassCallbackGuard requires a canonical physical
-    //! path key so aliases cannot acquire the same Queue lock behind the active callback.
-    private final String contextListenerCallbackKey;
+    @Nullable
+    private volatile String contextListenerCallbackKey;
     // Uses this.closers as a lock. concurrent read, locking for write.
     @SuppressWarnings("rawtypes")
     private final Map<BytesStore, LongValue> metaStoreMap = new ConcurrentHashMap<>();
@@ -182,9 +181,6 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 //noinspection ResultOfMethodCallIgnored
                 path.mkdirs();
             fileAbsolutePath = path.getAbsolutePath();
-            //! Resolve aliases before entering the JVM-wide callback guard; two spellings of one
-            //! Queue must not wait on the same write lock from inside a callback.
-            contextListenerCallbackKey = path.toPath().toRealPath().toString();
             wireType = builder.wireType();
             blockSize = builder.blockSize();
             // the maximum message size is 1L << 30 so greater overlapSize has no effect
@@ -692,17 +688,18 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
     void enterContextListenerCallback() {
         final Thread currentThread = Thread.currentThread();
+        final String callbackKey = contextListenerCallbackKey();
         //! secondQueueInstanceOnSamePathFailsImmediatelyDuringCallback mutation-times out if this
         //! path-scoped guard is removed and a second Queue blocks on the non-reentrant write lock.
         final Thread existing = ACTIVE_CONTEXT_LISTENER_CALLBACKS.putIfAbsent(
-                contextListenerCallbackKey, currentThread);
+                callbackKey, currentThread);
         if (existing != null)
             throw new IllegalStateException("A Queue context listener callback is already active for " +
-                    contextListenerCallbackKey + " on thread " + existing.getName());
+                    callbackKey + " on thread " + existing.getName());
     }
 
     void exitContextListenerCallback() {
-        ACTIVE_CONTEXT_LISTENER_CALLBACKS.remove(contextListenerCallbackKey, Thread.currentThread());
+        ACTIVE_CONTEXT_LISTENER_CALLBACKS.remove(contextListenerCallbackKey(), Thread.currentThread());
     }
 
     void throwIfContextListenerCallbackActive() {
@@ -710,9 +707,29 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         //! #capturedAppenderRollbackFromListenerFailsFast, #capturedAppenderNormalisationFromListenerFailsFast,
         //! #capturedAppenderWireAccessFromListenerFailsFast and #capturedAppenderIndexWireAccessFromListenerFailsFast
         //! require rejection before every public mutation or mutable-Wire escape performs a side effect.
-        if (ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
+        if (ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey()))
             throw new IllegalStateException("Cannot enter a Queue appender from a context listener callback; " +
                     "write through the supplied method writer instead");
+    }
+
+    private String contextListenerCallbackKey() {
+        String callbackKey = contextListenerCallbackKey;
+        if (callbackKey != null)
+            return callbackKey;
+        synchronized (this) {
+            callbackKey = contextListenerCallbackKey;
+            if (callbackKey == null) {
+                //! ContextListenerCoreTest#symlinkAliasCannotBypassCallbackGuard requires a canonical real-path
+                //! key. Resolve and cache it on first appender/callback use so ordinary Queue construction does not
+                //! acquire a new filesystem lookup or failure mode solely for the optional listener feature.
+                try {
+                    contextListenerCallbackKey = callbackKey = path.toPath().toRealPath().toString();
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Unable to resolve Queue callback path " + path, e);
+                }
+            }
+        }
+        return callbackKey;
     }
 
     // used by enterprise CQ
@@ -1066,7 +1083,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     protected void assertCloseable() {
         //! queueCloseFromListenerFailsBeforeTeardownAndReleasesTheLock prevents callback code from
         //! closing stores and locks still owned by the outer application write.
-        if (ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
+        final String callbackKey = contextListenerCallbackKey;
+        if (callbackKey != null && ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(callbackKey))
             throw new IllegalStateException(
                     "Cannot close a Queue from a context listener callback; return from the callback first");
         super.assertCloseable();

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -134,6 +134,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     final AppenderListener appenderListener;
     @NotNull
     private final ContextListenerState contextListenerState;
+    private final ThreadLocal<Boolean> contextListenerCallback =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
     protected int sourceId;
     private int cycleFileRenamed = -1;
     @NotNull
@@ -647,6 +649,22 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     ContextListenerState newContextListenerState(
             StoreAppender appender, StoreAppender.StoreAppenderContext context) {
         return contextListenerState.forAppender(appender, context);
+    }
+
+    void enterContextListenerCallback() {
+        if (contextListenerCallback.get())
+            throw new IllegalStateException("A Queue context listener callback is already active on this thread");
+        contextListenerCallback.set(Boolean.TRUE);
+    }
+
+    void exitContextListenerCallback() {
+        contextListenerCallback.remove();
+    }
+
+    void throwIfContextListenerCallbackActive() {
+        if (contextListenerCallback.get())
+            throw new IllegalStateException("Cannot enter a Queue appender from a context listener callback; " +
+                    "write through the supplied method writer instead");
     }
 
     // used by enterprise CQ

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -1039,6 +1039,14 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      * block, and special care is taken to close the event loop and other important components.
      */
     @Override
+    protected void assertCloseable() {
+        if (contextListenerCallbacksEnabled && contextListenerCallback.get())
+            throw new IllegalStateException(
+                    "Cannot close a Queue from a context listener callback; return from the callback first");
+        super.assertCloseable();
+    }
+
+    @Override
     protected void performClose() {
         synchronized (closers) {
             metaStoreMap.values().forEach(Closeable::closeQuietly);

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -172,7 +172,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 //noinspection ResultOfMethodCallIgnored
                 path.mkdirs();
             fileAbsolutePath = path.getAbsolutePath();
-            contextListenerCallbackKey = path.toPath().toAbsolutePath().normalize().toString();
+            //! Resolve aliases before entering the process-wide callback guard; two spellings of
+            //! one Queue must not contend on the non-reentrant write lock from inside a callback.
+            contextListenerCallbackKey = path.toPath().toRealPath().toString();
             wireType = builder.wireType();
             blockSize = builder.blockSize();
             // the maximum message size is 1L << 30 so greater overlapSize has no effect

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -708,6 +708,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @SuppressWarnings("deprecation")
     @NotNull
     public ExcerptAppender acquireAppender() {
+        throwIfContextListenerCallbackActive();
         return ThreadLocalAppender.acquireThreadLocalAppender(this);
     }
 
@@ -722,6 +723,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @NotNull
     ExcerptAppender acquireThreadLocalAppender(@NotNull SingleChronicleQueue queue) {
         queue.throwExceptionIfClosed();
+        queue.throwIfContextListenerCallbackActive();
         if (queue.readOnly)
             throw new IllegalStateException("Can't append to a read-only chronicle");
 
@@ -744,6 +746,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @Override
     public ExcerptAppender createAppender() {
         throwExceptionIfClosed();
+        throwIfContextListenerCallbackActive();
 
         if (readOnly)
             throw new IllegalStateException("Can't append to a read-only chronicle");

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -78,6 +78,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
     private static final boolean SHOULD_CHECK_CYCLE = Jvm.getBoolean("chronicle.queue.checkrollcycle");
     static final int WARN_SLOW_APPENDER_MS = Jvm.getInteger("chronicle.queue.warnSlowAppenderMs", 100);
+    private static final Map<String, Thread> ACTIVE_CONTEXT_LISTENER_CALLBACKS = new ConcurrentHashMap<>();
+    private static volatile boolean anyContextListenerCallbackActive;
 
     @NotNull
     protected final EventLoop eventLoop;
@@ -91,6 +93,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @NotNull
     final File path;
     final String fileAbsolutePath;
+    private final String contextListenerCallbackKey;
     // Uses this.closers as a lock. concurrent read, locking for write.
     @SuppressWarnings("rawtypes")
     private final Map<BytesStore, LongValue> metaStoreMap = new ConcurrentHashMap<>();
@@ -136,8 +139,6 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @NotNull
     private final ContextListenerState contextListenerState;
     private volatile boolean contextListenerCallbacksEnabled;
-    private final ThreadLocal<Boolean> contextListenerCallback =
-            ThreadLocal.withInitial(() -> Boolean.FALSE);
     protected int sourceId;
     private int cycleFileRenamed = -1;
     @NotNull
@@ -172,6 +173,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 //noinspection ResultOfMethodCallIgnored
                 path.mkdirs();
             fileAbsolutePath = path.getAbsolutePath();
+            contextListenerCallbackKey = path.toPath().toAbsolutePath().normalize().toString();
             wireType = builder.wireType();
             blockSize = builder.blockSize();
             // the maximum message size is 1L << 30 so greater overlapSize has no effect
@@ -675,17 +677,24 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
     void enterContextListenerCallback() {
         contextListenerCallbacksEnabled = true;
-        if (contextListenerCallback.get())
-            throw new IllegalStateException("A Queue context listener callback is already active on this thread");
-        contextListenerCallback.set(Boolean.TRUE);
+        final Thread currentThread = Thread.currentThread();
+        final Thread existing = ACTIVE_CONTEXT_LISTENER_CALLBACKS.putIfAbsent(
+                contextListenerCallbackKey, currentThread);
+        if (existing != null)
+            throw new IllegalStateException("A Queue context listener callback is already active for " +
+                    contextListenerCallbackKey + " on thread " + existing.getName());
+        anyContextListenerCallbackActive = true;
     }
 
     void exitContextListenerCallback() {
-        contextListenerCallback.remove();
+        ACTIVE_CONTEXT_LISTENER_CALLBACKS.remove(contextListenerCallbackKey, Thread.currentThread());
+        if (ACTIVE_CONTEXT_LISTENER_CALLBACKS.isEmpty())
+            anyContextListenerCallbackActive = false;
     }
 
     void throwIfContextListenerCallbackActive() {
-        if (contextListenerCallbacksEnabled && contextListenerCallback.get())
+        if (anyContextListenerCallbackActive &&
+                ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
             throw new IllegalStateException("Cannot enter a Queue appender from a context listener callback; " +
                     "write through the supplied method writer instead");
     }
@@ -1040,7 +1049,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      */
     @Override
     protected void assertCloseable() {
-        if (contextListenerCallbacksEnabled && contextListenerCallback.get())
+        if (anyContextListenerCallbackActive &&
+                ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
             throw new IllegalStateException(
                     "Cannot close a Queue from a context listener callback; return from the callback first");
         super.assertCloseable();

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -175,6 +175,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             storeSupplier = new StoreSupplier();
             pool = WireStorePool.withSupplier(storeSupplier, storeFileListener);
             isBuffered = BufferMode.Asynchronous == builder.writeBufferMode();
+            //! ContextListenerCoreTest#rejectsEncodedAndEncryptedBuilderModes requires retaining effective builder
+            //! encryption/encoding state because listener registration may occur only after Queue construction.
             encodedOrEncrypted = builder.key() != null || builder.encodingSupplier() != null;
             path = builder.path();
             if (!builder.readOnly())
@@ -276,8 +278,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     static void validateContextListenerCompatibility(boolean encodedOrEncrypted,
                                                      boolean asynchronous,
                                                      boolean doubleBuffered) {
-        //! ContextListenerCoreTest#rejectsEveryUnsupportedEffectiveQueueMode pins each classification
-        //! branch; the listener must target the same synchronous Wire as its triggering document.
+        //! ContextListenerCoreTest#rejectsEveryUnsupportedEffectiveQueueMode and #rejectsDoubleBuffering pin each
+        //! classification branch; the listener must target the same synchronous Wire as its triggering document.
         if (encodedOrEncrypted)
             throw new UnsupportedOperationException(
                     "contextListener is not supported on encoded or encrypted Enterprise queues");

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -135,6 +135,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     final AppenderListener appenderListener;
     @NotNull
     private final ContextListenerState contextListenerState;
+    private volatile boolean contextListenerCallbacksEnabled;
     private final ThreadLocal<Boolean> contextListenerCallback =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     protected int sourceId;
@@ -197,6 +198,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             readOnly = builder.readOnly();
             appenderListener = builder.appenderListener();
             contextListenerState = builder.contextListenerState();
+            contextListenerCallbacksEnabled = contextListenerState != ContextListenerState.UNSET;
 
             //! ReadonlyNamedTailerIndexesTest#readOnlyQueueWithMetadataUsesPersistedDirectoryListing
             //! distinguishes a missing metadata table from a read-only mapped table; only the former
@@ -672,6 +674,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     void enterContextListenerCallback() {
+        contextListenerCallbacksEnabled = true;
         if (contextListenerCallback.get())
             throw new IllegalStateException("A Queue context listener callback is already active on this thread");
         contextListenerCallback.set(Boolean.TRUE);
@@ -682,9 +685,13 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     void throwIfContextListenerCallbackActive() {
-        if (contextListenerCallback.get())
+        if (contextListenerCallbacksEnabled && contextListenerCallback.get())
             throw new IllegalStateException("Cannot enter a Queue appender from a context listener callback; " +
                     "write through the supplied method writer instead");
+    }
+
+    void enableContextListenerCallbackGuard() {
+        contextListenerCallbacksEnabled = true;
     }
 
     // used by enterprise CQ

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -97,6 +97,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     private final StoreSupplier storeSupplier;
     private final long epoch;
     private final boolean isBuffered;
+    private final boolean encodedOrEncrypted;
     @NotNull
     private final WireType wireType;
     private final long blockSize;
@@ -164,6 +165,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             storeSupplier = new StoreSupplier();
             pool = WireStorePool.withSupplier(storeSupplier, storeFileListener);
             isBuffered = BufferMode.Asynchronous == builder.writeBufferMode();
+            encodedOrEncrypted = builder.key() != null || builder.encodingSupplier() != null;
             path = builder.path();
             if (!builder.readOnly())
                 //noinspection ResultOfMethodCallIgnored
@@ -252,6 +254,24 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             close();
             throw Jvm.rethrow(t);
         }
+    }
+
+    void validateContextListenerCompatibility() {
+        validateContextListenerCompatibility(encodedOrEncrypted, isBuffered, doubleBuffer);
+    }
+
+    static void validateContextListenerCompatibility(boolean encodedOrEncrypted,
+                                                     boolean asynchronous,
+                                                     boolean doubleBuffered) {
+        if (encodedOrEncrypted)
+            throw new UnsupportedOperationException(
+                    "contextListener is not supported on encoded or encrypted Enterprise queues");
+        if (asynchronous)
+            throw new UnsupportedOperationException(
+                    "contextListener is not supported on asynchronous Enterprise write buffers");
+        if (doubleBuffered)
+            throw new UnsupportedOperationException(
+                    "contextListener is not supported with double buffering");
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -132,6 +132,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @NotNull
     private final RollCycle rollCycle;
     final AppenderListener appenderListener;
+    @NotNull
+    private final ContextListenerState contextListenerState;
     protected int sourceId;
     private int cycleFileRenamed = -1;
     @NotNull
@@ -190,6 +192,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             }
             readOnly = builder.readOnly();
             appenderListener = builder.appenderListener();
+            contextListenerState = builder.contextListenerState();
 
             //! ReadonlyNamedTailerIndexesTest#readOnlyQueueWithMetadataUsesPersistedDirectoryListing
             //! distinguishes a missing metadata table from a read-only mapped table; only the former
@@ -638,6 +641,12 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      */
     protected StoreFileListener storeFileListener() {
         return storeFileListener;
+    }
+
+    @NotNull
+    ContextListenerState newContextListenerState(
+            StoreAppender appender, StoreAppender.StoreAppenderContext context) {
+        return contextListenerState.forAppender(appender, context);
     }
 
     // used by enterprise CQ
@@ -1708,7 +1717,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
         /**
          * Acquires a {@link SingleChronicleQueueStore} for the specified cycle.
-         * If the store doesn't exist and the strategy is {@link CreateStrategy.CREATE}, it will create a new store.
+         * If the store doesn't exist and the strategy is {@code CreateStrategy.CREATE}, it will create a new store.
          *
          * @param cycle          the cycle to acquire the store for
          * @param createStrategy the strategy for creating or reading the store

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -138,7 +138,6 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     final AppenderListener appenderListener;
     @NotNull
     private final ContextListenerState contextListenerState;
-    private volatile boolean contextListenerCallbacksEnabled;
     protected int sourceId;
     private int cycleFileRenamed = -1;
     @NotNull
@@ -200,7 +199,6 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             readOnly = builder.readOnly();
             appenderListener = builder.appenderListener();
             contextListenerState = builder.contextListenerState();
-            contextListenerCallbacksEnabled = contextListenerState != ContextListenerState.UNSET;
 
             //! ReadonlyNamedTailerIndexesTest#readOnlyQueueWithMetadataUsesPersistedDirectoryListing
             //! distinguishes a missing metadata table from a read-only mapped table; only the former
@@ -267,6 +265,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     static void validateContextListenerCompatibility(boolean encodedOrEncrypted,
                                                      boolean asynchronous,
                                                      boolean doubleBuffered) {
+        //! ContextListenerCoreTest#rejectsEveryUnsupportedEffectiveQueueMode pins these exclusions:
+        //! the listener must target the same synchronous physical Wire as its triggering document.
         if (encodedOrEncrypted)
             throw new UnsupportedOperationException(
                     "contextListener is not supported on encoded or encrypted Enterprise queues");
@@ -676,8 +676,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     void enterContextListenerCallback() {
-        contextListenerCallbacksEnabled = true;
         final Thread currentThread = Thread.currentThread();
+        //! secondQueueInstanceOnSamePathFailsImmediatelyDuringCallback mutation-times out if this
+        //! path-scoped guard is removed and a second Queue blocks on the non-reentrant write lock.
         final Thread existing = ACTIVE_CONTEXT_LISTENER_CALLBACKS.putIfAbsent(
                 contextListenerCallbackKey, currentThread);
         if (existing != null)
@@ -693,14 +694,12 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     }
 
     void throwIfContextListenerCallbackActive() {
+        //! The captured-appender, appender-creation, mutable-Wire and normalization regressions
+        //! require this check before every public mutation/escape path performs any side effect.
         if (anyContextListenerCallbackActive &&
                 ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
             throw new IllegalStateException("Cannot enter a Queue appender from a context listener callback; " +
                     "write through the supplied method writer instead");
-    }
-
-    void enableContextListenerCallbackGuard() {
-        contextListenerCallbacksEnabled = true;
     }
 
     // used by enterprise CQ
@@ -1049,6 +1048,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
      */
     @Override
     protected void assertCloseable() {
+        //! queueCloseFromListenerFailsBeforeTeardownAndReleasesTheLock prevents callback code from
+        //! closing stores and locks still owned by the outer application write.
         if (anyContextListenerCallbackActive &&
                 ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
             throw new IllegalStateException(

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -81,8 +81,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     //! ContextListenerCoreTest#secondAppenderReentryFailsImmediatelyAndReleasesTheQueueLock,
     //! #secondQueueInstanceOnSamePathFailsImmediatelyDuringCallback,
     //! #symlinkAliasCannotBypassCallbackGuard and #otherThreadUsingSamePathFailsImmediatelyDuringCallback
-    //! require process-wide physical-Queue ownership; a per-instance or thread-local guard can deadlock
-    //! on the non-reentrant cross-process write lock instead of rejecting the callback escape.
+    //! require JVM-wide ownership keyed by canonical real path; a per-instance or thread-local guard
+    //! can wait on the callback's already-held cross-process write lock instead of rejecting the escape.
     private static final Map<String, Thread> ACTIVE_CONTEXT_LISTENER_CALLBACKS = new ConcurrentHashMap<>();
 
     @NotNull
@@ -106,8 +106,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     private final StoreSupplier storeSupplier;
     private final long epoch;
     private final boolean isBuffered;
-    //! ContextListenerCoreTest#rejectsEveryUnsupportedEffectiveQueueMode requires listener
-    //! compatibility to include enterprise encoding/encryption selected by the effective builder.
+    //! ContextListenerCoreTest#rejectsEveryUnsupportedEffectiveQueueMode pins classification, while
+    //! #rejectsEncodedAndEncryptedBuilderModes exercises effective builder encryption and encoding.
     private final boolean encodedOrEncrypted;
     @NotNull
     private final WireType wireType;
@@ -182,8 +182,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
                 //noinspection ResultOfMethodCallIgnored
                 path.mkdirs();
             fileAbsolutePath = path.getAbsolutePath();
-            //! Resolve aliases before entering the process-wide callback guard; two spellings of
-            //! one Queue must not contend on the non-reentrant write lock from inside a callback.
+            //! Resolve aliases before entering the JVM-wide callback guard; two spellings of one
+            //! Queue must not wait on the same write lock from inside a callback.
             contextListenerCallbackKey = path.toPath().toRealPath().toString();
             wireType = builder.wireType();
             blockSize = builder.blockSize();
@@ -280,8 +280,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     static void validateContextListenerCompatibility(boolean encodedOrEncrypted,
                                                      boolean asynchronous,
                                                      boolean doubleBuffered) {
-        //! ContextListenerCoreTest#rejectsEveryUnsupportedEffectiveQueueMode pins these exclusions:
-        //! the listener must target the same synchronous physical Wire as its triggering document.
+        //! ContextListenerCoreTest#rejectsEveryUnsupportedEffectiveQueueMode pins each classification
+        //! branch; the listener must target the same synchronous Wire as its triggering document.
         if (encodedOrEncrypted)
             throw new UnsupportedOperationException(
                     "contextListener is not supported on encoded or encrypted Enterprise queues");
@@ -729,9 +729,6 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @SuppressWarnings("deprecation")
     @NotNull
     public ExcerptAppender acquireAppender() {
-        //! ContextListenerCoreTest#appenderCreationFromListenerFailsFast requires the cached public
-        //! acquisition path to reject before it can expose an appender bound to the active Queue lock.
-        throwIfContextListenerCallbackActive();
         return ThreadLocalAppender.acquireThreadLocalAppender(this);
     }
 
@@ -746,8 +743,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @NotNull
     ExcerptAppender acquireThreadLocalAppender(@NotNull SingleChronicleQueue queue) {
         queue.throwExceptionIfClosed();
-        //! ContextListenerCoreTest#appenderCreationFromListenerFailsFast requires the shared
-        //! construction/acquisition path to reject before consulting or creating thread-local state.
+        //! ContextListenerCoreTest#acquireAppenderFromListenerFailsFast pre-populates the thread-local
+        //! cache and requires this shared path to reject before returning or constructing an appender.
         queue.throwIfContextListenerCallbackActive();
         if (queue.readOnly)
             throw new IllegalStateException("Can't append to a read-only chronicle");

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueue.java
@@ -78,8 +78,12 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
     private static final boolean SHOULD_CHECK_CYCLE = Jvm.getBoolean("chronicle.queue.checkrollcycle");
     static final int WARN_SLOW_APPENDER_MS = Jvm.getInteger("chronicle.queue.warnSlowAppenderMs", 100);
+    //! ContextListenerCoreTest#secondAppenderReentryFailsImmediatelyAndReleasesTheQueueLock,
+    //! #secondQueueInstanceOnSamePathFailsImmediatelyDuringCallback,
+    //! #symlinkAliasCannotBypassCallbackGuard and #otherThreadUsingSamePathFailsImmediatelyDuringCallback
+    //! require process-wide physical-Queue ownership; a per-instance or thread-local guard can deadlock
+    //! on the non-reentrant cross-process write lock instead of rejecting the callback escape.
     private static final Map<String, Thread> ACTIVE_CONTEXT_LISTENER_CALLBACKS = new ConcurrentHashMap<>();
-    private static volatile boolean anyContextListenerCallbackActive;
 
     @NotNull
     protected final EventLoop eventLoop;
@@ -93,6 +97,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @NotNull
     final File path;
     final String fileAbsolutePath;
+    //! ContextListenerCoreTest#symlinkAliasCannotBypassCallbackGuard requires a canonical physical
+    //! path key so aliases cannot acquire the same Queue lock behind the active callback.
     private final String contextListenerCallbackKey;
     // Uses this.closers as a lock. concurrent read, locking for write.
     @SuppressWarnings("rawtypes")
@@ -100,6 +106,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     private final StoreSupplier storeSupplier;
     private final long epoch;
     private final boolean isBuffered;
+    //! ContextListenerCoreTest#rejectsEveryUnsupportedEffectiveQueueMode requires listener
+    //! compatibility to include enterprise encoding/encryption selected by the effective builder.
     private final boolean encodedOrEncrypted;
     @NotNull
     private final WireType wireType;
@@ -137,6 +145,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     private final RollCycle rollCycle;
     final AppenderListener appenderListener;
     @NotNull
+    //! ContextListenerCoreTest#notifiesEachAppenderWithItsOwnContextOncePerRoll requires Queue-level
+    //! configuration to create independent lifecycle state for every appender.
     private final ContextListenerState contextListenerState;
     protected int sourceId;
     private int cycleFileRenamed = -1;
@@ -200,6 +210,9 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
             }
             readOnly = builder.readOnly();
             appenderListener = builder.appenderListener();
+            //! ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter and
+            //! #listenerRemainsCallerOwned require the Queue to retain configuration while each
+            //! appender receives its own state; the caller-owned listener itself is never closed.
             contextListenerState = builder.contextListenerState();
 
             //! ReadonlyNamedTailerIndexesTest#readOnlyQueueWithMetadataUsesPersistedDirectoryListing
@@ -686,20 +699,18 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
         if (existing != null)
             throw new IllegalStateException("A Queue context listener callback is already active for " +
                     contextListenerCallbackKey + " on thread " + existing.getName());
-        anyContextListenerCallbackActive = true;
     }
 
     void exitContextListenerCallback() {
         ACTIVE_CONTEXT_LISTENER_CALLBACKS.remove(contextListenerCallbackKey, Thread.currentThread());
-        if (ACTIVE_CONTEXT_LISTENER_CALLBACKS.isEmpty())
-            anyContextListenerCallbackActive = false;
     }
 
     void throwIfContextListenerCallbackActive() {
-        //! The captured-appender, appender-creation, mutable-Wire and normalization regressions
-        //! require this check before every public mutation/escape path performs any side effect.
-        if (anyContextListenerCallbackActive &&
-                ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
+        //! ContextListenerCoreTest#appenderWriteFromListenerFailsFast,
+        //! #capturedAppenderRollbackFromListenerFailsFast, #capturedAppenderNormalisationFromListenerFailsFast,
+        //! #capturedAppenderWireAccessFromListenerFailsFast and #capturedAppenderIndexWireAccessFromListenerFailsFast
+        //! require rejection before every public mutation or mutable-Wire escape performs a side effect.
+        if (ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
             throw new IllegalStateException("Cannot enter a Queue appender from a context listener callback; " +
                     "write through the supplied method writer instead");
     }
@@ -718,6 +729,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @SuppressWarnings("deprecation")
     @NotNull
     public ExcerptAppender acquireAppender() {
+        //! ContextListenerCoreTest#appenderCreationFromListenerFailsFast requires the cached public
+        //! acquisition path to reject before it can expose an appender bound to the active Queue lock.
         throwIfContextListenerCallbackActive();
         return ThreadLocalAppender.acquireThreadLocalAppender(this);
     }
@@ -733,6 +746,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @NotNull
     ExcerptAppender acquireThreadLocalAppender(@NotNull SingleChronicleQueue queue) {
         queue.throwExceptionIfClosed();
+        //! ContextListenerCoreTest#appenderCreationFromListenerFailsFast requires the shared
+        //! construction/acquisition path to reject before consulting or creating thread-local state.
         queue.throwIfContextListenerCallbackActive();
         if (queue.readOnly)
             throw new IllegalStateException("Can't append to a read-only chronicle");
@@ -756,6 +771,8 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     @Override
     public ExcerptAppender createAppender() {
         throwExceptionIfClosed();
+        //! ContextListenerCoreTest#appenderCreationFromListenerFailsFast mutation-times out if a
+        //! callback can create a second appender and wait on the outer write's non-reentrant lock.
         throwIfContextListenerCallbackActive();
 
         if (readOnly)
@@ -1052,8 +1069,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
     protected void assertCloseable() {
         //! queueCloseFromListenerFailsBeforeTeardownAndReleasesTheLock prevents callback code from
         //! closing stores and locks still owned by the outer application write.
-        if (anyContextListenerCallbackActive &&
-                ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
+        if (ACTIVE_CONTEXT_LISTENER_CALLBACKS.containsKey(contextListenerCallbackKey))
             throw new IllegalStateException(
                     "Cannot close a Queue from a context listener callback; return from the callback first");
         super.assertCloseable();
@@ -1786,7 +1802,7 @@ public class SingleChronicleQueue extends AbstractCloseable implements RollingCh
 
         /**
          * Acquires a {@link SingleChronicleQueueStore} for the specified cycle.
-         * If the store doesn't exist and the strategy is {@code CreateStrategy.CREATE}, it will create a new store.
+         * If the store doesn't exist and the strategy is {@link CreateStrategy.CREATE}, it will create a new store.
          *
          * @param cycle          the cycle to acquire the store for
          * @param createStrategy the strategy for creating or reading the store

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -374,8 +374,8 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
      */
     @NotNull
     public SingleChronicleQueue build() {
-        validateContextListenerCompatibility();
         preBuild();
+        validateContextListenerCompatibility();
 
         SingleChronicleQueue chronicleQueue;
 
@@ -394,12 +394,15 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     private void validateContextListenerCompatibility() {
         if (contextListener == null)
             return;
-        if (key != null || encodingSupplier != null)
-            throw new UnsupportedOperationException("contextListener is not supported on encoded or encrypted Enterprise queues");
-        if (writeBufferMode == BufferMode.Asynchronous)
-            throw new UnsupportedOperationException("contextListener is not supported on asynchronous Enterprise write buffers");
-        if (doubleBuffer)
-            throw new UnsupportedOperationException("contextListener is not supported with double buffering");
+        try {
+            SingleChronicleQueue.validateContextListenerCompatibility(
+                    key != null || encodingSupplier != null,
+                    writeBufferMode() == BufferMode.Asynchronous,
+                    doubleBuffer());
+        } catch (RuntimeException incompatible) {
+            Closeable.closeQuietly(metaStore);
+            throw incompatible;
+        }
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -139,6 +139,9 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     private Function<SingleChronicleQueue, Condition> createAppenderConditionCreator;
     private long forceDirectoryListingRefreshIntervalMs = 60_000;
     private AppenderListener appenderListener;
+    //! ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter and
+    //! #listenerRemainsCallerOwned require builder registration to retain the writer contract and
+    //! caller-owned callback until the Queue creates independent appender lifecycle state.
     @Nullable
     private Class<?> contextListenerWriterType;
     @Nullable
@@ -375,6 +378,9 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     @NotNull
     public SingleChronicleQueue build() {
         preBuild();
+        //! ContextListenerCoreTest#validatesModesLoadedDuringPreBuildAndClosesMetadata requires the
+        //! compatibility decision after persisted/enterprise configuration has been loaded but
+        //! before a Queue can expose an unsupported listener/output combination.
         validateContextListenerCompatibility();
 
         SingleChronicleQueue chronicleQueue;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -139,6 +139,10 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     private Function<SingleChronicleQueue, Condition> createAppenderConditionCreator;
     private long forceDirectoryListingRefreshIntervalMs = 60_000;
     private AppenderListener appenderListener;
+    @Nullable
+    private Class<?> contextListenerWriterType;
+    @Nullable
+    private MarshallableOut.ContextListener<?> contextListener;
     private SyncMode syncMode;
 
     protected SingleChronicleQueueBuilder() {
@@ -370,6 +374,7 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
      */
     @NotNull
     public SingleChronicleQueue build() {
+        validateContextListenerCompatibility();
         preBuild();
 
         SingleChronicleQueue chronicleQueue;
@@ -384,6 +389,17 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
         postBuild(chronicleQueue);
 
         return chronicleQueue;
+    }
+
+    private void validateContextListenerCompatibility() {
+        if (contextListener == null)
+            return;
+        if (key != null || encodingSupplier != null)
+            throw new UnsupportedOperationException("contextListener is not supported on encoded or encrypted Enterprise queues");
+        if (writeBufferMode == BufferMode.Asynchronous)
+            throw new UnsupportedOperationException("contextListener is not supported on asynchronous Enterprise write buffers");
+        if (doubleBuffer)
+            throw new UnsupportedOperationException("contextListener is not supported with double buffering");
     }
 
     /**
@@ -1617,6 +1633,24 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
      */
     public AppenderListener appenderListener() {
         return appenderListener;
+    }
+
+    /**
+     * Sets the default context listener for appenders created by this queue.
+     * The caller retains ownership of the listener.
+     *
+     * @see ExcerptAppender#contextListener(Class, MarshallableOut.ContextListener)
+     */
+    public <T> SingleChronicleQueueBuilder contextListener(@NotNull Class<T> writerType,
+                                                            @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        contextListenerWriterType = requireNonNull(writerType, "writerType");
+        contextListener = requireNonNull(listener, "listener");
+        return this;
+    }
+
+    @NotNull
+    ContextListenerState contextListenerState() {
+        return new ContextListenerState(contextListenerWriterType, contextListener);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -394,6 +394,8 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     private void validateContextListenerCompatibility() {
         if (contextListener == null)
             return;
+        //! validatesModesLoadedDuringPreBuildAndClosesMetadata requires validation after preBuild
+        //! and requires the metadata mapping to close when persisted settings make the mode invalid.
         try {
             SingleChronicleQueue.validateContextListenerCompatibility(
                     key != null || encodingSupplier != null,
@@ -1646,6 +1648,8 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
      */
     public <T> SingleChronicleQueueBuilder contextListener(@NotNull Class<T> writerType,
                                                             @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        //! ContextListenerCoreTest#listenerRemainsCallerOwned requires configuration to retain but
+        //! never close the caller-owned listener.
         contextListenerWriterType = requireNonNull(writerType, "writerType");
         contextListener = requireNonNull(listener, "listener");
         return this;

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -368,6 +368,12 @@ class StoreAppender extends AbstractCloseable
     @Nullable
     @Override
     public Wire wireForIndex() {
+        queue.throwIfContextListenerCallbackActive();
+        return wireForIndex;
+    }
+
+    @Nullable
+    Wire wireForIndexInternal() {
         return wireForIndex;
     }
 
@@ -622,7 +628,7 @@ class StoreAppender extends AbstractCloseable
         queue.throwIfContextListenerCallbackActive();
         // we allow the sink process to write metaData
         checkAppendLock(metaData);
-        ContextListenerState listenerState = startContextListenerWriteAttempt();
+        ContextListenerState listenerState = startContextListenerWriteAttempt(metaData);
         count++;
         try {
             return prepareAndReturnWriteContext(metaData, listenerState);
@@ -635,8 +641,12 @@ class StoreAppender extends AbstractCloseable
         }
     }
 
-    private ContextListenerState startContextListenerWriteAttempt() {
+    private ContextListenerState startContextListenerWriteAttempt(boolean metaData) {
         ContextListenerState state = contextListenerState;
+        // Metadata and exact-index recovery are listener-free and do not consume the ordinary
+        // output registration window.
+        if (metaData)
+            return state;
         if (state == ContextListenerState.UNSET)
             contextListenerState = state = ContextListenerState.NONE;
         state.onWriteAttempt();
@@ -1368,7 +1378,7 @@ class StoreAppender extends AbstractCloseable
         throwExceptionIfClosed();
         queue.throwIfContextListenerCallbackActive();
         checkAppendLock();
-        ContextListenerState listenerState = startContextListenerWriteAttempt();
+        ContextListenerState listenerState = startContextListenerWriteAttempt(false);
         writeLock.lock();
         try {
             if (listenerState.requiresDestinationPreflight(false)) {
@@ -2032,7 +2042,7 @@ class StoreAppender extends AbstractCloseable
             // If the sequence numbers don't match, log an error and perform a linear scan
             if (seq1 != seq2) {
                 final long seq3 = store.indexing
-                        .linearScanByPosition(wireForIndex(), position, 0, 0, true);
+                        .linearScanByPosition(wireForIndex, position, 0, 0, true);
                 Jvm.error().on(getClass(),
                         "Thread=" + Thread.currentThread().getName() +
                                 " pos: " + position +

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -358,6 +358,7 @@ class StoreAppender extends AbstractCloseable
     @Nullable
     @Override
     public Wire wire() {
+        queue.throwIfContextListenerCallbackActive();
         return wire;
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -655,16 +655,20 @@ class StoreAppender extends AbstractCloseable
             writeLock.lock();
 
             try {
-                long safeLength = queue.overlapSize();
-                resolveOrdinaryAppendDestination();
-                if (listenerState.beforeDocument(metaData, lastOrdinaryContextCount))
+                final long safeLength = queue.overlapSize();
+                if (listenerState.requiresDestinationPreflight(metaData)) {
+                    resolveOrdinaryAppendDestination();
+                    if (listenerState.beforeDocument(false, lastOrdinaryContextCount))
+                        resetPosition();
+                    assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
+                    openContext(metaData, safeLength, false);
+                } else {
+                    moveToCycleForAppend();
                     resetPosition();
-                assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
-
-                //! ordinaryWritingDocumentRollsForwardPastSealedCurrentCycle fails if document acquisition bypasses
-                //! the bounded EOF-aware destination preflight above. Passing false here opens the already-selected
-                //! cycle without performing a second roll policy after listener output has begun.
-                openContext(metaData, safeLength, false);
+                    assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
+                    openContext(metaData, safeLength, true);
+                    lastOrdinaryContextCount = cycle;
+                }
 
                 // Move readPosition to the start of the context. i.e. readRemaining() == 0
                 wire.bytes().readPosition(wire.bytes().writePosition());
@@ -1272,7 +1276,7 @@ class StoreAppender extends AbstractCloseable
      */
     void openContextForContextListener(boolean metaData) {
         resetPosition();
-        openContext(metaData, queue.overlapSize());
+        openContext(metaData, queue.overlapSize(), false);
     }
 
     /**
@@ -1354,10 +1358,16 @@ class StoreAppender extends AbstractCloseable
         ContextListenerState listenerState = startContextListenerWriteAttempt();
         writeLock.lock();
         try {
-            resolveOrdinaryAppendDestination();
-            if (listenerState.beforeRawDocument(lastOrdinaryContextCount))
-                resetPosition();
-            this.positionOfHeader = writeHeader(queue.overlapSize());
+            if (listenerState.requiresDestinationPreflight(false)) {
+                resolveOrdinaryAppendDestination();
+                if (listenerState.beforeRawDocument(lastOrdinaryContextCount))
+                    resetPosition();
+                this.positionOfHeader = writeHeader(queue.overlapSize());
+            } else {
+                moveToCycleForAppend();
+                this.positionOfHeader = writeHeaderForOrdinaryAppend(queue.overlapSize());
+                lastOrdinaryContextCount = cycle;
+            }
 
             assert isInsideHeader(wire);
             beforeAppend(wire, wire.headerNumber() + 1);

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -2373,7 +2373,7 @@ class StoreAppender extends AbstractCloseable
         }
 
         @Override
-        public int contextCount() {
+        public long contextCount() {
             // Reject on any double-buffered queue, not just when this write happened to hit lock
             // contention: otherwise the same code works or throws depending on runtime contention.
             // Progressive contextCount usage and double buffering are an unsupported combination.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -33,6 +33,7 @@ import java.io.StreamCorruptedException;
 import java.nio.BufferOverflowException;
 import java.time.DateTimeException;
 import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
@@ -80,6 +81,8 @@ class StoreAppender extends AbstractCloseable
     private Pretoucher pretoucher = null;
     private MicroToucher microtoucher = null;
     private Wire bufferWire = null;
+    @NotNull
+    private ContextListenerState contextListenerState;
     private int count = 0;
 
     /**
@@ -99,6 +102,7 @@ class StoreAppender extends AbstractCloseable
         this.writeLock = queue.writeLock();
         this.appendLock = queue.appendLock();
         this.context = new StoreAppenderContext();
+        this.contextListenerState = queue.newContextListenerState(this, context);
         this.finalizer = Jvm.isResourceTracing() ? new Finalizer() : null;
 
         try {
@@ -267,6 +271,7 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     protected void performClose() {
+        contextListenerState = ContextListenerState.NONE;
         releaseBytesFor(wireForIndex);
         releaseBytesFor(wire);
         releaseBytesFor(bufferWire);
@@ -563,6 +568,21 @@ class StoreAppender extends AbstractCloseable
 
     @NotNull
     @Override
+    public <T> ExcerptAppender contextListener(@NotNull Class<T> writerType,
+                                                @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        throwExceptionIfClosed();
+        Objects.requireNonNull(writerType, "writerType");
+        Objects.requireNonNull(listener, "listener");
+        if (queue.doubleBuffer)
+            throw new UnsupportedOperationException("contextListener is not supported with double buffering");
+        if (contextListenerState.started())
+            throw new IllegalStateException("Cannot change contextListener after this appender has written");
+        contextListenerState = ContextListenerState.forAppender(this, context, writerType, listener);
+        return this;
+    }
+
+    @NotNull
+    @Override
     // throws UnrecoverableTimeoutException
     public DocumentContext writingDocument() {
         return writingDocument(false); // avoid overhead of a default method.
@@ -582,13 +602,25 @@ class StoreAppender extends AbstractCloseable
         throwExceptionIfClosed();
         // we allow the sink process to write metaData
         checkAppendLock(metaData);
+        ContextListenerState listenerState = startContextListenerWriteAttempt();
         count++;
         try {
-            return prepareAndReturnWriteContext(metaData);
-        } catch (RuntimeException e) {
+            return prepareAndReturnWriteContext(metaData, listenerState);
+        } catch (Throwable e) {
+            // Throwable, not just RuntimeException: an Error from a context listener must also
+            // restore count, or the next write takes the count>1 fast path and is handed a stale,
+            // never-opened context - permanently wedging the appender.
             count--;
-            throw e;
+            throw Jvm.rethrow(e);
         }
+    }
+
+    private ContextListenerState startContextListenerWriteAttempt() {
+        ContextListenerState state = contextListenerState;
+        if (state == ContextListenerState.UNSET)
+            contextListenerState = state = ContextListenerState.NONE;
+        state.onWriteAttempt();
+        return state;
     }
 
     /**
@@ -599,7 +631,8 @@ class StoreAppender extends AbstractCloseable
      * @param metaData indicates if the write context is for metadata
      * @return the prepared {@link StoreAppenderContext} ready for writing
      */
-    private StoreAppender.StoreAppenderContext prepareAndReturnWriteContext(boolean metaData) {
+    private StoreAppender.StoreAppenderContext prepareAndReturnWriteContext(
+            boolean metaData, ContextListenerState listenerState) {
         if (count > 1) {
             assert metaData == context.metaData;
             return context;
@@ -620,6 +653,8 @@ class StoreAppender extends AbstractCloseable
 
                 long safeLength = queue.overlapSize();
                 resetPosition();
+                if (listenerState.beforeDocument(metaData))
+                    resetPosition();
                 assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
 
                 //! ordinaryWritingDocumentRollsForwardPastSealedCurrentCycle fails if document acquisition bypasses
@@ -629,9 +664,12 @@ class StoreAppender extends AbstractCloseable
 
                 // Move readPosition to the start of the context. i.e. readRemaining() == 0
                 wire.bytes().readPosition(wire.bytes().writePosition());
-            } catch (RuntimeException e) {
+            } catch (Throwable e) {
+                // Catch Throwable, not just RuntimeException: a context listener (or a corrupt-index
+                // AssertionError) can throw an Error, and leaking the cross-process write lock would
+                // stall every appender in every process until the lock times out.
                 writeLock.unlock();
-                throw e;
+                throw Jvm.rethrow(e);
             }
         }
 
@@ -1188,6 +1226,42 @@ class StoreAppender extends AbstractCloseable
     }
 
     /**
+     * Opens a document for a context listener while this appender's write lock is already held.
+     *
+     * <p>This is package-private solely for {@link ContextListenerState}. Context
+     * listeners cannot use the regular appender entry points because those paths attempt to acquire
+     * the non-reentrant write lock again.</p>
+     *
+     * @param metaData whether the listener document contains metadata
+     */
+    void openContextForContextListener(boolean metaData) {
+        resetPosition();
+        openContext(metaData, queue.overlapSize());
+    }
+
+    void resetPositionForContextListener() {
+        resetPosition();
+    }
+
+    /**
+     * Closes the document written by a context listener without releasing the appender's write
+     * lock, which remains owned by the outer application write.
+     *
+     * <p>The temporary count prevents any nesting state from the application write from suppressing
+     * the listener document's commit. The original count is restored for the application document
+     * that follows.</p>
+     */
+    void closeContextForContextListener() {
+        int savedCount = count;
+        try {
+            count = 1;
+            context.close(false);
+        } finally {
+            count = savedCount;
+        }
+    }
+
+    /**
      * Checks if the current header number matches the expected sequence in the queue.
      * Throws an {@link AssertionError} if there is a mismatch.
      *
@@ -1244,15 +1318,13 @@ class StoreAppender extends AbstractCloseable
     public void writeBytes(@NotNull final BytesStore<?, ?> bytes) {
         throwExceptionIfClosed();
         checkAppendLock();
+        ContextListenerState listenerState = startContextListenerWriteAttempt();
         writeLock.lock();
         try {
-            //! sequentialWriteBytesIgnoresClockRollback fails if this entry point retains the former clock-only
-            //! selection: bytes would move backwards while writingDocument() follows the shared published maximum.
-            moveToCycleForAppend();
-            //! sequentialWriteBytesRollsForwardPastSealedCurrentCycle proves sequential byte appends need the same
-            //! bounded EOF transition as ordinary document writes; calling writeHeader() directly leaves this path
-            //! behind the seal.
-            this.positionOfHeader = writeHeaderForOrdinaryAppend((int) queue.overlapSize());
+            resolveOrdinaryAppendDestination();
+            if (listenerState.beforeRawDocument())
+                resetPosition();
+            this.positionOfHeader = writeHeader((int) queue.overlapSize());
 
             assert isInsideHeader(wire);
             beforeAppend(wire, wire.headerNumber() + 1);
@@ -1291,6 +1363,7 @@ class StoreAppender extends AbstractCloseable
     public void writeBytes(final long index, @NotNull final BytesStore<?, ?> bytes) {
         throwExceptionIfClosed();
         checkAppendLock();
+        startContextListenerWriteAttempt();
         writeLock.lock();
         try {
             writeBytesInternal(index, bytes);
@@ -1716,7 +1789,6 @@ class StoreAppender extends AbstractCloseable
     private void writeBytesInternal(@NotNull final BytesStore<?, ?> bytes, boolean metadata) {
         assert writeLock.locked();
         try {
-            int safeLength = (int) queue.overlapSize();
             assert count == 0 : "count=" + count;
             //! canBackfillPreviousCycleAfterEOF and exactBackfillFindsEofInEmptySealedCycle require exact recovery to
             //! handle the intended physical EOF before this call. Passing false keeps Q2's ordinary successor-cycle
@@ -2298,6 +2370,16 @@ class StoreAppender extends AbstractCloseable
                     throw e;
                 }
             }
+        }
+
+        @Override
+        public int contextCount() {
+            // Reject on any double-buffered queue, not just when this write happened to hit lock
+            // contention: otherwise the same code works or throws depending on runtime contention.
+            // Progressive contextCount usage and double buffering are an unsupported combination.
+            if (queue.doubleBuffer)
+                throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
+            return isClosed ? -1 : StoreAppender.this.cycle();
         }
 
         /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -574,8 +574,7 @@ class StoreAppender extends AbstractCloseable
         throwExceptionIfClosed();
         Objects.requireNonNull(writerType, "writerType");
         Objects.requireNonNull(listener, "listener");
-        if (queue.doubleBuffer)
-            throw new UnsupportedOperationException("contextListener is not supported with double buffering");
+        queue.validateContextListenerCompatibility();
         if (contextListenerState.started())
             throw new IllegalStateException("Cannot change contextListener after this appender has written");
         contextListenerState = ContextListenerState.forAppender(this, context, writerType, listener);

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -293,6 +293,12 @@ class StoreAppender extends AbstractCloseable
         bufferWire = null;
     }
 
+    @Override
+    protected void assertCloseable() {
+        queue.throwIfContextListenerCallbackActive();
+        super.assertCloseable();
+    }
+
     /**
      * pretouch() has to be run on the same thread, as the thread that created the appender. If you want to use pretouch() in another thread, you must
      * first create or have an appender that was created on this thread, and then use this appender to call the pretouch()
@@ -300,6 +306,7 @@ class StoreAppender extends AbstractCloseable
     @Override
     public void pretouch() {
         throwExceptionIfClosed();
+        queue.throwIfContextListenerCallbackActive();
 
         try {
             if (pretoucher == null)
@@ -321,6 +328,7 @@ class StoreAppender extends AbstractCloseable
     @Override
     public boolean microTouch() {
         throwExceptionIfClosed();
+        queue.throwIfContextListenerCallbackActive();
 
         if (microtoucher == null)
             microtoucher = new MicroToucher(this);
@@ -334,6 +342,7 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     public void bgMicroTouch() {
+        queue.throwIfContextListenerCallbackActive();
         if (isClosed())
             throw new ClosedIllegalStateException(getClass().getName() + " closed for " + Thread.currentThread().getName(), closedHere);
 
@@ -572,11 +581,13 @@ class StoreAppender extends AbstractCloseable
     public <T> ExcerptAppender contextListener(@NotNull Class<T> writerType,
                                                 @NotNull MarshallableOut.ContextListener<? super T> listener) {
         throwExceptionIfClosed();
+        queue.throwIfContextListenerCallbackActive();
         Objects.requireNonNull(writerType, "writerType");
         Objects.requireNonNull(listener, "listener");
         queue.validateContextListenerCompatibility();
         if (contextListenerState.started())
             throw new IllegalStateException("Cannot change contextListener after this appender has written");
+        queue.enableContextListenerCallbackGuard();
         contextListenerState = ContextListenerState.forAppender(this, context, writerType, listener);
         return this;
     }
@@ -708,6 +719,7 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     public DocumentContext acquireWritingDocument(boolean metaData) {
+        queue.throwIfContextListenerCallbackActive();
         if (!DISABLE_SINGLE_THREADED_CHECK)
             this.threadSafetyCheck(true);
         if (context.wire != null && context.isOpen() && context.chainedElement())
@@ -724,6 +736,7 @@ class StoreAppender extends AbstractCloseable
     }
 
     void normaliseEOFs(@Nullable Runnable afterCycleEnumeration) {
+        queue.throwIfContextListenerCallbackActive();
         long start = System.nanoTime();
         final WriteLock writeLock = queue.writeLock();
         writeLock.lock();
@@ -2090,6 +2103,7 @@ class StoreAppender extends AbstractCloseable
     @SuppressWarnings("rawtypes")
     @Override
     public void sync() {
+        queue.throwIfContextListenerCallbackActive();
         if (store == null || wire == null)
             return;
 
@@ -2117,6 +2131,7 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     public void rollbackIfNotComplete() {
+        queue.throwIfContextListenerCallbackActive();
         context.rollbackIfNotComplete();
     }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -651,7 +651,7 @@ class StoreAppender extends AbstractCloseable
         queue.throwIfContextListenerCallbackActive();
         // we allow the sink process to write metaData
         checkAppendLock(metaData);
-        ContextListenerState listenerState = startContextListenerWriteAttempt(metaData);
+        ContextListenerState listenerState = contextListenerState;
         count++;
         try {
             return prepareAndReturnWriteContext(metaData, listenerState);
@@ -663,12 +663,13 @@ class StoreAppender extends AbstractCloseable
         }
     }
 
-    private ContextListenerState startContextListenerWriteAttempt(boolean metaData) {
-        ContextListenerState state = contextListenerState;
+    private ContextListenerState acceptContextListenerWriteAttempt(
+            boolean metaData, ContextListenerState state) {
         // Metadata and exact-index recovery are listener-free and do not consume the ordinary
         // output registration window.
-        //! metadataDoesNotConsumeAppenderListenerRegistration mutation-fails if metadata selects
-        //! NONE or marks the appender's ordinary listener state as started.
+        //! metadataDoesNotConsumeAppenderListenerRegistration and
+        //! secondEofLeavesListenerRegistrationOpen require state mutation only after ordinary
+        //! destination preflight succeeds; metadata and a rejected destination leave it unchanged.
         if (metaData)
             return state;
         if (state == ContextListenerState.UNSET)
@@ -692,6 +693,7 @@ class StoreAppender extends AbstractCloseable
         //! preflight to accompany this exact attempt rather than being re-read after locking.
         if (count > 1) {
             assert metaData == context.metaData;
+            acceptContextListenerWriteAttempt(metaData, listenerState);
             return context;
         }
 
@@ -699,6 +701,7 @@ class StoreAppender extends AbstractCloseable
 
         if (shouldPrepareDoubleBuffer) {
             prepareDoubleBuffer();
+            acceptContextListenerWriteAttempt(metaData, listenerState);
         } else {
             writeLock.lock();
 
@@ -708,6 +711,7 @@ class StoreAppender extends AbstractCloseable
                     //! sealedHighestRollIsResolvedBeforeDocumentListener mutation-fails if the
                     //! callback observes a cycle before QUEUE-146 resolves EOF and the actual destination.
                     resolveOrdinaryAppendDestination();
+                    acceptContextListenerWriteAttempt(false, listenerState);
                     if (listenerState.beforeDocument(false, lastOrdinaryContextCount))
                         resetPosition();
                     assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
@@ -720,16 +724,18 @@ class StoreAppender extends AbstractCloseable
                     resetPosition();
                     assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
                     openContext(metaData, safeLength, true);
-                    if (!metaData)
+                    if (!metaData) {
+                        acceptContextListenerWriteAttempt(false, listenerState);
                         lastOrdinaryContextCount = cycle;
+                    }
                 }
 
                 // Move readPosition to the start of the context. i.e. readRemaining() == 0
                 wire.bytes().readPosition(wire.bytes().writePosition());
             } catch (Throwable e) {
                 //! ContextListenerCoreTest#listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable
-                //! requires Error as well as RuntimeException to release the cross-process write lock;
-                //! leaking it stalls every appender in every process until lock-timeout recovery.
+                //! requires Error as well as RuntimeException to restore count, roll back the held
+                //! document, release the table write lock and leave this appender usable.
                 writeLock.unlock();
                 throw Jvm.rethrow(e);
             }
@@ -1425,19 +1431,21 @@ class StoreAppender extends AbstractCloseable
         throwExceptionIfClosed();
         queue.throwIfContextListenerCallbackActive();
         checkAppendLock();
-        ContextListenerState listenerState = startContextListenerWriteAttempt(false);
+        ContextListenerState listenerState = contextListenerState;
         writeLock.lock();
         try {
             if (listenerState.requiresDestinationPreflight(false)) {
                 //! sealedHighestRollIsResolvedBeforeRawListener pins sequential raw writes to the
                 //! same resolved destination and notification ordering as document writes.
                 resolveOrdinaryAppendDestination();
+                acceptContextListenerWriteAttempt(false, listenerState);
                 if (listenerState.beforeRawDocument(lastOrdinaryContextCount))
                     resetPosition();
                 this.positionOfHeader = writeHeader(queue.overlapSize());
             } else {
                 moveToCycleForAppend();
                 this.positionOfHeader = writeHeaderForOrdinaryAppend(queue.overlapSize());
+                acceptContextListenerWriteAttempt(false, listenerState);
                 lastOrdinaryContextCount = cycle;
             }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -688,7 +688,8 @@ class StoreAppender extends AbstractCloseable
                     resetPosition();
                     assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
                     openContext(metaData, safeLength, true);
-                    lastOrdinaryContextCount = cycle;
+                    if (!metaData)
+                        lastOrdinaryContextCount = cycle;
                 }
 
                 // Move readPosition to the start of the context. i.e. readRemaining() == 0

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -295,6 +295,8 @@ class StoreAppender extends AbstractCloseable
 
     @Override
     protected void assertCloseable() {
+        //! capturedAppenderCloseFromListenerFailsFast keeps callback teardown from releasing the
+        //! outer write's lock and mapped state.
         queue.throwIfContextListenerCallbackActive();
         super.assertCloseable();
     }
@@ -592,15 +594,18 @@ class StoreAppender extends AbstractCloseable
         Objects.requireNonNull(writerType, "writerType");
         Objects.requireNonNull(listener, "listener");
         queue.validateContextListenerCompatibility();
+        //! metadataDoesNotConsumeAppenderListenerRegistration and appendLockRejectionDoesNotConsumeListenerRegistration
+        //! pin the registration boundary to the first accepted ordinary write attempt.
         if (contextListenerState.started())
             throw new IllegalStateException("Cannot change contextListener after this appender has written");
-        queue.enableContextListenerCallbackGuard();
         contextListenerState = ContextListenerState.forAppender(this, context, writerType, listener);
         return this;
     }
 
     @Override
     public int contextCount() {
+        //! rolledBackClockDoesNotRepeatAnOlderContext and exactHistoricalRecoveryDoesNotChangeOrdinaryContext
+        //! pin this to the last resolved ordinary destination, not the appender's temporary cycle.
         if (queue.doubleBuffer)
             throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
         return isClosed() ? -1 : lastOrdinaryContextCount;
@@ -633,9 +638,8 @@ class StoreAppender extends AbstractCloseable
         try {
             return prepareAndReturnWriteContext(metaData, listenerState);
         } catch (Throwable e) {
-            // Throwable, not just RuntimeException: an Error from a context listener must also
-            // restore count, or the next write takes the count>1 fast path and is handed a stale,
-            // never-opened context - permanently wedging the appender.
+            //! listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable requires Error as well as
+            //! RuntimeException to restore count; otherwise the next write receives a stale context.
             count--;
             throw Jvm.rethrow(e);
         }
@@ -645,6 +649,8 @@ class StoreAppender extends AbstractCloseable
         ContextListenerState state = contextListenerState;
         // Metadata and exact-index recovery are listener-free and do not consume the ordinary
         // output registration window.
+        //! metadataDoesNotConsumeAppenderListenerRegistration mutation-fails if metadata selects
+        //! NONE or marks the appender's ordinary listener state as started.
         if (metaData)
             return state;
         if (state == ContextListenerState.UNSET)
@@ -678,6 +684,8 @@ class StoreAppender extends AbstractCloseable
             try {
                 final long safeLength = queue.overlapSize();
                 if (listenerState.requiresDestinationPreflight(metaData)) {
+                    //! sealedHighestRollIsResolvedBeforeDocumentListener mutation-fails if the
+                    //! callback observes a cycle before QUEUE-146 resolves EOF and the actual destination.
                     resolveOrdinaryAppendDestination();
                     if (listenerState.beforeDocument(false, lastOrdinaryContextCount))
                         resetPosition();
@@ -1058,6 +1066,8 @@ class StoreAppender extends AbstractCloseable
      * QUEUE-144 invokes context listeners only after this method has fixed the actual cycle.
      */
     private void resolveOrdinaryAppendDestination() {
+        //! secondEofFailsBeforeListenerStateChanges requires the same one-advance QUEUE-146 rule
+        //! to complete before listener state or application-header state changes.
         moveToCycleForAppend();
         resetPosition();
         int header = nextApplicationHeader();
@@ -1276,9 +1286,9 @@ class StoreAppender extends AbstractCloseable
      */
     private void openContext(final boolean metaData, final long safeLength, final boolean rollAtEndOfData) {
         assert wire != null;
-        //! Exact-index recovery must remain strict while ordinary documents may cross one EOF. Keeping the policy as
-        //! an explicit argument prevents writeBytesInternal() from accidentally inheriting the ordinary retry when
-        //! the two paths share context construction.
+        //! exactHistoricalRecoveryDoesNotChangeOrdinaryContext requires explicit-index recovery to
+        //! remain listener-free and strict at EOF. Keeping the policy explicit prevents writeBytesInternal() from
+        //! accidentally inheriting the ordinary one-advance helper when both paths share context construction.
         this.positionOfHeader = rollAtEndOfData
                 ? writeHeaderForOrdinaryAppend(safeLength)
                 : writeHeader(safeLength);
@@ -1299,6 +1309,8 @@ class StoreAppender extends AbstractCloseable
      * @param metaData whether the listener document contains metadata
      */
     void openContextForContextListener(boolean metaData) {
+        //! listenerCanHoldOneDocumentWhileWritingContext requires an in-lock opening path; public
+        //! appender entry would try to reacquire the non-reentrant Queue write lock.
         resetPosition();
         openContext(metaData, queue.overlapSize(), false);
     }
@@ -1312,6 +1324,8 @@ class StoreAppender extends AbstractCloseable
      * that follows.</p>
      */
     void closeContextForContextListener() {
+        //! listenerClosePreservesNestingForDocumentWrite mutation-pins committing the listener
+        //! document without consuming the outer application's nesting/count state.
         int savedCount = count;
         try {
             count = 1;
@@ -1383,6 +1397,8 @@ class StoreAppender extends AbstractCloseable
         writeLock.lock();
         try {
             if (listenerState.requiresDestinationPreflight(false)) {
+                //! sealedHighestRollIsResolvedBeforeRawListener pins sequential raw writes to the
+                //! same resolved destination and notification ordering as document writes.
                 resolveOrdinaryAppendDestination();
                 if (listenerState.beforeRawDocument(lastOrdinaryContextCount))
                     resetPosition();
@@ -1855,6 +1871,8 @@ class StoreAppender extends AbstractCloseable
 
     private void writeBytesInternal(@NotNull final BytesStore<?, ?> bytes, boolean metadata) {
         assert writeLock.locked();
+        //! indexedWriteDoesNotNotifyOrConsumeListenerRegistration pins this exact-index path as
+        //! recovery infrastructure: it must not invoke or advance ordinary listener state.
         try {
             assert count == 0 : "count=" + count;
             //! canBackfillPreviousCycleAfterEOF and exactBackfillFindsEofInEmptySealedCycle require exact recovery to

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -655,8 +655,10 @@ class StoreAppender extends AbstractCloseable
         try {
             return prepareAndReturnWriteContext(metaData);
         } catch (Throwable e) {
-            //! listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable requires Error as well as
-            //! RuntimeException to restore count; otherwise the next write receives a stale context.
+            //! listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable and
+            //! documentApplicationHeaderFailureDoesNotRepeatSuccessfulListener require Error as well as
+            //! RuntimeException to restore count, including failure after successful listener output;
+            //! otherwise the next write receives a stale context.
             count--;
             throw Jvm.rethrow(e);
         }
@@ -716,13 +718,19 @@ class StoreAppender extends AbstractCloseable
                     assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
                     openContext(metaData, safeLength, false);
                 } else {
-                    //! ContextListenerCoreTest#metadataDoesNotConsumeAppenderListenerRegistration and
-                    //! #indexedWriteDoesNotNotifyOrConsumeListenerRegistration require listener-free
-                    //! paths to preserve positioning without advancing listener lifecycle state.
+                    //! writingDocumentIgnoresClockRollback and stalledWriterFollowsAnotherWriterToLaterCycle
+                    //! preserve Q1 destination selection for listener-free documents. Retaining a separate
+                    //! clock-only branch here would move ordinary writers below the published high-water mark.
                     moveToCycleForAppend();
                     resetPosition();
                     assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
+                    //! ordinaryWritingDocumentRollsForwardPastSealedCurrentCycle and
+                    //! stalledWriterAdvancesOnceFromPublishedSealedCycle preserve Q2's one-EOF transition after Q1
+                    //! selects the authoritative destination, even when no listener is configured.
                     openContext(metaData, safeLength, true);
+                    //! ContextListenerCoreTest#metadataDoesNotConsumeAppenderListenerRegistration leaves metadata
+                    //! outside ordinary lifecycle state; #secondEofLeavesListenerRegistrationOpen requires the
+                    //! ordinary header to be acquired before a listener-free appender closes registration.
                     if (!metaData) {
                         acceptContextListenerWriteAttempt(false, listenerState);
                         lastOrdinaryContextCount = cycle;
@@ -733,8 +741,9 @@ class StoreAppender extends AbstractCloseable
                 wire.bytes().readPosition(wire.bytes().writePosition());
             } catch (Throwable e) {
                 //! ContextListenerCoreTest#listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable
-                //! requires Error as well as RuntimeException to restore count, roll back the held
-                //! document, release the table write lock and leave this appender usable.
+                //! covers failure inside the callback; #documentApplicationHeaderFailureDoesNotRepeatSuccessfulListener
+                //! covers the later application acquisition. Both require this lock to be released on Throwable,
+                //! while the outer catch restores count; only failed listener output is rolled back by its lifecycle.
                 writeLock.unlock();
                 throw Jvm.rethrow(e);
             }
@@ -1088,13 +1097,6 @@ class StoreAppender extends AbstractCloseable
     }
 
     /**
-     * Writes a header for the current wire, ensuring the correct position and header number
-     * is set for the next write operation.
-     *
-     * @param safeLength the safe length of data that can be written
-     * @return the position of the written header
-     */
-    /**
      * Selects the authoritative ordinary-write destination without opening an application header.
      * QUEUE-144 invokes context listeners only after this method has fixed the actual cycle.
      */
@@ -1132,6 +1134,13 @@ class StoreAppender extends AbstractCloseable
         }
     }
 
+    /**
+     * Writes a header for the current wire, ensuring the correct position and header number
+     * is set for the next write operation.
+     *
+     * @param safeLength the safe length of data that can be written
+     * @return the position of the written header
+     */
     private long writeHeader(final long safeLength) {
         //! canBackfillPreviousCycleAfterEOF and exactWriteReplacesAnIncompleteRequestedEntryWithAWarning require
         //! exact recovery to inspect the next physical header before Wire opens or overwrites it. Ordinary writes
@@ -1445,7 +1454,11 @@ class StoreAppender extends AbstractCloseable
                     resetPosition();
                 this.positionOfHeader = writeHeader(queue.overlapSize());
             } else {
+                //! sequentialWriteBytesIgnoresClockRollback preserves Q1 selection for listener-free byte writes;
+                //! choosing from wall time alone would diverge from the ordinary document path.
                 moveToCycleForAppend();
+                //! sequentialWriteBytesRollsForwardPastSealedCurrentCycle preserves Q2's bounded EOF retry for this
+                //! caller. Listener preflight must not leave ordinary listener-free bytes stranded behind a seal.
                 this.positionOfHeader = writeHeaderForOrdinaryAppend(queue.overlapSize());
                 acceptContextListenerWriteAttempt(false, listenerState);
                 lastOrdinaryContextCount = cycle;
@@ -1462,6 +1475,8 @@ class StoreAppender extends AbstractCloseable
         } catch (StreamCorruptedException e) {
             throw new AssertionError(e);
         } finally {
+            //! ContextListenerCoreTest#rawApplicationHeaderFailureDoesNotRepeatSuccessfulListener requires this
+            //! release even when the listener committed successfully and subsequent application acquisition failed.
             writeLock.unlock();
         }
     }
@@ -2105,8 +2120,9 @@ class StoreAppender extends AbstractCloseable
 
             // If the sequence numbers don't match, log an error and perform a linear scan
             if (seq1 != seq2) {
-                //! ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter requires
-                //! this internal diagnostic scan to avoid the guarded public wireForIndex() escape.
+                //! No current listener test discriminates this error-only scan: healthy publication keeps seq1 and
+                //! seq2 equal. Retain internal Wire access so diagnosing a mismatched index during a callback does
+                //! not throw the public re-entry error before reporting the original index inconsistency.
                 final long seq3 = store.indexing
                         .linearScanByPosition(wireForIndex, position, 0, 0, true);
                 Jvm.error().on(getClass(),

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -622,7 +622,8 @@ class StoreAppender extends AbstractCloseable
         //! doubleBufferedAppenderAndDocumentContextCountsAreUnavailable directly requires rejection
         //! before a buffered flush has selected its physical destination.
         if (queue.doubleBuffer)
-            throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
+            throw new IndexNotAvailableException("Context count is unavailable when double buffering because "
+                    + "the target cycle is selected when the buffer is flushed");
         return isClosed() ? -1 : lastOrdinaryContextCount;
     }
 
@@ -2515,7 +2516,8 @@ class StoreAppender extends AbstractCloseable
             //! requires deterministic rejection for every buffered Queue: destination/context selection
             //! occurs only when the buffer flushes, so the count cannot depend on incidental contention.
             if (queue.doubleBuffer)
-                throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
+                throw new IndexNotAvailableException("Context count is unavailable when double buffering because "
+                        + "the target cycle is selected when the buffer is flushed");
             return isClosed ? -1 : StoreAppender.this.contextCount();
         }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -2373,7 +2373,7 @@ class StoreAppender extends AbstractCloseable
         }
 
         @Override
-        public long contextCount() {
+        public int contextCount() {
             // Reject on any double-buffered queue, not just when this write happened to hit lock
             // contention: otherwise the same code works or throws depending on runtime contention.
             // Progressive contextCount usage and double buffering are an unsupported combination.

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -33,7 +33,6 @@ import java.io.StreamCorruptedException;
 import java.nio.BufferOverflowException;
 import java.time.DateTimeException;
 import java.util.NavigableSet;
-import java.util.Objects;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
@@ -81,6 +80,9 @@ class StoreAppender extends AbstractCloseable
     private Pretoucher pretoucher = null;
     private MicroToucher microtoucher = null;
     private Wire bufferWire = null;
+    //! ContextListenerCoreTest#notifiesEachAppenderWithItsOwnContextOncePerRoll requires lifecycle
+    //! state to belong to this appender, while #rolledBackClockDoesNotRepeatAnOlderContext requires
+    //! the last notified value to track the resolved ordinary destination rather than wall time.
     @NotNull
     private ContextListenerState contextListenerState;
     private int lastOrdinaryContextCount = -1;
@@ -103,6 +105,8 @@ class StoreAppender extends AbstractCloseable
         this.writeLock = queue.writeLock();
         this.appendLock = queue.appendLock();
         this.context = new StoreAppenderContext();
+        //! ContextListenerCoreTest#notifiesEachAppenderWithItsOwnContextOncePerRoll distinguishes
+        //! independent appender lifecycle state from one Queue-global notification state.
         this.contextListenerState = queue.newContextListenerState(this, context);
         this.finalizer = Jvm.isResourceTracing() ? new Finalizer() : null;
 
@@ -272,6 +276,8 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     protected void performClose() {
+        //! No focused regression observes this assignment directly; detach the listener lifecycle
+        //! before releasing its mapped Wires so no later close path can call into torn-down state.
         contextListenerState = ContextListenerState.NONE;
         releaseBytesFor(wireForIndex);
         releaseBytesFor(wire);
@@ -308,6 +314,8 @@ class StoreAppender extends AbstractCloseable
     @Override
     public void pretouch() {
         throwExceptionIfClosed();
+        //! ContextListenerCoreTest#capturedAppenderPretouchFromListenerFailsFast requires rejection
+        //! before a captured appender can mutate the Queue's next-cycle mapped state.
         queue.throwIfContextListenerCallbackActive();
 
         try {
@@ -330,7 +338,6 @@ class StoreAppender extends AbstractCloseable
     @Override
     public boolean microTouch() {
         throwExceptionIfClosed();
-        queue.throwIfContextListenerCallbackActive();
 
         if (microtoucher == null)
             microtoucher = new MicroToucher(this);
@@ -344,6 +351,8 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     public void bgMicroTouch() {
+        //! ContextListenerCoreTest#capturedAppenderBackgroundMicroTouchFromListenerFailsFast requires
+        //! rejection before scheduling mapped-page work against the callback's outer appender.
         queue.throwIfContextListenerCallbackActive();
         if (isClosed())
             throw new ClosedIllegalStateException(getClass().getName() + " closed for " + Thread.currentThread().getName(), closedHere);
@@ -360,6 +369,9 @@ class StoreAppender extends AbstractCloseable
     @Nullable
     @Override
     public Wire wire() {
+        //! ContextListenerCoreTest#capturedAppenderWireAccessFromListenerFailsFast and
+        //! #capturedAppenderMicroTouchFromListenerFailsFast require mutable application Wire access
+        //! to fail before direct or composed paths can corrupt the held outer document.
         queue.throwIfContextListenerCallbackActive();
         return wire;
     }
@@ -370,12 +382,16 @@ class StoreAppender extends AbstractCloseable
     @Nullable
     @Override
     public Wire wireForIndex() {
+        //! ContextListenerCoreTest#capturedAppenderIndexWireAccessFromListenerFailsFast requires the
+        //! public mutable index Wire to be hidden while Queue internals use wireForIndexInternal().
         queue.throwIfContextListenerCallbackActive();
         return wireForIndex;
     }
 
     @Nullable
     Wire wireForIndexInternal() {
+        //! ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter requires Queue's
+        //! own index publication to proceed under the callback guard without exposing this path publicly.
         return wireForIndex;
     }
 
@@ -590,9 +606,9 @@ class StoreAppender extends AbstractCloseable
     public <T> ExcerptAppender contextListener(@NotNull Class<T> writerType,
                                                 @NotNull MarshallableOut.ContextListener<? super T> listener) {
         throwExceptionIfClosed();
+        //! ContextListenerCoreTest#capturedAppenderListenerRegistrationFromListenerFailsFast requires
+        //! registration through a captured appender to fail before replacing active callback state.
         queue.throwIfContextListenerCallbackActive();
-        Objects.requireNonNull(writerType, "writerType");
-        Objects.requireNonNull(listener, "listener");
         queue.validateContextListenerCompatibility();
         //! metadataDoesNotConsumeAppenderListenerRegistration and appendLockRejectionDoesNotConsumeListenerRegistration
         //! pin the registration boundary to the first accepted ordinary write attempt.
@@ -630,6 +646,8 @@ class StoreAppender extends AbstractCloseable
     // throws UnrecoverableTimeoutException
     public DocumentContext writingDocument(final boolean metaData) {
         throwExceptionIfClosed();
+        //! ContextListenerCoreTest#appenderWriteFromListenerFailsFast mutation-times out without
+        //! rejection before the captured appender attempts to reacquire its non-reentrant write lock.
         queue.throwIfContextListenerCallbackActive();
         // we allow the sink process to write metaData
         checkAppendLock(metaData);
@@ -669,6 +687,9 @@ class StoreAppender extends AbstractCloseable
      */
     private StoreAppender.StoreAppenderContext prepareAndReturnWriteContext(
             boolean metaData, ContextListenerState listenerState) {
+        //! ContextListenerCoreTest#metadataDoesNotConsumeAppenderListenerRegistration and
+        //! #appendLockRejectionDoesNotConsumeListenerRegistration require the state chosen after
+        //! preflight to accompany this exact attempt rather than being re-read after locking.
         if (count > 1) {
             assert metaData == context.metaData;
             return context;
@@ -692,6 +713,9 @@ class StoreAppender extends AbstractCloseable
                     assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
                     openContext(metaData, safeLength, false);
                 } else {
+                    //! ContextListenerCoreTest#metadataDoesNotConsumeAppenderListenerRegistration and
+                    //! #indexedWriteDoesNotNotifyOrConsumeListenerRegistration require listener-free
+                    //! paths to preserve positioning without advancing listener lifecycle state.
                     moveToCycleForAppend();
                     resetPosition();
                     assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
@@ -703,9 +727,9 @@ class StoreAppender extends AbstractCloseable
                 // Move readPosition to the start of the context. i.e. readRemaining() == 0
                 wire.bytes().readPosition(wire.bytes().writePosition());
             } catch (Throwable e) {
-                // Catch Throwable, not just RuntimeException: a context listener (or a corrupt-index
-                // AssertionError) can throw an Error, and leaking the cross-process write lock would
-                // stall every appender in every process until the lock times out.
+                //! ContextListenerCoreTest#listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable
+                //! requires Error as well as RuntimeException to release the cross-process write lock;
+                //! leaking it stalls every appender in every process until lock-timeout recovery.
                 writeLock.unlock();
                 throw Jvm.rethrow(e);
             }
@@ -739,6 +763,8 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     public DocumentContext acquireWritingDocument(boolean metaData) {
+        //! ContextListenerCoreTest#appenderWriteFromListenerFailsFast requires both document-opening
+        //! APIs to reject before chained-context reuse can expose the outer application document.
         queue.throwIfContextListenerCallbackActive();
         if (!DISABLE_SINGLE_THREADED_CHECK)
             this.threadSafetyCheck(true);
@@ -756,6 +782,8 @@ class StoreAppender extends AbstractCloseable
     }
 
     void normaliseEOFs(@Nullable Runnable afterCycleEnumeration) {
+        //! ContextListenerCoreTest#capturedAppenderNormalisationFromListenerFailsFast requires
+        //! rejection before normalization attempts to reacquire the callback's Queue write lock.
         queue.throwIfContextListenerCallbackActive();
         long start = System.nanoTime();
         final WriteLock writeLock = queue.writeLock();
@@ -1082,6 +1110,9 @@ class StoreAppender extends AbstractCloseable
     }
 
     private int nextApplicationHeader() {
+        //! ContextListenerCoreTest#sealedHighestRollIsResolvedBeforeDocumentListener and
+        //! #sealedHighestRollIsResolvedBeforeRawListener require metadata to be skipped while
+        //! locating the application header that decides whether notification may begin.
         positionForNextHeader();
         final Bytes<?> bytes = wire.bytes();
         long position = bytes.writePosition();
@@ -1324,8 +1355,9 @@ class StoreAppender extends AbstractCloseable
      * that follows.</p>
      */
     void closeContextForContextListener() {
-        //! listenerClosePreservesNestingForDocumentWrite mutation-pins committing the listener
-        //! document without consuming the outer application's nesting/count state.
+        //! ContextListenerCoreTest#listenerClosePreservesNestingForDocumentWrite and
+        //! #listenerClosePreservesNestingAfterRawWrite mutation-pin committing the listener document
+        //! without consuming either outer application's nesting/count state.
         int savedCount = count;
         try {
             count = 1;
@@ -1445,6 +1477,8 @@ class StoreAppender extends AbstractCloseable
     @Override
     public void writeBytes(final long index, @NotNull final BytesStore<?, ?> bytes) {
         throwExceptionIfClosed();
+        //! ContextListenerCoreTest#appenderWriteFromListenerFailsFast establishes the general rule:
+        //! captured public write entry points must reject before taking the outer write's lock.
         queue.throwIfContextListenerCallbackActive();
         checkAppendLock();
         writeLock.lock();
@@ -2060,6 +2094,8 @@ class StoreAppender extends AbstractCloseable
 
             // If the sequence numbers don't match, log an error and perform a linear scan
             if (seq1 != seq2) {
+                //! ContextListenerCoreTest#writesContextBeforeDataAndAllowsRetainingWriter requires
+                //! this internal diagnostic scan to avoid the guarded public wireForIndex() escape.
                 final long seq3 = store.indexing
                         .linearScanByPosition(wireForIndex, position, 0, 0, true);
                 Jvm.error().on(getClass(),
@@ -2133,6 +2169,8 @@ class StoreAppender extends AbstractCloseable
     @SuppressWarnings("rawtypes")
     @Override
     public void sync() {
+        //! ContextListenerCoreTest#capturedAppenderSyncFromListenerFailsFast requires rejection
+        //! before flushing durability state for a document the callback does not own.
         queue.throwIfContextListenerCallbackActive();
         if (store == null || wire == null)
             return;
@@ -2161,6 +2199,8 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     public void rollbackIfNotComplete() {
+        //! ContextListenerCoreTest#capturedAppenderRollbackFromListenerFailsFast requires rejection
+        //! before rollback can release or truncate the outer application's shared document.
         queue.throwIfContextListenerCallbackActive();
         context.rollbackIfNotComplete();
     }
@@ -2461,9 +2501,9 @@ class StoreAppender extends AbstractCloseable
 
         @Override
         public int contextCount() {
-            // Reject on any double-buffered queue, not just when this write happened to hit lock
-            // contention: otherwise the same code works or throws depending on runtime contention.
-            // Progressive contextCount usage and double buffering are an unsupported combination.
+            //! ContextListenerCoreTest#rejectsDoubleBuffering requires deterministic rejection for
+            //! every buffered Queue: destination/context selection occurs only when the buffer flushes,
+            //! so exposing a count here would vary with incidental lock contention.
             if (queue.doubleBuffer)
                 throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
             return isClosed ? -1 : StoreAppender.this.contextCount();

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -83,6 +83,7 @@ class StoreAppender extends AbstractCloseable
     private Wire bufferWire = null;
     @NotNull
     private ContextListenerState contextListenerState;
+    private int lastOrdinaryContextCount = -1;
     private int count = 0;
 
     /**
@@ -581,6 +582,13 @@ class StoreAppender extends AbstractCloseable
         return this;
     }
 
+    @Override
+    public int contextCount() {
+        if (queue.doubleBuffer)
+            throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
+        return isClosed() ? -1 : lastOrdinaryContextCount;
+    }
+
     @NotNull
     @Override
     // throws UnrecoverableTimeoutException
@@ -600,6 +608,7 @@ class StoreAppender extends AbstractCloseable
     // throws UnrecoverableTimeoutException
     public DocumentContext writingDocument(final boolean metaData) {
         throwExceptionIfClosed();
+        queue.throwIfContextListenerCallbackActive();
         // we allow the sink process to write metaData
         checkAppendLock(metaData);
         ContextListenerState listenerState = startContextListenerWriteAttempt();
@@ -646,21 +655,16 @@ class StoreAppender extends AbstractCloseable
             writeLock.lock();
 
             try {
-                //! writingDocumentIgnoresClockRollback and stalledWriterFollowsAnotherWriterToLaterCycle require
-                //! documents to use the same no-backward destination selector as sequential byte writes; retaining
-                //! the former local-clock selection lets the two public append paths choose different generations.
-                moveToCycleForAppend();
-
                 long safeLength = queue.overlapSize();
-                resetPosition();
-                if (listenerState.beforeDocument(metaData))
+                resolveOrdinaryAppendDestination();
+                if (listenerState.beforeDocument(metaData, lastOrdinaryContextCount))
                     resetPosition();
                 assert !QueueSystemProperties.CHECK_INDEX || checkWritePositionHeaderNumber();
 
                 //! ordinaryWritingDocumentRollsForwardPastSealedCurrentCycle fails if document acquisition bypasses
-                //! the bounded EOF-aware header path. stalledWriterAdvancesOnceFromPublishedSealedCycle additionally
-                //! requires moveToCycleForAppend above to select the published destination before EOF advances once.
-                openContext(metaData, safeLength, true);
+                //! the bounded EOF-aware destination preflight above. Passing false here opens the already-selected
+                //! cycle without performing a second roll policy after listener output has begun.
+                openContext(metaData, safeLength, false);
 
                 // Move readPosition to the start of the context. i.e. readRemaining() == 0
                 wire.bytes().readPosition(wire.bytes().writePosition());
@@ -1021,6 +1025,38 @@ class StoreAppender extends AbstractCloseable
      * @param safeLength the safe length of data that can be written
      * @return the position of the written header
      */
+    /**
+     * Selects the authoritative ordinary-write destination without opening an application header.
+     * QUEUE-144 invokes context listeners only after this method has fixed the actual cycle.
+     */
+    private void resolveOrdinaryAppendDestination() {
+        moveToCycleForAppend();
+        resetPosition();
+        int header = nextApplicationHeader();
+        if (header == END_OF_DATA) {
+            advanceOrdinaryAppendCycle();
+            resetPosition();
+            header = nextApplicationHeader();
+        }
+        if (header == END_OF_DATA)
+            throw new WriteAfterEOFException();
+        lastOrdinaryContextCount = cycle;
+    }
+
+    private int nextApplicationHeader() {
+        positionForNextHeader();
+        final Bytes<?> bytes = wire.bytes();
+        long position = bytes.writePosition();
+        for (; ; ) {
+            if (store.dataVersion() > 0)
+                position += BytesUtil.padOffset(position);
+            final int header = bytes.readVolatileInt(position);
+            if (!isReadyMetaData(header))
+                return header;
+            position += SPB_HEADER_SIZE + lengthOf(header);
+        }
+    }
+
     private long writeHeader(final long safeLength) {
         //! canBackfillPreviousCycleAfterEOF and exactWriteReplacesAnIncompleteRequestedEntryWithAWarning require
         //! exact recovery to inspect the next physical header before Wire opens or overwrites it. Ordinary writes
@@ -1239,10 +1275,6 @@ class StoreAppender extends AbstractCloseable
         openContext(metaData, queue.overlapSize());
     }
 
-    void resetPositionForContextListener() {
-        resetPosition();
-    }
-
     /**
      * Closes the document written by a context listener without releasing the appender's write
      * lock, which remains owned by the outer application write.
@@ -1317,14 +1349,15 @@ class StoreAppender extends AbstractCloseable
     @Override
     public void writeBytes(@NotNull final BytesStore<?, ?> bytes) {
         throwExceptionIfClosed();
+        queue.throwIfContextListenerCallbackActive();
         checkAppendLock();
         ContextListenerState listenerState = startContextListenerWriteAttempt();
         writeLock.lock();
         try {
             resolveOrdinaryAppendDestination();
-            if (listenerState.beforeRawDocument())
+            if (listenerState.beforeRawDocument(lastOrdinaryContextCount))
                 resetPosition();
-            this.positionOfHeader = writeHeader((int) queue.overlapSize());
+            this.positionOfHeader = writeHeader(queue.overlapSize());
 
             assert isInsideHeader(wire);
             beforeAppend(wire, wire.headerNumber() + 1);
@@ -1362,8 +1395,8 @@ class StoreAppender extends AbstractCloseable
     @Override
     public void writeBytes(final long index, @NotNull final BytesStore<?, ?> bytes) {
         throwExceptionIfClosed();
+        queue.throwIfContextListenerCallbackActive();
         checkAppendLock();
-        startContextListenerWriteAttempt();
         writeLock.lock();
         try {
             writeBytesInternal(index, bytes);
@@ -2379,7 +2412,7 @@ class StoreAppender extends AbstractCloseable
             // Progressive contextCount usage and double buffering are an unsupported combination.
             if (queue.doubleBuffer)
                 throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
-            return isClosed ? -1 : StoreAppender.this.cycle();
+            return isClosed ? -1 : StoreAppender.this.contextCount();
         }
 
         /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreAppender.java
@@ -276,9 +276,6 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     protected void performClose() {
-        //! No focused regression observes this assignment directly; detach the listener lifecycle
-        //! before releasing its mapped Wires so no later close path can call into torn-down state.
-        contextListenerState = ContextListenerState.NONE;
         releaseBytesFor(wireForIndex);
         releaseBytesFor(wire);
         releaseBytesFor(bufferWire);
@@ -622,6 +619,8 @@ class StoreAppender extends AbstractCloseable
     public int contextCount() {
         //! rolledBackClockDoesNotRepeatAnOlderContext and exactHistoricalRecoveryDoesNotChangeOrdinaryContext
         //! pin this to the last resolved ordinary destination, not the appender's temporary cycle.
+        //! doubleBufferedAppenderAndDocumentContextCountsAreUnavailable directly requires rejection
+        //! before a buffered flush has selected its physical destination.
         if (queue.doubleBuffer)
             throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
         return isClosed() ? -1 : lastOrdinaryContextCount;
@@ -651,10 +650,9 @@ class StoreAppender extends AbstractCloseable
         queue.throwIfContextListenerCallbackActive();
         // we allow the sink process to write metaData
         checkAppendLock(metaData);
-        ContextListenerState listenerState = contextListenerState;
         count++;
         try {
-            return prepareAndReturnWriteContext(metaData, listenerState);
+            return prepareAndReturnWriteContext(metaData);
         } catch (Throwable e) {
             //! listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable requires Error as well as
             //! RuntimeException to restore count; otherwise the next write receives a stale context.
@@ -686,11 +684,11 @@ class StoreAppender extends AbstractCloseable
      * @param metaData indicates if the write context is for metadata
      * @return the prepared {@link StoreAppenderContext} ready for writing
      */
-    private StoreAppender.StoreAppenderContext prepareAndReturnWriteContext(
-            boolean metaData, ContextListenerState listenerState) {
+    private StoreAppender.StoreAppenderContext prepareAndReturnWriteContext(boolean metaData) {
         //! ContextListenerCoreTest#metadataDoesNotConsumeAppenderListenerRegistration and
-        //! #appendLockRejectionDoesNotConsumeListenerRegistration require the state chosen after
-        //! preflight to accompany this exact attempt rather than being re-read after locking.
+        //! #appendLockRejectionDoesNotConsumeListenerRegistration require state to be accepted only
+        //! after the applicable lock/destination preflight, not when the public method is entered.
+        ContextListenerState listenerState = contextListenerState;
         if (count > 1) {
             assert metaData == context.metaData;
             acceptContextListenerWriteAttempt(metaData, listenerState);
@@ -769,8 +767,8 @@ class StoreAppender extends AbstractCloseable
      */
     @Override
     public DocumentContext acquireWritingDocument(boolean metaData) {
-        //! ContextListenerCoreTest#appenderWriteFromListenerFailsFast requires both document-opening
-        //! APIs to reject before chained-context reuse can expose the outer application document.
+        //! ContextListenerCoreTest#capturedAcquireWritingDocumentFromListenerFailsFast requires this
+        //! entry point to reject before chained-context reuse can expose the outer application document.
         queue.throwIfContextListenerCallbackActive();
         if (!DISABLE_SINGLE_THREADED_CHECK)
             this.threadSafetyCheck(true);
@@ -1117,8 +1115,9 @@ class StoreAppender extends AbstractCloseable
 
     private int nextApplicationHeader() {
         //! ContextListenerCoreTest#sealedHighestRollIsResolvedBeforeDocumentListener and
-        //! #sealedHighestRollIsResolvedBeforeRawListener require metadata to be skipped while
-        //! locating the application header that decides whether notification may begin.
+        //! #sealedHighestRollIsResolvedBeforeRawListener pin destination-before-callback ordering.
+        //! #trailingMetadataIsSkippedBeforeListenerDestination specifically requires ready metadata
+        //! beyond the published application position to be skipped before EOF selects the next cycle.
         positionForNextHeader();
         final Bytes<?> bytes = wire.bytes();
         long position = bytes.writePosition();
@@ -1429,6 +1428,8 @@ class StoreAppender extends AbstractCloseable
     @Override
     public void writeBytes(@NotNull final BytesStore<?, ?> bytes) {
         throwExceptionIfClosed();
+        //! ContextListenerCoreTest#capturedRawWriteFromListenerFailsFast requires rejection before
+        //! sequential raw output can reacquire the callback's held Queue write lock.
         queue.throwIfContextListenerCallbackActive();
         checkAppendLock();
         ContextListenerState listenerState = contextListenerState;
@@ -1485,8 +1486,8 @@ class StoreAppender extends AbstractCloseable
     @Override
     public void writeBytes(final long index, @NotNull final BytesStore<?, ?> bytes) {
         throwExceptionIfClosed();
-        //! ContextListenerCoreTest#appenderWriteFromListenerFailsFast establishes the general rule:
-        //! captured public write entry points must reject before taking the outer write's lock.
+        //! ContextListenerCoreTest#capturedExactWriteFromListenerFailsFast requires rejection before
+        //! exact recovery can take the callback's held lock or reposition historical appender state.
         queue.throwIfContextListenerCallbackActive();
         checkAppendLock();
         writeLock.lock();
@@ -1916,6 +1917,7 @@ class StoreAppender extends AbstractCloseable
         //! indexedWriteDoesNotNotifyOrConsumeListenerRegistration pins this exact-index path as
         //! recovery infrastructure: it must not invoke or advance ordinary listener state.
         try {
+            int safeLength = (int) queue.overlapSize();
             assert count == 0 : "count=" + count;
             //! canBackfillPreviousCycleAfterEOF and exactBackfillFindsEofInEmptySealedCycle require exact recovery to
             //! handle the intended physical EOF before this call. Passing false keeps Q2's ordinary successor-cycle
@@ -2509,9 +2511,9 @@ class StoreAppender extends AbstractCloseable
 
         @Override
         public int contextCount() {
-            //! ContextListenerCoreTest#rejectsDoubleBuffering requires deterministic rejection for
-            //! every buffered Queue: destination/context selection occurs only when the buffer flushes,
-            //! so exposing a count here would vary with incidental lock contention.
+            //! ContextListenerCoreTest#doubleBufferedAppenderAndDocumentContextCountsAreUnavailable
+            //! requires deterministic rejection for every buffered Queue: destination/context selection
+            //! occurs only when the buffer flushes, so the count cannot depend on incidental contention.
             if (queue.doubleBuffer)
                 throw new IndexNotAvailableException("Context count is unavailable when double buffering because the target cycle is selected when the buffer is flushed");
             return isClosed ? -1 : StoreAppender.this.contextCount();

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -1818,7 +1818,7 @@ class StoreTailer extends AbstractCloseable
         }
 
         @Override
-        public long contextCount() {
+        public int contextCount() {
             return queue.rollCycle().toCycle(index());
         }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -1818,7 +1818,7 @@ class StoreTailer extends AbstractCloseable
         }
 
         @Override
-        public int contextCount() {
+        public long contextCount() {
             return queue.rollCycle().toCycle(index());
         }
 

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -1817,6 +1817,11 @@ class StoreTailer extends AbstractCloseable
             return StoreTailer.this.sourceId();
         }
 
+        @Override
+        public int contextCount() {
+            return queue.rollCycle().toCycle(index());
+        }
+
         /**
          * Closes the context, and if necessary, increments the index after reading a document.
          */

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -1819,7 +1819,7 @@ class StoreTailer extends AbstractCloseable
 
         @Override
         public int contextCount() {
-            return queue.rollCycle().toCycle(index());
+            return isPresent() ? queue.rollCycle().toCycle(index()) : -1;
         }
 
         /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/StoreTailer.java
@@ -1819,6 +1819,8 @@ class StoreTailer extends AbstractCloseable
 
         @Override
         public int contextCount() {
+            //! ContextListenerCoreTest#tailerDocumentsExposeTheirActualCycle distinguishes an
+            //! unavailable context from the cycle of the document currently exposed to the reader.
             return isPresent() ? queue.rollCycle().toCycle(index()) : -1;
         }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -735,9 +735,10 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
         try (ChronicleQueue queue = builder(path)
                 .contextListener(ProgressiveEvents.class, writer -> {
-                    DocumentContext document = writer.writingDocument();
-                    writer.context(new ServiceContext("reset"));
-                    document.reset();
+                    try (DocumentContext document = writer.writingDocument()) {
+                        writer.context(new ServiceContext("reset"));
+                        document.reset();
+                    }
                 })
                 .build()) {
             queue.methodWriter(Events.class).message(new Message("application"));
@@ -754,6 +755,51 @@ public class ContextListenerCoreTest extends QueueTestCommon {
                 "  text: application\n" +
                 "}\n" +
                 "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test
+    public void listenerDocumentResetMakesNestedAutomaticClosesHarmless() {
+        File path = getTmpDir();
+
+        try (ChronicleQueue queue = builder(path)
+                .contextListener(ProgressiveEvents.class, writer -> {
+                    try (DocumentContext outer = writer.writingDocument();
+                         DocumentContext nested = writer.writingDocument()) {
+                        assertSame(outer, nested);
+                        writer.context(new ServiceContext("nested-reset"));
+                        nested.reset();
+                    }
+                })
+                .build()) {
+            queue.methodWriter(Events.class).message(new Message("application"));
+        }
+
+        assertTrue(dump(path).contains("name: nested-reset"));
+        assertTrue(dump(path).contains("text: application"));
+    }
+
+    @Test
+    public void listenerRollbackThenResetPoisonsContextAndAutomaticCloseIsHarmless() {
+        AtomicInteger attempts = new AtomicInteger();
+
+        try (ChronicleQueue queue = builder(getTmpDir())
+                .contextListener(ProgressiveEvents.class, writer -> {
+                    attempts.incrementAndGet();
+                    try (DocumentContext document = writer.writingDocument()) {
+                        writer.context(new ServiceContext("rolled-back"));
+                        document.rollbackOnClose();
+                        document.reset();
+                    }
+                })
+                .build()) {
+            Events events = queue.methodWriter(Events.class);
+            assertThrows(IllegalStateException.class,
+                    () -> events.message(new Message("first")));
+            assertThrows(IllegalStateException.class,
+                    () -> events.message(new Message("second")));
+        }
+
+        assertEquals(1, attempts.get());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -358,6 +358,29 @@ public class ContextListenerCoreTest extends QueueTestCommon {
         assertCapturedAppenderMutationFails(StoreAppender::close);
     }
 
+    @Test(timeout = 5_000)
+    public void capturedAppenderWireAccessFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(StoreAppender::wire);
+    }
+
+    @Test(timeout = 5_000)
+    public void appenderCreationFromListenerFailsFast() {
+        final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> queueRef.get().createAppender())
+                .build()) {
+            queueRef.set(queue);
+            final StoreAppender appender = (StoreAppender) queue.createAppender();
+
+            final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> appender.writeMessage("message", "first"));
+            assertTrue(failure.getMessage().contains("supplied method writer"));
+            assertThrows(IllegalStateException.class,
+                    () -> appender.writeMessage("message", "blocked"));
+        }
+    }
+
     private void assertCapturedAppenderMutationFails(Consumer<StoreAppender> mutation) {
         final AtomicReference<StoreAppender> appenderRef = new AtomicReference<>();
         final AtomicInteger callbacks = new AtomicInteger();

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -42,6 +42,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     @Before
     public void useDeterministicSystemTimeProvider() {
         timeProvider.currentTimeNanos(1_000_000_000L);
+        ignoreException("Queue context listener failed:");
     }
 
     @Test
@@ -364,6 +365,11 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     }
 
     @Test(timeout = 5_000)
+    public void capturedAppenderIndexWireAccessFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(StoreAppender::wireForIndex);
+    }
+
+    @Test(timeout = 5_000)
     public void appenderCreationFromListenerFailsFast() {
         final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
 
@@ -378,6 +384,54 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             assertTrue(failure.getMessage().contains("supplied method writer"));
             assertThrows(IllegalStateException.class,
                     () -> appender.writeMessage("message", "blocked"));
+        }
+    }
+
+    @Test(timeout = 5_000)
+    public void queueCloseFromListenerFailsBeforeTeardownAndReleasesTheLock() {
+        final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
+        final AtomicInteger callbacks = new AtomicInteger();
+
+        final SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> {
+                    if (callbacks.incrementAndGet() == 1)
+                        queueRef.get().close();
+                    else
+                        writer.context(new ServiceContext("recovered"));
+                })
+                .build();
+        queueRef.set(queue);
+        try {
+            final StoreAppender first = (StoreAppender) queue.createAppender();
+            final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> first.writeMessage("message", "first"));
+            assertTrue(failure.getMessage().contains("Cannot close a Queue"));
+            assertFalse(queue.isClosing());
+
+            try (ExcerptAppender second = queue.createAppender()) {
+                second.writeMessage("message", "after-failure");
+            }
+            assertFalse(queue.isClosing());
+        } finally {
+            queue.close();
+        }
+    }
+
+    @Test
+    public void metadataDoesNotConsumeAppenderListenerRegistration() {
+        final AtomicInteger callbacks = new AtomicInteger();
+        try (SingleChronicleQueue queue = builder(getTmpDir()).build()) {
+            final StoreAppender appender = (StoreAppender) queue.createAppender();
+            try (DocumentContext metadata = appender.writingDocument(true)) {
+                metadata.wire().write("header").text("metadata");
+            }
+
+            appender.contextListener(Events.class, writer -> {
+                callbacks.incrementAndGet();
+                writer.context(new ServiceContext("queue"));
+            });
+            appender.writeMessage("message", "ordinary");
+            assertEquals(1, callbacks.get());
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -13,6 +13,7 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.DocumentWritten;
 import net.openhft.chronicle.wire.MarshallableOut;
+import net.openhft.chronicle.wire.ProgressiveContext;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
@@ -545,7 +546,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     interface ProgressiveEvents extends Events, DocumentWritten {
     }
 
-    static final class ServiceContext extends SelfDescribingMarshallable {
+    static final class ServiceContext extends SelfDescribingMarshallable implements ProgressiveContext {
         private final String name;
         private transient int lastContextCount = -1;
 
@@ -553,6 +554,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             this.name = name;
         }
 
+        @Override
         public boolean needsResending(int contextCount) {
             if (contextCount <= lastContextCount)
                 return false;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
 import static org.junit.Assert.assertEquals;
@@ -340,6 +341,48 @@ public class ContextListenerCoreTest extends QueueTestCommon {
                 "# index: 200000001\n" +
                 "message: second\n" +
                 "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test(timeout = 5_000)
+    public void capturedAppenderRollbackFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(StoreAppender::rollbackIfNotComplete);
+    }
+
+    @Test(timeout = 5_000)
+    public void capturedAppenderNormalisationFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(StoreAppender::normaliseEOFs);
+    }
+
+    @Test(timeout = 5_000)
+    public void capturedAppenderCloseFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(StoreAppender::close);
+    }
+
+    private void assertCapturedAppenderMutationFails(Consumer<StoreAppender> mutation) {
+        final AtomicReference<StoreAppender> appenderRef = new AtomicReference<>();
+        final AtomicInteger callbacks = new AtomicInteger();
+
+        try (ChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> {
+                    if (callbacks.incrementAndGet() == 1)
+                        mutation.accept(appenderRef.get());
+                    else
+                        writer.context(new ServiceContext("recovered"));
+                })
+                .build()) {
+            final StoreAppender first = (StoreAppender) queue.createAppender();
+            appenderRef.set(first);
+
+            final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> first.writeMessage("message", "first"));
+            assertTrue(failure.getMessage().contains("supplied method writer"));
+            assertFalse(first.isClosed());
+
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
+            try (ExcerptAppender second = queue.createAppender()) {
+                second.writeMessage("message", "second");
+            }
+        }
     }
 
     @Test
@@ -686,6 +729,20 @@ public class ContextListenerCoreTest extends QueueTestCommon {
                 "# no more messages at 8000000000000000\n", dump(path, WireType.BINARY_LIGHT));
     }
 
+    @Test
+    public void tailerDocumentsExposeTheirActualCycle() {
+        final File path = getTmpDir();
+        try (ChronicleQueue queue = builder(path).build();
+             ExcerptAppender appender = queue.createAppender()) {
+            appender.writeText("one");
+            appender.writeText("two");
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
+            appender.writeText("three");
+        }
+
+        assertContextCounts(path, 1, 1, 2);
+    }
+
     private SingleChronicleQueueBuilder builder(File path) {
         return builder(path, WireType.BINARY);
     }
@@ -717,6 +774,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             }
             try (DocumentContext document = tailer.readingDocument()) {
                 assertFalse(document.isPresent());
+                assertEquals(-1, document.contextCount());
             }
         }
     }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -1,0 +1,588 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.single;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.time.SetTimeProvider;
+import net.openhft.chronicle.core.time.SystemTimeProvider;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.DocumentWritten;
+import net.openhft.chronicle.wire.MarshallableOut;
+import net.openhft.chronicle.wire.ProgressiveContext;
+import net.openhft.chronicle.wire.SelfDescribingMarshallable;
+import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.StringWriter;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class ContextListenerCoreTest extends QueueTestCommon {
+    private final SetTimeProvider timeProvider = new SetTimeProvider();
+
+    @Before
+    public void useDeterministicSystemTimeProvider() {
+        timeProvider.currentTimeNanos(1_000_000_000L);
+        SystemTimeProvider.CLOCK = timeProvider;
+    }
+
+    @After
+    public void resetSystemTimeProvider() {
+        SystemTimeProvider.CLOCK = SystemTimeProvider.INSTANCE;
+    }
+
+    @Test
+    public void writesContextBeforeDataAndAllowsRetainingWriter() {
+        File path = getTmpDir();
+        AtomicInteger callbacks = new AtomicInteger();
+        AtomicReference<Events> retainedWriter = new AtomicReference<>();
+
+        try (ChronicleQueue queue = builder(path)
+                .contextListener(Events.class, writer -> {
+                    callbacks.incrementAndGet();
+                    retainedWriter.set(writer);
+                    writer.context(new ServiceContext("queue"));
+                })
+                .build()) {
+            Events events = queue.methodWriter(Events.class);
+            events.message(new Message("one"));
+            retainedWriter.get().context(new ServiceContext("retained"));
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
+            events.message(new Message("two"));
+        }
+
+        assertEquals(2, callbacks.get());
+        assertEquals("" +
+                "# firstIndex: 100000000\n" +
+                "# index: 100000000\n" +
+                "context: {\n" +
+                "  name: queue\n" +
+                "}\n" +
+                "# index: 100000001\n" +
+                "message: {\n" +
+                "  text: one\n" +
+                "}\n" +
+                "# index: 100000002\n" +
+                "context: {\n" +
+                "  name: retained\n" +
+                "}\n" +
+                "# index: 200000000\n" +
+                "context: {\n" +
+                "  name: queue\n" +
+                "}\n" +
+                "# index: 200000001\n" +
+                "message: {\n" +
+                "  text: two\n" +
+                "}\n" +
+                "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test
+    public void writesContextBeforeHeldDataDocument() {
+        File path = getTmpDir();
+
+        try (SingleChronicleQueue queue = builder(path).build()) {
+            ExcerptAppender appender = queue.acquireAppender();
+            appender.contextListener(Events.class,
+                    writer -> writer.context(new ServiceContext("checkpoint")));
+            ProgressiveEvents events = appender.methodWriter(ProgressiveEvents.class);
+
+            writeMessages(events, "one", "two");
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
+            writeMessages(events, "three");
+        }
+
+        assertEquals("" +
+                "# firstIndex: 100000000\n" +
+                "# index: 100000000\n" +
+                "context: {\n" +
+                "  name: checkpoint\n" +
+                "}\n" +
+                "# index: 100000001\n" +
+                "message: {\n" +
+                "  text: one\n" +
+                "}\n" +
+                "message: {\n" +
+                "  text: two\n" +
+                "}\n" +
+                "# index: 200000000\n" +
+                "context: {\n" +
+                "  name: checkpoint\n" +
+                "}\n" +
+                "# index: 200000001\n" +
+                "message: {\n" +
+                "  text: three\n" +
+                "}\n" +
+                "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test
+    public void writesProgressiveContextInsideHeldDocumentWhenCycleAdvances() {
+        File path = getTmpDir();
+        ServiceContext context = new ServiceContext("progressive");
+        int firstCycle;
+        int sameCycle;
+        int secondCycle;
+
+        try (ChronicleQueue queue = builder(path).build()) {
+            ProgressiveEvents events = queue.createAppender().methodWriter(ProgressiveEvents.class);
+
+            firstCycle = writeProgressively(queue, events, context, "one");
+            sameCycle = writeProgressively(queue, events, context, "two");
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
+            secondCycle = writeProgressively(queue, events, context, "three");
+        }
+
+        assertEquals(firstCycle, sameCycle);
+        assertTrue(secondCycle > firstCycle);
+        assertEquals(secondCycle, context.lastContextCount);
+        assertContextCounts(path, firstCycle, sameCycle, secondCycle);
+        assertEquals("" +
+                "# firstIndex: 100000000\n" +
+                "# index: 100000000\n" +
+                "context: {\n" +
+                "  name: progressive\n" +
+                "}\n" +
+                "message: {\n" +
+                "  text: one\n" +
+                "}\n" +
+                "# index: 100000001\n" +
+                "message: {\n" +
+                "  text: two\n" +
+                "}\n" +
+                "# index: 200000000\n" +
+                "context: {\n" +
+                "  name: progressive\n" +
+                "}\n" +
+                "message: {\n" +
+                "  text: three\n" +
+                "}\n" +
+                "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test
+    public void indexedWriteDoesNotNotifyButStartsAppender() {
+        AtomicInteger callbacks = new AtomicInteger();
+
+        try (ChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> callbacks.incrementAndGet())
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            long index = queue.rollCycle().toIndex(((SingleChronicleQueue) queue).cycle(), 0);
+            Bytes<?> payload = binaryPayload("indexed");
+            try {
+                appender.writeBytes(index, payload);
+            } finally {
+                payload.releaseLast();
+            }
+
+            assertEquals(0, callbacks.get());
+            assertThrows(IllegalStateException.class,
+                    () -> appender.contextListener(Events.class, writer -> { }));
+        }
+    }
+
+    @Test
+    public void notifiesEachAppenderWithItsOwnContextOncePerRoll() {
+        File path = getTmpDir();
+        AtomicInteger firstCallbacks = new AtomicInteger();
+        AtomicInteger secondCallbacks = new AtomicInteger();
+
+        try (ChronicleQueue queue = builder(path).build()) {
+            StoreAppender first = (StoreAppender) queue.createAppender()
+                    .contextListener(Events.class, writer -> {
+                        firstCallbacks.incrementAndGet();
+                        writer.context(new ServiceContext("first"));
+                    });
+            StoreAppender second = (StoreAppender) queue.createAppender()
+                    .contextListener(Events.class, writer -> {
+                        secondCallbacks.incrementAndGet();
+                        writer.context(new ServiceContext("second"));
+                    });
+
+            first.writeMessage("message", "one");
+            first.writeMessage("message", "two");
+            assertEquals(1, firstCallbacks.get());
+            assertEquals(0, secondCallbacks.get());
+            second.writeMessage("message", "three");
+            second.writeMessage("message", "four");
+            assertEquals(1, firstCallbacks.get());
+            assertEquals(1, secondCallbacks.get());
+
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
+            second.writeMessage("message", "five");
+            second.writeMessage("message", "six");
+            assertEquals(1, firstCallbacks.get());
+            assertEquals(2, secondCallbacks.get());
+            first.writeMessage("message", "seven");
+            first.writeMessage("message", "eight");
+            assertEquals(2, firstCallbacks.get());
+            assertEquals(2, secondCallbacks.get());
+        }
+
+        assertEquals("" +
+                "# firstIndex: 100000000\n" +
+                "# index: 100000000\n" +
+                "context: {\n" +
+                "  name: first\n" +
+                "}\n" +
+                "# index: 100000001\n" +
+                "message: one\n" +
+                "# index: 100000002\n" +
+                "message: two\n" +
+                "# index: 100000003\n" +
+                "context: {\n" +
+                "  name: second\n" +
+                "}\n" +
+                "# index: 100000004\n" +
+                "message: three\n" +
+                "# index: 100000005\n" +
+                "message: four\n" +
+                "# index: 200000000\n" +
+                "context: {\n" +
+                "  name: second\n" +
+                "}\n" +
+                "# index: 200000001\n" +
+                "message: five\n" +
+                "# index: 200000002\n" +
+                "message: six\n" +
+                "# index: 200000003\n" +
+                "context: {\n" +
+                "  name: first\n" +
+                "}\n" +
+                "# index: 200000004\n" +
+                "message: seven\n" +
+                "# index: 200000005\n" +
+                "message: eight\n" +
+                "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test
+    public void listenerFailureAfterWritingContextIsNotRetriedInTheSameRoll() {
+        File path = getTmpDir();
+        AtomicInteger callbacks = new AtomicInteger();
+
+        try (ChronicleQueue queue = builder(path)
+                .contextListener(Events.class, writer -> {
+                    callbacks.incrementAndGet();
+                    writer.context(new ServiceContext("partial"));
+                    throw new IllegalStateException("boom");
+                })
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+
+            assertThrows(IllegalStateException.class,
+                    () -> appender.writeMessage("message", "first"));
+            appender.writeMessage("message", "second");
+            assertEquals(1, callbacks.get());
+        }
+
+        assertEquals("" +
+                "# firstIndex: 100000000\n" +
+                "# index: 100000000\n" +
+                "context: {\n" +
+                "  name: partial\n" +
+                "}\n" +
+                "# index: 100000001\n" +
+                "message: second\n" +
+                "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test(timeout = 5_000)
+    public void listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable() {
+        File path = getTmpDir();
+        AtomicInteger callbacks = new AtomicInteger();
+
+        try (ChronicleQueue queue = builder(path)
+                .contextListener(ProgressiveEvents.class, writer -> {
+                    callbacks.incrementAndGet();
+                    DocumentContext document = writer.writingDocument();
+                    writer.context(new ServiceContext("partial"));
+                    assertTrue(document.isNotComplete());
+                    throw new AssertionError("boom");
+                })
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+
+            assertThrows(AssertionError.class,
+                    () -> appender.writeMessage("message", "first"));
+            appender.writeMessage("message", "second");
+            assertEquals(1, callbacks.get());
+        }
+
+        assertEquals("" +
+                "# firstIndex: 100000000\n" +
+                "# index: 100000000\n" +
+                "message: second\n" +
+                "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test(timeout = 5_000)
+    public void appenderWriteFromListenerFailsFast() {
+        File path = getTmpDir();
+        AtomicReference<StoreAppender> appenderRef = new AtomicReference<>();
+
+        try (ChronicleQueue queue = builder(path)
+                .contextListener(Events.class,
+                        writer -> appenderRef.get().writeMessage("message", "reentrant"))
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appenderRef.set(appender);
+
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                    () -> appender.writeMessage("message", "first"));
+            assertTrue(exception.getMessage().contains("supplied method writer"));
+            appender.writeMessage("message", "second");
+        }
+
+        assertEquals("" +
+                "# firstIndex: 100000000\n" +
+                "# index: 100000000\n" +
+                "message: second\n" +
+                "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test
+    public void listenerCanHoldOneDocumentWhileWritingContext() {
+        AtomicBoolean outerDocumentRemainedOpen = new AtomicBoolean();
+        AtomicInteger contextCount = new AtomicInteger();
+
+        try (ChronicleQueue queue = builder(getTmpDir())
+                .contextListener(ProgressiveEvents.class, writer -> {
+                    try (DocumentContext document = writer.writingDocument()) {
+                        contextCount.set(document.contextCount());
+                        writer.context(new ServiceContext("queue"));
+                        outerDocumentRemainedOpen.set(document.isNotComplete());
+                    }
+                })
+                .build()) {
+            int expectedCycle = ((SingleChronicleQueue) queue).cycle();
+            queue.createAppender().writeMessage("message", "one");
+
+            assertEquals(expectedCycle, contextCount.get());
+            assertTrue(outerDocumentRemainedOpen.get());
+        }
+    }
+
+    @Test
+    public void listenerClosePreservesNestingForDocumentWrite() {
+        try (ChronicleQueue queue = builder(getTmpDir())
+                .timeoutMS(100)
+                .contextListener(Events.class,
+                        writer -> writer.context(new ServiceContext("queue")))
+                .build()) {
+            assertNestedWriteReusesContext((StoreAppender) queue.createAppender());
+        }
+    }
+
+    @Test
+    public void listenerClosePreservesNestingAfterRawWrite() {
+        try (ChronicleQueue queue = builder(getTmpDir())
+                .timeoutMS(100)
+                .contextListener(Events.class,
+                        writer -> writer.context(new ServiceContext("queue")))
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            Bytes<?> payload = binaryPayload("raw");
+            try {
+                appender.writeBytes(payload);
+            } finally {
+                payload.releaseLast();
+            }
+
+            assertNestedWriteReusesContext(appender);
+        }
+    }
+
+    @Test
+    public void listenerRemainsCallerOwned() {
+        CloseableListener listener = new CloseableListener();
+
+        try (ChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, listener)
+                .build()) {
+            queue.methodWriter(Events.class).message(new Message("one"));
+        }
+
+        assertFalse(listener.closed);
+    }
+
+    @Test
+    public void rejectsDoubleBuffering() {
+        assertThrows(UnsupportedOperationException.class, () -> builder(getTmpDir())
+                .doubleBuffer(true)
+                .contextListener(Events.class, writer -> { })
+                .build());
+
+        try (ChronicleQueue queue = builder(getTmpDir()).doubleBuffer(true).build()) {
+            assertThrows(UnsupportedOperationException.class,
+                    () -> queue.createAppender().contextListener(Events.class, writer -> { }));
+        }
+    }
+
+    @Test
+    public void encodesContextWithQueueWireType() {
+        File path = getTmpDir();
+
+        try (ChronicleQueue queue = builder(path, WireType.BINARY_LIGHT)
+                .contextListener(Events.class,
+                        writer -> writer.context(new ServiceContext("queue")))
+                .build()) {
+            queue.createAppender().writeMessage("message", "one");
+        }
+
+        assertEquals("" +
+                "# firstIndex: 100000000\n" +
+                "# index: 100000000\n" +
+                "context: {\n" +
+                "  name: queue\n" +
+                "}\n" +
+                "# index: 100000001\n" +
+                "message: one\n" +
+                "# no more messages at 8000000000000000\n", dump(path, WireType.BINARY_LIGHT));
+    }
+
+    private static SingleChronicleQueueBuilder builder(File path) {
+        return builder(path, WireType.BINARY);
+    }
+
+    private static SingleChronicleQueueBuilder builder(File path, WireType wireType) {
+        return SingleChronicleQueueBuilder.builder(path, wireType)
+                .testBlockSize()
+                .rollCycle(TEST_SECONDLY);
+    }
+
+    private static void writeMessages(ProgressiveEvents events, String... messages) {
+        try (DocumentContext document = events.writingDocument()) {
+            assertTrue(document.isOpen());
+            for (String message : messages)
+                events.message(new Message(message));
+        }
+    }
+
+    private static int writeProgressively(ChronicleQueue queue,
+                                          ProgressiveEvents events,
+                                          ServiceContext context,
+                                          String message) {
+        try (DocumentContext document = events.writingDocument()) {
+            int contextCount = document.contextCount();
+            assertEquals(queue.rollCycle().toCycle(document.index()), contextCount);
+            if (context.needsResending(contextCount))
+                events.context(context);
+            events.message(new Message(message));
+            return contextCount;
+        }
+    }
+
+    private static void assertContextCounts(File path, int... expected) {
+        try (ChronicleQueue queue = builder(path).build();
+             ExcerptTailer tailer = queue.createTailer()) {
+            for (int contextCount : expected) {
+                try (DocumentContext document = tailer.readingDocument()) {
+                    assertTrue(document.isPresent());
+                    assertEquals(contextCount, document.contextCount());
+                    assertEquals(queue.rollCycle().toCycle(document.index()), document.contextCount());
+                }
+            }
+            try (DocumentContext document = tailer.readingDocument()) {
+                assertFalse(document.isPresent());
+            }
+        }
+    }
+
+    private static Bytes<?> binaryPayload(String value) {
+        Bytes<?> payload = Bytes.allocateElasticOnHeap();
+        Wire wire = WireType.BINARY.apply(payload);
+        wire.write("message").text(value);
+        return payload;
+    }
+
+    private static void assertNestedWriteReusesContext(StoreAppender appender) {
+        try (DocumentContext outer = appender.writingDocument()) {
+            outer.wire().write("outer").text("one");
+            try (DocumentContext nested = appender.writingDocument()) {
+                assertSame(outer, nested);
+                nested.wire().write("nested").text("two");
+            }
+            assertTrue(outer.isNotComplete());
+        }
+    }
+
+    private static String dump(File path) {
+        return dump(path, WireType.BINARY);
+    }
+
+    private static String dump(File path, WireType wireType) {
+        try (ChronicleQueue queue = builder(path, wireType).build()) {
+            StringWriter writer = new StringWriter();
+            queue.dump(writer, 0, Long.MAX_VALUE);
+            return writer.toString();
+        }
+    }
+
+    interface Events {
+        void context(ServiceContext context);
+
+        void message(Message message);
+    }
+
+    interface ProgressiveEvents extends Events, DocumentWritten {
+    }
+
+    static final class ServiceContext extends SelfDescribingMarshallable implements ProgressiveContext {
+        private final String name;
+        private transient int lastContextCount = -1;
+
+        ServiceContext(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean needsResending(int contextCount) {
+            if (contextCount <= lastContextCount)
+                return false;
+            lastContextCount = contextCount;
+            return true;
+        }
+    }
+
+    static final class Message extends SelfDescribingMarshallable {
+        private final String text;
+
+        Message(String text) {
+            this.text = text;
+        }
+    }
+
+    private static final class CloseableListener
+            implements MarshallableOut.ContextListener<Events>, AutoCloseable {
+        private boolean closed;
+
+        @Override
+        public void onNewContext(Events writer) {
+            writer.context(new ServiceContext("queue"));
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.StringWriter;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
@@ -362,7 +361,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     @Test
     public void listenerCanHoldOneDocumentWhileWritingContext() {
         AtomicBoolean outerDocumentRemainedOpen = new AtomicBoolean();
-        AtomicLong contextCount = new AtomicLong();
+        AtomicInteger contextCount = new AtomicInteger();
 
         try (ChronicleQueue queue = builder(getTmpDir())
                 .contextListener(ProgressiveEvents.class, writer -> {
@@ -482,13 +481,12 @@ public class ContextListenerCoreTest extends QueueTestCommon {
                                           ServiceContext context,
                                           String message) {
         try (DocumentContext document = events.writingDocument()) {
-            long contextCount = document.contextCount();
+            int contextCount = document.contextCount();
             assertEquals(queue.rollCycle().toCycle(document.index()), contextCount);
-            final int cycle = Math.toIntExact(contextCount);
-            if (context.needsResending(cycle))
+            if (context.needsResending(contextCount))
                 events.context(context);
             events.message(new Message(message));
-            return cycle;
+            return contextCount;
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -13,7 +13,6 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.DocumentWritten;
 import net.openhft.chronicle.wire.MarshallableOut;
-import net.openhft.chronicle.wire.ProgressiveContext;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
@@ -25,6 +24,7 @@ import java.io.File;
 import java.io.StringWriter;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
@@ -362,7 +362,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     @Test
     public void listenerCanHoldOneDocumentWhileWritingContext() {
         AtomicBoolean outerDocumentRemainedOpen = new AtomicBoolean();
-        AtomicInteger contextCount = new AtomicInteger();
+        AtomicLong contextCount = new AtomicLong();
 
         try (ChronicleQueue queue = builder(getTmpDir())
                 .contextListener(ProgressiveEvents.class, writer -> {
@@ -482,12 +482,13 @@ public class ContextListenerCoreTest extends QueueTestCommon {
                                           ServiceContext context,
                                           String message) {
         try (DocumentContext document = events.writingDocument()) {
-            int contextCount = document.contextCount();
+            long contextCount = document.contextCount();
             assertEquals(queue.rollCycle().toCycle(document.index()), contextCount);
-            if (context.needsResending(contextCount))
+            final int cycle = Math.toIntExact(contextCount);
+            if (context.needsResending(cycle))
                 events.context(context);
             events.message(new Message(message));
-            return contextCount;
+            return cycle;
         }
     }
 
@@ -546,7 +547,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     interface ProgressiveEvents extends Events, DocumentWritten {
     }
 
-    static final class ServiceContext extends SelfDescribingMarshallable implements ProgressiveContext {
+    static final class ServiceContext extends SelfDescribingMarshallable {
         private final String name;
         private transient int lastContextCount = -1;
 
@@ -554,7 +555,6 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             this.name = name;
         }
 
-        @Override
         public boolean needsResending(int contextCount) {
             if (contextCount <= lastContextCount)
                 return false;

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -22,7 +22,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -648,8 +651,6 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             sealCycle(queue, sealedCycle + 1);
             queue.tableStoreAcquire("listing.highestCycle", sealedCycle)
                     .setVolatileValue(sealedCycle);
-            queue.tableStoreAcquire("listing.highestCycleWriteFloor", sealedCycle)
-                    .setVolatileValue(sealedCycle);
 
             assertThrows(WriteAfterEOFException.class,
                     () -> appender.writeMessage("message", "must-fail"));
@@ -727,6 +728,43 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             assertTrue(failure.getMessage().contains("supplied method writer"));
 
             second.createAppender().writeMessage("message", "after-failure");
+        }
+    }
+
+    @Test(timeout = 5_000)
+    public void symlinkAliasCannotBypassCallbackGuard() throws Exception {
+        Path real = Files.createDirectories(getTmpDir().toPath().toAbsolutePath());
+        Path alias = real.resolveSibling(real.getFileName() + "-alias");
+        try {
+            Files.createSymbolicLink(alias, real);
+        } catch (IOException | UnsupportedOperationException | SecurityException unavailable) {
+            org.junit.Assume.assumeNoException(unavailable);
+        }
+        assertTrue(Files.isSameFile(real, alias));
+
+        AtomicReference<SingleChronicleQueue> aliasQueue = new AtomicReference<>();
+        AtomicReference<Throwable> aliasFailure = new AtomicReference<>();
+        try (SingleChronicleQueue primary = builder(real.toFile())
+                .timeoutMS(100)
+                .contextListener(Events.class, writer -> {
+                    try {
+                        aliasQueue.get().createAppender().writeMessage("message", "reentrant");
+                    } catch (Throwable failure) {
+                        aliasFailure.set(failure);
+                    }
+                    writer.context(new ServiceContext("valid-context"));
+                })
+                .build();
+             SingleChronicleQueue second = builder(alias.toFile()).timeoutMS(100).build()) {
+            aliasQueue.set(second);
+
+            //! Callback isolation is keyed by physical Queue identity, not the spelling used to
+            //! open it; an alias must fail before touching the cross-process write lock.
+            primary.createAppender().writeMessage("message", "application");
+
+            assertTrue(aliasFailure.get() instanceof IllegalStateException);
+            assertTrue(aliasFailure.get().getMessage().contains("supplied method writer"));
+            second.createAppender().writeMessage("message", "after-callback");
         }
     }
 
@@ -873,6 +911,16 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     }
 
     @Test
+    public void sequentialResetsPreserveAutomaticClosesForQueueListener() {
+        assertSequentialResetsPreserveAutomaticCloses(true);
+    }
+
+    @Test
+    public void sequentialResetsPreserveAutomaticClosesForAppenderListener() {
+        assertSequentialResetsPreserveAutomaticCloses(false);
+    }
+
+    @Test
     public void listenerRollbackThenResetPoisonsContextAndAutomaticCloseIsHarmless() {
         //! Pins rollback intent across reset while absorbing already-satisfied automatic closes.
         AtomicInteger attempts = new AtomicInteger();
@@ -1011,6 +1059,40 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             for (String message : messages)
                 events.message(new Message(message));
         }
+    }
+
+    private void assertSequentialResetsPreserveAutomaticCloses(boolean queueListener) {
+        File path = getTmpDir();
+        MarshallableOut.ContextListener<ProgressiveEvents> listener = writer -> {
+            try (DocumentContext first = writer.writingDocument()) {
+                writer.context(new ServiceContext("first"));
+                first.reset();
+                try (DocumentContext second = writer.writingDocument()) {
+                    writer.context(new ServiceContext("second"));
+                    second.reset();
+                }
+            }
+        };
+
+        SingleChronicleQueueBuilder builder = builder(path);
+        if (queueListener)
+            builder.contextListener(ProgressiveEvents.class, listener);
+        try (SingleChronicleQueue queue = builder.build()) {
+            ExcerptAppender appender = queue.createAppender();
+            if (!queueListener)
+                appender.contextListener(ProgressiveEvents.class, listener);
+
+            //! Each reset satisfies one active document but every enclosing try-with-resources
+            //! scope still closes later; deferred close accounting must accumulate across resets.
+            if (queueListener)
+                appender.methodWriter(Events.class).message(new Message("application"));
+            else
+                appender.writeMessage("message", "application");
+        }
+
+        String dump = dump(path);
+        assertTrue(dump, dump.indexOf("name: first") < dump.indexOf("name: second"));
+        assertTrue(dump, dump.indexOf("name: second") < dump.indexOf("application"));
     }
 
     private void assertContextCounts(File path, int... expected) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -416,6 +416,21 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     }
 
     @Test(timeout = 5_000)
+    public void capturedAcquireWritingDocumentFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(appender -> appender.acquireWritingDocument(false));
+    }
+
+    @Test(timeout = 5_000)
+    public void capturedRawWriteFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(appender -> writeRaw(appender, "recursive"));
+    }
+
+    @Test(timeout = 5_000)
+    public void capturedExactWriteFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(appender -> writeExact(appender, "recursive"));
+    }
+
+    @Test(timeout = 5_000)
     public void appenderCreationFromListenerFailsFast() {
         // Pins the common new-appender guard before a second appender can block on the write lock.
         final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
@@ -605,6 +620,37 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             writeRaw(appender, "after");
 
             assertEquals(2, callbacks.get());
+            assertEquals(sealedCycle + 1, appender.contextCount());
+            assertDocumentCycles(queue, sealedCycle, sealedCycle, sealedCycle + 1, sealedCycle + 1);
+        }
+    }
+
+    @Test
+    public void trailingMetadataIsSkippedBeforeListenerDestination() {
+        AtomicInteger callbacks = new AtomicInteger();
+        AtomicReference<StoreAppender> appenderReference = new AtomicReference<>();
+        AtomicInteger observedContext = new AtomicInteger(-1);
+
+        try (SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> {
+                    callbacks.incrementAndGet();
+                    observedContext.set(appenderReference.get().contextCount());
+                    writer.context(new ServiceContext("queue"));
+                })
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appenderReference.set(appender);
+            appender.writeMessage("message", "before");
+            int sealedCycle = appender.cycle();
+            try (DocumentContext metadata = appender.writingDocument(true)) {
+                metadata.wire().write("header").text("trailing-metadata");
+            }
+            sealCurrentCycle(appender);
+
+            appender.writeMessage("message", "after");
+
+            assertEquals(2, callbacks.get());
+            assertEquals(sealedCycle + 1, observedContext.get());
             assertEquals(sealedCycle + 1, appender.contextCount());
             assertDocumentCycles(queue, sealedCycle, sealedCycle, sealedCycle + 1, sealedCycle + 1);
         }
@@ -1044,6 +1090,19 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     }
 
     @Test
+    public void doubleBufferedAppenderAndDocumentContextCountsAreUnavailable() {
+        try (ChronicleQueue queue = builder(getTmpDir()).doubleBuffer(true).build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+
+            assertThrows(IndexNotAvailableException.class, appender::contextCount);
+            try (DocumentContext document = appender.writingDocument()) {
+                assertThrows(IndexNotAvailableException.class, document::contextCount);
+                document.rollbackOnClose();
+            }
+        }
+    }
+
+    @Test
     public void rejectsEveryUnsupportedEffectiveQueueMode() {
         // Directly pins the mode-classification helper; builder integration is covered separately.
         assertThrows(UnsupportedOperationException.class,
@@ -1206,6 +1265,15 @@ public class ContextListenerCoreTest extends QueueTestCommon {
         Bytes<?> payload = binaryPayload(value);
         try {
             appender.writeBytes(payload);
+        } finally {
+            payload.releaseLast();
+        }
+    }
+
+    private static void writeExact(StoreAppender appender, String value) {
+        Bytes<?> payload = binaryPayload(value);
+        try {
+            appender.writeBytes(0L, payload);
         } finally {
             payload.releaseLast();
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -4,8 +4,8 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.MappedBytes;
 import net.openhft.chronicle.core.time.SetTimeProvider;
-import net.openhft.chronicle.core.time.SystemTimeProvider;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
@@ -13,11 +13,10 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.DocumentWritten;
 import net.openhft.chronicle.wire.MarshallableOut;
-import net.openhft.chronicle.wire.ProgressiveContext;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
-import org.junit.After;
+import net.openhft.chronicle.wire.WriteAfterEOFException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,6 +24,7 @@ import java.io.File;
 import java.io.StringWriter;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static net.openhft.chronicle.queue.rollcycles.TestRollCycles.TEST_SECONDLY;
@@ -40,12 +40,6 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     @Before
     public void useDeterministicSystemTimeProvider() {
         timeProvider.currentTimeNanos(1_000_000_000L);
-        SystemTimeProvider.CLOCK = timeProvider;
-    }
-
-    @After
-    public void resetSystemTimeProvider() {
-        SystemTimeProvider.CLOCK = SystemTimeProvider.INSTANCE;
     }
 
     @Test
@@ -134,51 +128,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     }
 
     @Test
-    public void writesProgressiveContextInsideHeldDocumentWhenCycleAdvances() {
-        File path = getTmpDir();
-        ServiceContext context = new ServiceContext("progressive");
-        int firstCycle;
-        int sameCycle;
-        int secondCycle;
-
-        try (ChronicleQueue queue = builder(path).build()) {
-            ProgressiveEvents events = queue.createAppender().methodWriter(ProgressiveEvents.class);
-
-            firstCycle = writeProgressively(queue, events, context, "one");
-            sameCycle = writeProgressively(queue, events, context, "two");
-            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
-            secondCycle = writeProgressively(queue, events, context, "three");
-        }
-
-        assertEquals(firstCycle, sameCycle);
-        assertTrue(secondCycle > firstCycle);
-        assertEquals(secondCycle, context.lastContextCount);
-        assertContextCounts(path, firstCycle, sameCycle, secondCycle);
-        assertEquals("" +
-                "# firstIndex: 100000000\n" +
-                "# index: 100000000\n" +
-                "context: {\n" +
-                "  name: progressive\n" +
-                "}\n" +
-                "message: {\n" +
-                "  text: one\n" +
-                "}\n" +
-                "# index: 100000001\n" +
-                "message: {\n" +
-                "  text: two\n" +
-                "}\n" +
-                "# index: 200000000\n" +
-                "context: {\n" +
-                "  name: progressive\n" +
-                "}\n" +
-                "message: {\n" +
-                "  text: three\n" +
-                "}\n" +
-                "# no more messages at 8000000000000000\n", dump(path));
-    }
-
-    @Test
-    public void indexedWriteDoesNotNotifyButStartsAppender() {
+    public void indexedWriteDoesNotNotifyOrConsumeListenerRegistration() {
         AtomicInteger callbacks = new AtomicInteger();
 
         try (ChronicleQueue queue = builder(getTmpDir())
@@ -194,8 +144,9 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             }
 
             assertEquals(0, callbacks.get());
-            assertThrows(IllegalStateException.class,
-                    () -> appender.contextListener(Events.class, writer -> { }));
+            appender.contextListener(Events.class, writer -> callbacks.incrementAndGet());
+            appender.writeMessage("message", "ordinary");
+            assertEquals(1, callbacks.get());
         }
     }
 
@@ -281,17 +232,22 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
         try (ChronicleQueue queue = builder(path)
                 .contextListener(Events.class, writer -> {
-                    callbacks.incrementAndGet();
-                    writer.context(new ServiceContext("partial"));
-                    throw new IllegalStateException("boom");
+                    if (callbacks.incrementAndGet() == 1) {
+                        writer.context(new ServiceContext("partial"));
+                        throw new IllegalStateException("boom");
+                    }
+                    writer.context(new ServiceContext("recovered"));
                 })
                 .build()) {
             StoreAppender appender = (StoreAppender) queue.createAppender();
 
             assertThrows(IllegalStateException.class,
                     () -> appender.writeMessage("message", "first"));
+            assertThrows(IllegalStateException.class,
+                    () -> appender.writeMessage("message", "blocked"));
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
             appender.writeMessage("message", "second");
-            assertEquals(1, callbacks.get());
+            assertEquals(2, callbacks.get());
         }
 
         assertEquals("" +
@@ -300,7 +256,11 @@ public class ContextListenerCoreTest extends QueueTestCommon {
                 "context: {\n" +
                 "  name: partial\n" +
                 "}\n" +
-                "# index: 100000001\n" +
+                "# index: 200000000\n" +
+                "context: {\n" +
+                "  name: recovered\n" +
+                "}\n" +
+                "# index: 200000001\n" +
                 "message: second\n" +
                 "# no more messages at 8000000000000000\n", dump(path));
     }
@@ -312,24 +272,33 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
         try (ChronicleQueue queue = builder(path)
                 .contextListener(ProgressiveEvents.class, writer -> {
-                    callbacks.incrementAndGet();
-                    DocumentContext document = writer.writingDocument();
-                    writer.context(new ServiceContext("partial"));
-                    assertTrue(document.isNotComplete());
-                    throw new AssertionError("boom");
+                    if (callbacks.incrementAndGet() == 1) {
+                        DocumentContext document = writer.writingDocument();
+                        writer.context(new ServiceContext("partial"));
+                        assertTrue(document.isNotComplete());
+                        throw new AssertionError("boom");
+                    }
+                    writer.context(new ServiceContext("recovered"));
                 })
                 .build()) {
             StoreAppender appender = (StoreAppender) queue.createAppender();
 
             assertThrows(AssertionError.class,
                     () -> appender.writeMessage("message", "first"));
+            assertThrows(IllegalStateException.class,
+                    () -> appender.writeMessage("message", "blocked"));
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
             appender.writeMessage("message", "second");
-            assertEquals(1, callbacks.get());
+            assertEquals(2, callbacks.get());
         }
 
         assertEquals("" +
                 "# firstIndex: 100000000\n" +
-                "# index: 100000000\n" +
+                "# index: 200000000\n" +
+                "context: {\n" +
+                "  name: recovered\n" +
+                "}\n" +
+                "# index: 200000001\n" +
                 "message: second\n" +
                 "# no more messages at 8000000000000000\n", dump(path));
     }
@@ -338,10 +307,16 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     public void appenderWriteFromListenerFailsFast() {
         File path = getTmpDir();
         AtomicReference<StoreAppender> appenderRef = new AtomicReference<>();
+        AtomicInteger callbacks = new AtomicInteger();
 
         try (ChronicleQueue queue = builder(path)
                 .contextListener(Events.class,
-                        writer -> appenderRef.get().writeMessage("message", "reentrant"))
+                        writer -> {
+                            if (callbacks.incrementAndGet() == 1)
+                                appenderRef.get().writeMessage("message", "reentrant");
+                            else
+                                writer.context(new ServiceContext("recovered"));
+                        })
                 .build()) {
             StoreAppender appender = (StoreAppender) queue.createAppender();
             appenderRef.set(appender);
@@ -349,12 +324,19 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             IllegalStateException exception = assertThrows(IllegalStateException.class,
                     () -> appender.writeMessage("message", "first"));
             assertTrue(exception.getMessage().contains("supplied method writer"));
+            assertThrows(IllegalStateException.class,
+                    () -> appender.writeMessage("message", "blocked"));
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
             appender.writeMessage("message", "second");
         }
 
         assertEquals("" +
                 "# firstIndex: 100000000\n" +
-                "# index: 100000000\n" +
+                "# index: 200000000\n" +
+                "context: {\n" +
+                "  name: recovered\n" +
+                "}\n" +
+                "# index: 200000001\n" +
                 "message: second\n" +
                 "# no more messages at 8000000000000000\n", dump(path));
     }
@@ -378,6 +360,221 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
             assertEquals(expectedCycle, contextCount.get());
             assertTrue(outerDocumentRemainedOpen.get());
+        }
+    }
+
+    @Test
+    public void sealedHighestRollIsResolvedBeforeDocumentListener() {
+        AtomicInteger callbacks = new AtomicInteger();
+        AtomicInteger observedContext = new AtomicInteger(-1);
+        AtomicReference<StoreAppender> appenderReference = new AtomicReference<>();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> {
+                    callbacks.incrementAndGet();
+                    observedContext.set(appenderReference.get().contextCount());
+                    writer.context(new ServiceContext("queue"));
+                })
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appenderReference.set(appender);
+            appender.writeMessage("message", "before");
+            int sealedCycle = appender.cycle();
+            sealCurrentCycle(appender);
+
+            appender.writeMessage("message", "after");
+
+            assertEquals(2, callbacks.get());
+            assertEquals(sealedCycle + 1, appender.cycle());
+            assertEquals(sealedCycle + 1, appender.contextCount());
+            assertEquals(sealedCycle + 1, observedContext.get());
+            assertDocumentCycles(queue, sealedCycle, sealedCycle, sealedCycle + 1, sealedCycle + 1);
+        }
+    }
+
+    @Test
+    public void sealedHighestRollIsResolvedBeforeRawListener() {
+        AtomicInteger callbacks = new AtomicInteger();
+        AtomicReference<StoreAppender> appenderReference = new AtomicReference<>();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> {
+                    callbacks.incrementAndGet();
+                    assertEquals(appenderReference.get().cycle(), appenderReference.get().contextCount());
+                    writer.context(new ServiceContext("queue"));
+                })
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appenderReference.set(appender);
+            writeRaw(appender, "before");
+            int sealedCycle = appender.cycle();
+            sealCurrentCycle(appender);
+
+            writeRaw(appender, "after");
+
+            assertEquals(2, callbacks.get());
+            assertEquals(sealedCycle + 1, appender.contextCount());
+            assertDocumentCycles(queue, sealedCycle, sealedCycle, sealedCycle + 1, sealedCycle + 1);
+        }
+    }
+
+    @Test
+    public void rolledBackClockDoesNotRepeatAnOlderContext() {
+        AtomicInteger callbacks = new AtomicInteger();
+        AtomicLong clock = new AtomicLong(1_000L);
+
+        try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder(
+                        getTmpDir(), WireType.BINARY)
+                .testBlockSize()
+                .rollCycle(TEST_SECONDLY)
+                .timeProvider(clock::get)
+                .contextListener(Events.class, writer -> {
+                    callbacks.incrementAndGet();
+                    writer.context(new ServiceContext("queue"));
+                })
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appender.writeMessage("message", "first");
+            clock.addAndGet(2L * TEST_SECONDLY.lengthInMillis());
+            appender.writeMessage("message", "high-water");
+            int highWater = appender.contextCount();
+
+            clock.set(1_000L);
+            appender.writeMessage("message", "clock-rollback");
+
+            assertEquals(2, callbacks.get());
+            assertEquals(highWater, appender.contextCount());
+            assertEquals(highWater, appender.cycle());
+        }
+    }
+
+    @Test
+    public void exactHistoricalRecoveryDoesNotChangeOrdinaryContext() {
+        ignoreException("Exact-index recovery reopened end-of-data");
+        AtomicInteger callbacks = new AtomicInteger();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> {
+                    callbacks.incrementAndGet();
+                    writer.context(new ServiceContext("queue"));
+                })
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appender.writeMessage("message", "historical");
+            int historicalCycle = appender.contextCount();
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
+            appender.writeMessage("message", "current");
+            int ordinaryContext = appender.contextCount();
+            assertTrue(ordinaryContext > historicalCycle);
+            assertEquals(2, callbacks.get());
+
+            Bytes<?> recovered = binaryPayload("recovered");
+            try {
+                long recoveryIndex = queue.rollCycle().toIndex(historicalCycle, 2);
+                appender.writeBytes(recoveryIndex, recovered);
+            } finally {
+                recovered.releaseLast();
+            }
+
+            assertEquals(ordinaryContext, appender.contextCount());
+            assertEquals(2, callbacks.get());
+            appender.writeMessage("message", "following");
+            assertEquals(ordinaryContext, appender.contextCount());
+            assertEquals(2, callbacks.get());
+        }
+    }
+
+    @Test
+    public void secondEofFailsBeforeListenerStateChanges() {
+        AtomicInteger callbacks = new AtomicInteger();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> {
+                    callbacks.incrementAndGet();
+                    writer.context(new ServiceContext("queue"));
+                })
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            appender.writeMessage("message", "before");
+            int sealedCycle = appender.cycle();
+            sealCurrentCycle(appender);
+            sealCycle(queue, sealedCycle + 1);
+            queue.tableStoreAcquire("listing.highestCycle", sealedCycle)
+                    .setVolatileValue(sealedCycle);
+            queue.tableStoreAcquire("listing.highestCycleWriteFloor", sealedCycle)
+                    .setVolatileValue(sealedCycle);
+
+            assertThrows(WriteAfterEOFException.class,
+                    () -> appender.writeMessage("message", "must-fail"));
+            assertEquals(1, callbacks.get());
+            assertEquals(sealedCycle, appender.contextCount());
+        }
+    }
+
+    @Test
+    public void unclosedListenerDocumentPoisonsOnlyTheCurrentRoll() {
+        AtomicInteger callbacks = new AtomicInteger();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(ProgressiveEvents.class, writer -> {
+                    if (callbacks.incrementAndGet() == 1) {
+                        writer.writingDocument();
+                        writer.context(new ServiceContext("abandoned"));
+                    } else {
+                        writer.context(new ServiceContext("recovered"));
+                    }
+                })
+                .build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            IllegalStateException abandoned = assertThrows(IllegalStateException.class,
+                    () -> appender.writeMessage("message", "first"));
+            assertTrue(abandoned.getMessage().contains("unclosed document"));
+            assertThrows(IllegalStateException.class,
+                    () -> appender.writeMessage("message", "blocked"));
+
+            timeProvider.advanceMillis(TEST_SECONDLY.lengthInMillis());
+            appender.writeMessage("message", "second");
+            assertEquals(2, callbacks.get());
+        }
+    }
+
+    @Test(timeout = 5_000)
+    public void secondAppenderReentryFailsImmediatelyAndReleasesTheQueueLock() {
+        AtomicReference<StoreAppender> secondReference = new AtomicReference<>();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir()).build()) {
+            StoreAppender first = (StoreAppender) queue.createAppender();
+            StoreAppender second = (StoreAppender) queue.createAppender();
+            secondReference.set(second);
+            first.contextListener(Events.class,
+                    writer -> secondReference.get().writeMessage("message", "reentrant"));
+
+            IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> first.writeMessage("message", "first"));
+            assertTrue(failure.getMessage().contains("supplied method writer"));
+            second.writeMessage("message", "after-failure");
+            assertThrows(IllegalStateException.class,
+                    () -> first.writeMessage("message", "blocked"));
+        }
+    }
+
+    @Test
+    public void appendLockRejectionDoesNotConsumeListenerRegistration() {
+        try (SingleChronicleQueue queue = builder(getTmpDir()).timeoutMS(100).build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            WriteLock appendLock = queue.appendLock();
+            appendLock.lock();
+            try {
+                assertThrows(IllegalStateException.class,
+                        () -> appender.writeMessage("message", "blocked"));
+            } finally {
+                appendLock.unlock();
+            }
+
+            appender.contextListener(Events.class,
+                    writer -> writer.context(new ServiceContext("queue")));
+            appender.writeMessage("message", "allowed");
+            assertEquals(appender.cycle(), appender.contextCount());
         }
     }
 
@@ -459,14 +656,15 @@ public class ContextListenerCoreTest extends QueueTestCommon {
                 "# no more messages at 8000000000000000\n", dump(path, WireType.BINARY_LIGHT));
     }
 
-    private static SingleChronicleQueueBuilder builder(File path) {
+    private SingleChronicleQueueBuilder builder(File path) {
         return builder(path, WireType.BINARY);
     }
 
-    private static SingleChronicleQueueBuilder builder(File path, WireType wireType) {
+    private SingleChronicleQueueBuilder builder(File path, WireType wireType) {
         return SingleChronicleQueueBuilder.builder(path, wireType)
                 .testBlockSize()
-                .rollCycle(TEST_SECONDLY);
+                .rollCycle(TEST_SECONDLY)
+                .timeProvider(timeProvider);
     }
 
     private static void writeMessages(ProgressiveEvents events, String... messages) {
@@ -477,21 +675,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
         }
     }
 
-    private static int writeProgressively(ChronicleQueue queue,
-                                          ProgressiveEvents events,
-                                          ServiceContext context,
-                                          String message) {
-        try (DocumentContext document = events.writingDocument()) {
-            int contextCount = document.contextCount();
-            assertEquals(queue.rollCycle().toCycle(document.index()), contextCount);
-            if (context.needsResending(contextCount))
-                events.context(context);
-            events.message(new Message(message));
-            return contextCount;
-        }
-    }
-
-    private static void assertContextCounts(File path, int... expected) {
+    private void assertContextCounts(File path, int... expected) {
         try (ChronicleQueue queue = builder(path).build();
              ExcerptTailer tailer = queue.createTailer()) {
             for (int contextCount : expected) {
@@ -514,6 +698,49 @@ public class ContextListenerCoreTest extends QueueTestCommon {
         return payload;
     }
 
+    private static void writeRaw(StoreAppender appender, String value) {
+        Bytes<?> payload = binaryPayload(value);
+        try {
+            appender.writeBytes(payload);
+        } finally {
+            payload.releaseLast();
+        }
+    }
+
+    private static void assertDocumentCycles(SingleChronicleQueue queue, int... expectedCycles) {
+        try (ExcerptTailer tailer = queue.createTailer()) {
+            for (int expectedCycle : expectedCycles) {
+                try (DocumentContext document = tailer.readingDocument()) {
+                    assertTrue(document.isPresent());
+                    assertEquals(expectedCycle, queue.rollCycle().toCycle(document.index()));
+                }
+            }
+            try (DocumentContext document = tailer.readingDocument()) {
+                assertFalse(document.isPresent());
+            }
+        }
+    }
+
+    private static void sealCurrentCycle(StoreAppender appender) {
+        SingleChronicleQueueStore store = appender.store;
+        if (store == null)
+            throw new AssertionError("Appender has no current store");
+        try (MappedBytes bytes = store.bytes()) {
+            Wire wire = appender.queue().wireType().apply(bytes);
+            wire.usePadding(store.dataVersion() > 0);
+            assertTrue(store.writeEOF(wire, appender.queue().timeoutMS));
+        }
+    }
+
+    private static void sealCycle(SingleChronicleQueue queue, int cycle) {
+        try (SingleChronicleQueueStore store = queue.storeForCycle(cycle, queue.epoch(), true, null);
+             MappedBytes bytes = store.bytes()) {
+            Wire wire = queue.wireType().apply(bytes);
+            wire.usePadding(store.dataVersion() > 0);
+            assertTrue(store.writeEOF(wire, queue.timeoutMS));
+        }
+    }
+
     private static void assertNestedWriteReusesContext(StoreAppender appender) {
         try (DocumentContext outer = appender.writingDocument()) {
             outer.wire().write("outer").text("one");
@@ -525,11 +752,11 @@ public class ContextListenerCoreTest extends QueueTestCommon {
         }
     }
 
-    private static String dump(File path) {
+    private String dump(File path) {
         return dump(path, WireType.BINARY);
     }
 
-    private static String dump(File path, WireType wireType) {
+    private String dump(File path, WireType wireType) {
         try (ChronicleQueue queue = builder(path, wireType).build()) {
             StringWriter writer = new StringWriter();
             queue.dump(writer, 0, Long.MAX_VALUE);
@@ -546,20 +773,11 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     interface ProgressiveEvents extends Events, DocumentWritten {
     }
 
-    static final class ServiceContext extends SelfDescribingMarshallable implements ProgressiveContext {
+    static final class ServiceContext extends SelfDescribingMarshallable {
         private final String name;
-        private transient int lastContextCount = -1;
 
         ServiceContext(String name) {
             this.name = name;
-        }
-
-        @Override
-        public boolean needsResending(int contextCount) {
-            if (contextCount <= lastContextCount)
-                return false;
-            lastContextCount = contextCount;
-            return true;
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -11,6 +11,7 @@ import net.openhft.chronicle.queue.BufferMode;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.wire.AbstractWire;
 import net.openhft.chronicle.wire.DocumentContext;
 import net.openhft.chronicle.wire.DocumentWritten;
 import net.openhft.chronicle.wire.MarshallableOut;
@@ -18,12 +19,16 @@ import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
 import net.openhft.chronicle.wire.WriteAfterEOFException;
+import net.openhft.chronicle.wire.domestic.InternalWire;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
@@ -318,6 +323,113 @@ public class ContextListenerCoreTest extends QueueTestCommon {
                 "# index: 200000001\n" +
                 "message: second\n" +
                 "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test(timeout = 5_000)
+    public void documentApplicationHeaderFailureDoesNotRepeatSuccessfulListener() {
+        assertApplicationHeaderFailureRetainsSuccessfulListener(false, new IllegalStateException("application header failure"));
+        assertApplicationHeaderFailureRetainsSuccessfulListener(false, new AssertionError("application header error"));
+    }
+
+    @Test(timeout = 5_000)
+    public void rawApplicationHeaderFailureDoesNotRepeatSuccessfulListener() {
+        assertApplicationHeaderFailureRetainsSuccessfulListener(true, new IllegalStateException("application header failure"));
+        assertApplicationHeaderFailureRetainsSuccessfulListener(true, new AssertionError("application header error"));
+    }
+
+    private void assertApplicationHeaderFailureRetainsSuccessfulListener(boolean raw, Throwable injectedFailure) {
+        final AtomicInteger callbacks = new AtomicInteger();
+        final AtomicReference<StoreAppender> appenderReference = new AtomicReference<>();
+        final AtomicReference<Wire> underlyingWire = new AtomicReference<>();
+        final AtomicBoolean injected = new AtomicBoolean();
+        final AtomicLong committedContextPosition = new AtomicLong();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> {
+                    callbacks.incrementAndGet();
+                    writer.context(new ServiceContext("checkpoint"));
+                    final StoreAppender appender = appenderReference.get();
+                    committedContextPosition.set(appender.store.writePosition());
+                    underlyingWire.set(failNextApplicationHeader(appender, injectedFailure, injected));
+                }).build()) {
+            final StoreAppender appender = (StoreAppender) queue.acquireAppender();
+            appenderReference.set(appender);
+
+            final Throwable observed = assertThrows(injectedFailure.getClass(), () -> {
+                if (raw)
+                    writeRaw(appender, "must-not-be-written");
+                else
+                    appender.writeMessage("message", "must-not-be-written");
+            });
+
+            assertSame("the failure must originate after the successful callback", injectedFailure, observed);
+            assertTrue(injected.get());
+            assertEquals(1, callbacks.get());
+            assertEquals(committedContextPosition.get(), appender.store.writePosition());
+            assertEquals(1, queue.entryCount());
+            assertEquals(queue.cycle(), appender.contextCount());
+            assertFalse(queue.writeLock().locked());
+            assertEquals(0, appenderNestingCount(appender));
+            assertTrue(appender.writingIsComplete());
+            assertFalse(((AbstractWire) underlyingWire.get()).isInsideHeader());
+
+            if (raw)
+                writeRaw(appender, "accepted");
+            else
+                appender.writeMessage("message", "accepted");
+
+            assertEquals("retry must retain successful listener state", 1, callbacks.get());
+            assertEquals(2, queue.entryCount());
+            assertFalse(queue.writeLock().locked());
+            assertEquals(0, appenderNestingCount(appender));
+            try (ExcerptTailer tailer = queue.createTailer()) {
+                try (DocumentContext document = tailer.readingDocument()) {
+                    assertTrue(document.isPresent());
+                    assertEquals("checkpoint", document.wire().read("context").object(ServiceContext.class).name);
+                }
+                try (DocumentContext document = tailer.readingDocument()) {
+                    assertTrue(document.isPresent());
+                    assertEquals("accepted", document.wire().read("message").text());
+                }
+                try (DocumentContext absent = tailer.readingDocument()) {
+                    assertFalse(absent.isPresent());
+                }
+            }
+        }
+    }
+
+    private static Wire failNextApplicationHeader(StoreAppender appender, Throwable failure, AtomicBoolean injected) {
+        try {
+            final Field field = StoreAppender.class.getDeclaredField("wire");
+            field.setAccessible(true);
+            final Wire delegate = (Wire) field.get(appender);
+            final Wire failingWire = (Wire) Proxy.newProxyInstance(Wire.class.getClassLoader(),
+                    new Class<?>[]{Wire.class, InternalWire.class}, (proxy, method, args) -> {
+                        // Installed only after the listener document commits. Reject acquisition before any
+                        // application header is written, as a capacity failure at enterHeader would do.
+                        if (method.getName().equals("enterHeader") && injected.compareAndSet(false, true))
+                            throw failure;
+                        try {
+                            return method.invoke(delegate, args);
+                        } catch (InvocationTargetException invocationFailure) {
+                            throw invocationFailure.getCause();
+                        }
+                    });
+            field.set(appender, failingWire);
+            return delegate;
+        } catch (ReflectiveOperationException reflectionFailure) {
+            throw new AssertionError("Unable to inject application-header acquisition failure", reflectionFailure);
+        }
+    }
+
+    private static int appenderNestingCount(StoreAppender appender) {
+        try {
+            final Field field = StoreAppender.class.getDeclaredField("count");
+            field.setAccessible(true);
+            return field.getInt(appender);
+        } catch (ReflectiveOperationException reflectionFailure) {
+            throw new AssertionError("Unable to inspect appender nesting after failure", reflectionFailure);
+        }
     }
 
     @Test(timeout = 5_000)

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -52,6 +52,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void writesContextBeforeDataAndAllowsRetainingWriter() {
+        //! Mutation-removing beforeDocument() leaves no context and fails this first ordering check.
         File path = getTmpDir();
         AtomicInteger callbacks = new AtomicInteger();
         AtomicReference<Events> retainedWriter = new AtomicReference<>();
@@ -98,6 +99,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void writesContextBeforeHeldDataDocument() {
+        //! Pins one shared, nested listener document while the application context remains open.
         File path = getTmpDir();
 
         try (SingleChronicleQueue queue = builder(path).build()) {
@@ -137,6 +139,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void indexedWriteDoesNotNotifyOrConsumeListenerRegistration() {
+        //! Distinguishes recovery writes from the first subsequent ordinary listener boundary.
         AtomicInteger callbacks = new AtomicInteger();
 
         try (ChronicleQueue queue = builder(getTmpDir())
@@ -160,6 +163,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void notifiesEachAppenderWithItsOwnContextOncePerRoll() {
+        //! Mutation of cycle rearming changes callback counts and fails this per-appender matrix.
         File path = getTmpDir();
         AtomicInteger firstCallbacks = new AtomicInteger();
         AtomicInteger secondCallbacks = new AtomicInteger();
@@ -235,6 +239,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerFailureAfterWritingContextIsNotRetriedInTheSameRoll() {
+        //! Mutation-changing FAILED to READY permits the next write and fails the one-attempt count.
         File path = getTmpDir();
         AtomicInteger callbacks = new AtomicInteger();
 
@@ -275,6 +280,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable() {
+        //! Pins Throwable cleanup, document rollback, count restoration and later-roll recovery.
         File path = getTmpDir();
         AtomicInteger callbacks = new AtomicInteger();
 
@@ -313,6 +319,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void appenderWriteFromListenerFailsFast() {
+        //! Prevents deadlock/reentrancy through the captured appender's ordinary write path.
         File path = getTmpDir();
         AtomicReference<StoreAppender> appenderRef = new AtomicReference<>();
         AtomicInteger callbacks = new AtomicInteger();
@@ -351,31 +358,37 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void capturedAppenderRollbackFromListenerFailsFast() {
+        //! Pins rejection before rollback can release the outer write's shared context and lock.
         assertCapturedAppenderMutationFails(StoreAppender::rollbackIfNotComplete);
     }
 
     @Test(timeout = 5_000)
     public void capturedAppenderNormalisationFromListenerFailsFast() {
+        //! Pins rejection before normalisation attempts to reacquire the non-reentrant write lock.
         assertCapturedAppenderMutationFails(StoreAppender::normaliseEOFs);
     }
 
     @Test(timeout = 5_000)
     public void capturedAppenderCloseFromListenerFailsFast() {
+        //! Pins rejection before callback code can tear down the outer write's appender.
         assertCapturedAppenderMutationFails(StoreAppender::close);
     }
 
     @Test(timeout = 5_000)
     public void capturedAppenderWireAccessFromListenerFailsFast() {
+        //! Prevents mutable outer-Wire escape from the supplied listener writer.
         assertCapturedAppenderMutationFails(StoreAppender::wire);
     }
 
     @Test(timeout = 5_000)
     public void capturedAppenderIndexWireAccessFromListenerFailsFast() {
+        //! Prevents mutable index-Wire escape while internal index publication uses its private path.
         assertCapturedAppenderMutationFails(StoreAppender::wireForIndex);
     }
 
     @Test(timeout = 5_000)
     public void appenderCreationFromListenerFailsFast() {
+        //! Pins the common new-appender guard before a second appender can block on the write lock.
         final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
 
         try (SingleChronicleQueue queue = builder(getTmpDir())
@@ -394,6 +407,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void queueCloseFromListenerFailsBeforeTeardownAndReleasesTheLock() {
+        //! Pins close rejection before teardown and verifies normal close after callback unwinding.
         final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
         final AtomicInteger callbacks = new AtomicInteger();
 
@@ -424,6 +438,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void metadataDoesNotConsumeAppenderListenerRegistration() {
+        //! Mutation-removing the metadata exemption makes later listener registration fail here.
         final AtomicInteger callbacks = new AtomicInteger();
         try (SingleChronicleQueue queue = builder(getTmpDir()).build()) {
             final StoreAppender appender = (StoreAppender) queue.createAppender();
@@ -469,6 +484,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerCanHoldOneDocumentWhileWritingContext() {
+        //! Pins chained/nested supplied-writer semantics within one listener callback.
         AtomicBoolean outerDocumentRemainedOpen = new AtomicBoolean();
         AtomicInteger contextCount = new AtomicInteger();
 
@@ -491,6 +507,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void sealedHighestRollIsResolvedBeforeDocumentListener() {
+        //! Mutation-removing destination preflight fails before the callback can target the rolled cycle.
         AtomicInteger callbacks = new AtomicInteger();
         AtomicInteger observedContext = new AtomicInteger(-1);
         AtomicReference<StoreAppender> appenderReference = new AtomicReference<>();
@@ -520,6 +537,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void sealedHighestRollIsResolvedBeforeRawListener() {
+        //! Applies the same QUEUE-146 destination invariant to sequential raw writes.
         AtomicInteger callbacks = new AtomicInteger();
         AtomicReference<StoreAppender> appenderReference = new AtomicReference<>();
 
@@ -546,6 +564,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void rolledBackClockDoesNotRepeatAnOlderContext() {
+        //! Pins contextCount to the monotonic ordinary destination rather than rolled-back wall time.
         AtomicInteger callbacks = new AtomicInteger();
         AtomicLong clock = new AtomicLong(1_000L);
 
@@ -576,6 +595,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void exactHistoricalRecoveryDoesNotChangeOrdinaryContext() {
+        //! Pins exact-index recovery as listener-free and unable to move the ordinary context backwards.
         ignoreException("Exact-index recovery reopened end-of-data");
         AtomicInteger callbacks = new AtomicInteger();
 
@@ -612,6 +632,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void secondEofFailsBeforeListenerStateChanges() {
+        //! Pins failure before callback state changes when QUEUE-146's one advance also finds EOF.
         AtomicInteger callbacks = new AtomicInteger();
 
         try (SingleChronicleQueue queue = builder(getTmpDir())
@@ -639,6 +660,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void unclosedListenerDocumentPoisonsOnlyTheCurrentRoll() {
+        //! Mutation-removing the open-document check changes the failure and leaves invalid header state.
         AtomicInteger callbacks = new AtomicInteger();
 
         try (SingleChronicleQueue queue = builder(getTmpDir())
@@ -666,6 +688,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void secondAppenderReentryFailsImmediatelyAndReleasesTheQueueLock() {
+        //! Pins same-instance reentry rejection and subsequent lock usability.
         AtomicReference<StoreAppender> secondReference = new AtomicReference<>();
 
         try (SingleChronicleQueue queue = builder(getTmpDir()).build()) {
@@ -686,6 +709,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void secondQueueInstanceOnSamePathFailsImmediatelyDuringCallback() {
+        //! Mutation-removing the path guard times out on the cross-instance write lock.
         File path = getTmpDir();
         AtomicReference<SingleChronicleQueue> secondReference = new AtomicReference<>();
 
@@ -708,6 +732,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void otherThreadUsingSamePathFailsImmediatelyDuringCallback() throws Exception {
+        //! Pins process-wide path isolation rather than a thread-local-only callback guard.
         File path = getTmpDir();
         CountDownLatch callbackStarted = new CountDownLatch(1);
         CountDownLatch releaseCallback = new CountDownLatch(1);
@@ -745,6 +770,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void appendLockRejectionDoesNotConsumeListenerRegistration() {
+        //! Keeps rejected preflight outside the listener's started/attempt lifecycle.
         try (SingleChronicleQueue queue = builder(getTmpDir()).timeoutMS(100).build()) {
             StoreAppender appender = (StoreAppender) queue.createAppender();
             WriteLock appendLock = queue.appendLock();
@@ -765,6 +791,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerClosePreservesNestingForDocumentWrite() {
+        //! Pins listener close/commit without consuming the outer application document nesting.
         try (ChronicleQueue queue = builder(getTmpDir())
                 .timeoutMS(100)
                 .contextListener(Events.class,
@@ -776,6 +803,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerClosePreservesNestingAfterRawWrite() {
+        //! Pins the same count restoration for sequential raw output.
         try (ChronicleQueue queue = builder(getTmpDir())
                 .timeoutMS(100)
                 .contextListener(Events.class,
@@ -795,6 +823,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerDocumentResetCommitsContextBeforeApplicationData() {
+        //! Fails if reset clears the holder before committing the active listener document.
         File path = getTmpDir();
 
         try (ChronicleQueue queue = builder(path)
@@ -823,6 +852,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerDocumentResetMakesNestedAutomaticClosesHarmless() {
+        //! Mutation-removing closesAfterReset produces a spurious no-document-open failure.
         File path = getTmpDir();
 
         try (ChronicleQueue queue = builder(path)
@@ -844,6 +874,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerRollbackThenResetPoisonsContextAndAutomaticCloseIsHarmless() {
+        //! Pins rollback intent across reset while absorbing already-satisfied automatic closes.
         AtomicInteger attempts = new AtomicInteger();
 
         try (ChronicleQueue queue = builder(getTmpDir())
@@ -868,6 +899,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerRemainsCallerOwned() {
+        //! Guards the ownership contract: Queue retains but never closes the supplied listener.
         CloseableListener listener = new CloseableListener();
 
         try (ChronicleQueue queue = builder(getTmpDir())
@@ -881,6 +913,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void rejectsDoubleBuffering() {
+        //! Pins rejection because buffered destination selection occurs after notification time.
         assertThrows(UnsupportedOperationException.class, () -> builder(getTmpDir())
                 .doubleBuffer(true)
                 .contextListener(Events.class, writer -> { })
@@ -894,6 +927,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void rejectsEveryUnsupportedEffectiveQueueMode() {
+        //! Mutation-removing any compatibility branch admits a mode without same-Wire ordering.
         assertThrows(UnsupportedOperationException.class,
                 () -> SingleChronicleQueue.validateContextListenerCompatibility(true, false, false));
         assertThrows(UnsupportedOperationException.class,
@@ -904,6 +938,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void validatesModesLoadedDuringPreBuildAndClosesMetadata() {
+        //! Pins post-preBuild validation and exceptional metadata cleanup.
         SingleChronicleQueueBuilder delayedMode = new SingleChronicleQueueBuilder() {
             @Override
             protected void preBuild() {
@@ -923,6 +958,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void encodesContextWithQueueWireType() {
+        //! Distinguishes Queue's configured Wire type from a hard-coded listener format.
         File path = getTmpDir();
 
         try (ChronicleQueue queue = builder(path, WireType.BINARY_LIGHT)
@@ -945,6 +981,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void tailerDocumentsExposeTheirActualCycle() {
+        //! Mutation-returning a constant/unavailable count fails for present documents across rolls.
         final File path = getTmpDir();
         try (ChronicleQueue queue = builder(path).build();
              ExcerptAppender appender = queue.createAppender()) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -435,6 +435,25 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     }
 
     @Test(timeout = 5_000)
+    public void acquireAppenderFromListenerFailsFast() {
+        // Pre-populate the thread-local cache so this distinguishes rejection from construction.
+        final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir())
+                .contextListener(Events.class, writer -> queueRef.get().acquireAppender())
+                .build()) {
+            queueRef.set(queue);
+            final StoreAppender cached = (StoreAppender) queue.acquireAppender();
+
+            final IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> cached.writeMessage("message", "first"));
+            assertTrue(failure.getMessage().contains("supplied method writer"));
+            assertThrows(IllegalStateException.class,
+                    () -> cached.writeMessage("message", "blocked"));
+        }
+    }
+
+    @Test(timeout = 5_000)
     public void queueCloseFromListenerFailsBeforeTeardownAndReleasesTheLock() {
         // Pins close rejection before teardown and verifies normal close after callback unwinding.
         final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
@@ -686,6 +705,31 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     }
 
     @Test
+    public void secondEofLeavesListenerRegistrationOpen() {
+        AtomicInteger callbacks = new AtomicInteger();
+
+        try (SingleChronicleQueue queue = builder(getTmpDir()).build()) {
+            StoreAppender appender = (StoreAppender) queue.createAppender();
+            int sealedCycle = queue.cycle();
+            sealCycle(queue, sealedCycle);
+            sealCycle(queue, sealedCycle + 1);
+            queue.tableStoreAcquire("listing.highestCycle", sealedCycle)
+                    .setVolatileValue(sealedCycle);
+
+            assertThrows(WriteAfterEOFException.class,
+                    () -> appender.writeMessage("message", "must-fail"));
+            appender.contextListener(Events.class, writer -> {
+                callbacks.incrementAndGet();
+                writer.context(new ServiceContext("queue"));
+            });
+
+            timeProvider.advanceMillis(2L * TEST_SECONDLY.lengthInMillis());
+            appender.writeMessage("message", "accepted");
+            assertEquals(1, callbacks.get());
+        }
+    }
+
+    @Test
     public void unclosedListenerDocumentPoisonsOnlyTheCurrentRoll() {
         // Mutation-removing the open-document check changes the failure and leaves invalid header state.
         AtomicInteger callbacks = new AtomicInteger();
@@ -796,7 +840,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void otherThreadUsingSamePathFailsImmediatelyDuringCallback() throws Exception {
-        // Pins process-wide path isolation rather than a thread-local-only callback guard.
+        // Pins JVM-wide path isolation rather than a thread-local-only callback guard.
         File path = getTmpDir();
         CountDownLatch callbackStarted = new CountDownLatch(1);
         CountDownLatch releaseCallback = new CountDownLatch(1);
@@ -1001,13 +1045,26 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void rejectsEveryUnsupportedEffectiveQueueMode() {
-        // Mutation-removing any compatibility branch admits a mode without same-Wire ordering.
+        // Directly pins the mode-classification helper; builder integration is covered separately.
         assertThrows(UnsupportedOperationException.class,
                 () -> SingleChronicleQueue.validateContextListenerCompatibility(true, false, false));
         assertThrows(UnsupportedOperationException.class,
                 () -> SingleChronicleQueue.validateContextListenerCompatibility(false, true, false));
         assertThrows(UnsupportedOperationException.class,
                 () -> SingleChronicleQueue.validateContextListenerCompatibility(false, false, true));
+    }
+
+    @Test
+    public void rejectsEncodedAndEncryptedBuilderModes() {
+        assertThrows(UnsupportedOperationException.class, () -> builder(getTmpDir())
+                .aesEncryption(new byte[16])
+                .contextListener(Events.class, writer -> { })
+                .build());
+
+        assertThrows(UnsupportedOperationException.class, () -> builder(getTmpDir())
+                .codingSuppliers(() -> (input, output) -> { }, () -> (input, output) -> { })
+                .contextListener(Events.class, writer -> { })
+                .build());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -730,6 +730,33 @@ public class ContextListenerCoreTest extends QueueTestCommon {
     }
 
     @Test
+    public void listenerDocumentResetCommitsContextBeforeApplicationData() {
+        File path = getTmpDir();
+
+        try (ChronicleQueue queue = builder(path)
+                .contextListener(ProgressiveEvents.class, writer -> {
+                    DocumentContext document = writer.writingDocument();
+                    writer.context(new ServiceContext("reset"));
+                    document.reset();
+                })
+                .build()) {
+            queue.methodWriter(Events.class).message(new Message("application"));
+        }
+
+        assertEquals("" +
+                "# firstIndex: 100000000\n" +
+                "# index: 100000000\n" +
+                "context: {\n" +
+                "  name: reset\n" +
+                "}\n" +
+                "# index: 100000001\n" +
+                "message: {\n" +
+                "  text: application\n" +
+                "}\n" +
+                "# no more messages at 8000000000000000\n", dump(path));
+    }
+
+    @Test
     public void listenerRemainsCallerOwned() {
         CloseableListener listener = new CloseableListener();
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -7,6 +7,7 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.MappedBytes;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.queue.BufferMode;
 import net.openhft.chronicle.queue.ExcerptAppender;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.QueueTestCommon;
@@ -632,6 +633,35 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             assertThrows(UnsupportedOperationException.class,
                     () -> queue.createAppender().contextListener(Events.class, writer -> { }));
         }
+    }
+
+    @Test
+    public void rejectsEveryUnsupportedEffectiveQueueMode() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> SingleChronicleQueue.validateContextListenerCompatibility(true, false, false));
+        assertThrows(UnsupportedOperationException.class,
+                () -> SingleChronicleQueue.validateContextListenerCompatibility(false, true, false));
+        assertThrows(UnsupportedOperationException.class,
+                () -> SingleChronicleQueue.validateContextListenerCompatibility(false, false, true));
+    }
+
+    @Test
+    public void validatesModesLoadedDuringPreBuildAndClosesMetadata() {
+        SingleChronicleQueueBuilder delayedMode = new SingleChronicleQueueBuilder() {
+            @Override
+            protected void preBuild() {
+                super.preBuild();
+                writeBufferMode(BufferMode.Asynchronous);
+            }
+        };
+        delayedMode.path(getTmpDir())
+                .testBlockSize()
+                .rollCycle(TEST_SECONDLY)
+                .timeProvider(timeProvider)
+                .contextListener(Events.class, writer -> { });
+
+        assertThrows(UnsupportedOperationException.class, delayedMode::build);
+        assertTrue(delayedMode.metaStore().isClosed());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -23,6 +23,11 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.StringWriter;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -676,6 +681,65 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             second.writeMessage("message", "after-failure");
             assertThrows(IllegalStateException.class,
                     () -> first.writeMessage("message", "blocked"));
+        }
+    }
+
+    @Test(timeout = 5_000)
+    public void secondQueueInstanceOnSamePathFailsImmediatelyDuringCallback() {
+        File path = getTmpDir();
+        AtomicReference<SingleChronicleQueue> secondReference = new AtomicReference<>();
+
+        try (SingleChronicleQueue first = builder(path)
+                .contextListener(Events.class,
+                        writer -> secondReference.get().createAppender()
+                                .writeMessage("message", "reentrant"))
+                .build();
+             SingleChronicleQueue second = builder(path).build()) {
+            secondReference.set(second);
+            StoreAppender firstAppender = (StoreAppender) first.createAppender();
+
+            IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> firstAppender.writeMessage("message", "first"));
+            assertTrue(failure.getMessage().contains("supplied method writer"));
+
+            second.createAppender().writeMessage("message", "after-failure");
+        }
+    }
+
+    @Test(timeout = 5_000)
+    public void otherThreadUsingSamePathFailsImmediatelyDuringCallback() throws Exception {
+        File path = getTmpDir();
+        CountDownLatch callbackStarted = new CountDownLatch(1);
+        CountDownLatch releaseCallback = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try (SingleChronicleQueue first = builder(path)
+                .contextListener(Events.class, writer -> {
+                    callbackStarted.countDown();
+                    try {
+                        assertTrue(releaseCallback.await(3, TimeUnit.SECONDS));
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException("Interrupted while pausing listener", interrupted);
+                    }
+                    writer.context(new ServiceContext("first"));
+                })
+                .build();
+             SingleChronicleQueue second = builder(path).build()) {
+            Future<?> firstWrite = executor.submit(() ->
+                    first.createAppender().writeMessage("message", "first"));
+            assertTrue(callbackStarted.await(3, TimeUnit.SECONDS));
+
+            IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> second.createAppender().writeMessage("message", "blocked"));
+            assertTrue(failure.getMessage().contains("supplied method writer"));
+
+            releaseCallback.countDown();
+            firstWrite.get(3, TimeUnit.SECONDS);
+            second.createAppender().writeMessage("message", "after-callback");
+        } finally {
+            releaseCallback.countDown();
+            executor.shutdownNow();
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/ContextListenerCoreTest.java
@@ -55,7 +55,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void writesContextBeforeDataAndAllowsRetainingWriter() {
-        //! Mutation-removing beforeDocument() leaves no context and fails this first ordering check.
+        // Mutation-removing beforeDocument() leaves no context and fails this first ordering check.
         File path = getTmpDir();
         AtomicInteger callbacks = new AtomicInteger();
         AtomicReference<Events> retainedWriter = new AtomicReference<>();
@@ -102,7 +102,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void writesContextBeforeHeldDataDocument() {
-        //! Pins one shared, nested listener document while the application context remains open.
+        // Pins one shared, nested listener document while the application context remains open.
         File path = getTmpDir();
 
         try (SingleChronicleQueue queue = builder(path).build()) {
@@ -142,7 +142,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void indexedWriteDoesNotNotifyOrConsumeListenerRegistration() {
-        //! Distinguishes recovery writes from the first subsequent ordinary listener boundary.
+        // Distinguishes recovery writes from the first subsequent ordinary listener boundary.
         AtomicInteger callbacks = new AtomicInteger();
 
         try (ChronicleQueue queue = builder(getTmpDir())
@@ -166,7 +166,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void notifiesEachAppenderWithItsOwnContextOncePerRoll() {
-        //! Mutation of cycle rearming changes callback counts and fails this per-appender matrix.
+        // Mutation of cycle rearming changes callback counts and fails this per-appender matrix.
         File path = getTmpDir();
         AtomicInteger firstCallbacks = new AtomicInteger();
         AtomicInteger secondCallbacks = new AtomicInteger();
@@ -242,7 +242,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerFailureAfterWritingContextIsNotRetriedInTheSameRoll() {
-        //! Mutation-changing FAILED to READY permits the next write and fails the one-attempt count.
+        // Mutation-changing FAILED to READY permits the next write and fails the one-attempt count.
         File path = getTmpDir();
         AtomicInteger callbacks = new AtomicInteger();
 
@@ -283,7 +283,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void listenerErrorRollsBackHeldDocumentAndLeavesAppenderUsable() {
-        //! Pins Throwable cleanup, document rollback, count restoration and later-roll recovery.
+        // Pins Throwable cleanup, document rollback, count restoration and later-roll recovery.
         File path = getTmpDir();
         AtomicInteger callbacks = new AtomicInteger();
 
@@ -322,7 +322,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void appenderWriteFromListenerFailsFast() {
-        //! Prevents deadlock/reentrancy through the captured appender's ordinary write path.
+        // Prevents deadlock/reentrancy through the captured appender's ordinary write path.
         File path = getTmpDir();
         AtomicReference<StoreAppender> appenderRef = new AtomicReference<>();
         AtomicInteger callbacks = new AtomicInteger();
@@ -361,37 +361,63 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void capturedAppenderRollbackFromListenerFailsFast() {
-        //! Pins rejection before rollback can release the outer write's shared context and lock.
+        // Pins rejection before rollback can release the outer write's shared context and lock.
         assertCapturedAppenderMutationFails(StoreAppender::rollbackIfNotComplete);
     }
 
     @Test(timeout = 5_000)
     public void capturedAppenderNormalisationFromListenerFailsFast() {
-        //! Pins rejection before normalisation attempts to reacquire the non-reentrant write lock.
+        // Pins rejection before normalisation attempts to reacquire the non-reentrant write lock.
         assertCapturedAppenderMutationFails(StoreAppender::normaliseEOFs);
     }
 
     @Test(timeout = 5_000)
     public void capturedAppenderCloseFromListenerFailsFast() {
-        //! Pins rejection before callback code can tear down the outer write's appender.
+        // Pins rejection before callback code can tear down the outer write's appender.
         assertCapturedAppenderMutationFails(StoreAppender::close);
     }
 
     @Test(timeout = 5_000)
     public void capturedAppenderWireAccessFromListenerFailsFast() {
-        //! Prevents mutable outer-Wire escape from the supplied listener writer.
+        // Prevents mutable outer-Wire escape from the supplied listener writer.
         assertCapturedAppenderMutationFails(StoreAppender::wire);
     }
 
     @Test(timeout = 5_000)
     public void capturedAppenderIndexWireAccessFromListenerFailsFast() {
-        //! Prevents mutable index-Wire escape while internal index publication uses its private path.
+        // Prevents mutable index-Wire escape while internal index publication uses its private path.
         assertCapturedAppenderMutationFails(StoreAppender::wireForIndex);
     }
 
     @Test(timeout = 5_000)
+    public void capturedAppenderPretouchFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(StoreAppender::pretouch);
+    }
+
+    @Test(timeout = 5_000)
+    public void capturedAppenderMicroTouchFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(StoreAppender::microTouch);
+    }
+
+    @Test(timeout = 5_000)
+    public void capturedAppenderBackgroundMicroTouchFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(StoreAppender::bgMicroTouch);
+    }
+
+    @Test(timeout = 5_000)
+    public void capturedAppenderSyncFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(StoreAppender::sync);
+    }
+
+    @Test(timeout = 5_000)
+    public void capturedAppenderListenerRegistrationFromListenerFailsFast() {
+        assertCapturedAppenderMutationFails(appender ->
+                appender.contextListener(Events.class, writer -> { }));
+    }
+
+    @Test(timeout = 5_000)
     public void appenderCreationFromListenerFailsFast() {
-        //! Pins the common new-appender guard before a second appender can block on the write lock.
+        // Pins the common new-appender guard before a second appender can block on the write lock.
         final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
 
         try (SingleChronicleQueue queue = builder(getTmpDir())
@@ -410,7 +436,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void queueCloseFromListenerFailsBeforeTeardownAndReleasesTheLock() {
-        //! Pins close rejection before teardown and verifies normal close after callback unwinding.
+        // Pins close rejection before teardown and verifies normal close after callback unwinding.
         final AtomicReference<SingleChronicleQueue> queueRef = new AtomicReference<>();
         final AtomicInteger callbacks = new AtomicInteger();
 
@@ -441,7 +467,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void metadataDoesNotConsumeAppenderListenerRegistration() {
-        //! Mutation-removing the metadata exemption makes later listener registration fail here.
+        // Mutation-removing the metadata exemption makes later listener registration fail here.
         final AtomicInteger callbacks = new AtomicInteger();
         try (SingleChronicleQueue queue = builder(getTmpDir()).build()) {
             final StoreAppender appender = (StoreAppender) queue.createAppender();
@@ -487,7 +513,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerCanHoldOneDocumentWhileWritingContext() {
-        //! Pins chained/nested supplied-writer semantics within one listener callback.
+        // Pins chained/nested supplied-writer semantics within one listener callback.
         AtomicBoolean outerDocumentRemainedOpen = new AtomicBoolean();
         AtomicInteger contextCount = new AtomicInteger();
 
@@ -510,7 +536,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void sealedHighestRollIsResolvedBeforeDocumentListener() {
-        //! Mutation-removing destination preflight fails before the callback can target the rolled cycle.
+        // Mutation-removing destination preflight fails before the callback can target the rolled cycle.
         AtomicInteger callbacks = new AtomicInteger();
         AtomicInteger observedContext = new AtomicInteger(-1);
         AtomicReference<StoreAppender> appenderReference = new AtomicReference<>();
@@ -540,7 +566,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void sealedHighestRollIsResolvedBeforeRawListener() {
-        //! Applies the same QUEUE-146 destination invariant to sequential raw writes.
+        // Applies the same QUEUE-146 destination invariant to sequential raw writes.
         AtomicInteger callbacks = new AtomicInteger();
         AtomicReference<StoreAppender> appenderReference = new AtomicReference<>();
 
@@ -567,7 +593,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void rolledBackClockDoesNotRepeatAnOlderContext() {
-        //! Pins contextCount to the monotonic ordinary destination rather than rolled-back wall time.
+        // Pins contextCount to the monotonic ordinary destination rather than rolled-back wall time.
         AtomicInteger callbacks = new AtomicInteger();
         AtomicLong clock = new AtomicLong(1_000L);
 
@@ -598,7 +624,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void exactHistoricalRecoveryDoesNotChangeOrdinaryContext() {
-        //! Pins exact-index recovery as listener-free and unable to move the ordinary context backwards.
+        // Pins exact-index recovery as listener-free and unable to move the ordinary context backwards.
         ignoreException("Exact-index recovery reopened end-of-data");
         AtomicInteger callbacks = new AtomicInteger();
 
@@ -635,7 +661,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void secondEofFailsBeforeListenerStateChanges() {
-        //! Pins failure before callback state changes when QUEUE-146's one advance also finds EOF.
+        // Pins failure before callback state changes when QUEUE-146's one advance also finds EOF.
         AtomicInteger callbacks = new AtomicInteger();
 
         try (SingleChronicleQueue queue = builder(getTmpDir())
@@ -661,7 +687,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void unclosedListenerDocumentPoisonsOnlyTheCurrentRoll() {
-        //! Mutation-removing the open-document check changes the failure and leaves invalid header state.
+        // Mutation-removing the open-document check changes the failure and leaves invalid header state.
         AtomicInteger callbacks = new AtomicInteger();
 
         try (SingleChronicleQueue queue = builder(getTmpDir())
@@ -689,7 +715,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void secondAppenderReentryFailsImmediatelyAndReleasesTheQueueLock() {
-        //! Pins same-instance reentry rejection and subsequent lock usability.
+        // Pins same-instance reentry rejection and subsequent lock usability.
         AtomicReference<StoreAppender> secondReference = new AtomicReference<>();
 
         try (SingleChronicleQueue queue = builder(getTmpDir()).build()) {
@@ -710,7 +736,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void secondQueueInstanceOnSamePathFailsImmediatelyDuringCallback() {
-        //! Mutation-removing the path guard times out on the cross-instance write lock.
+        // Mutation-removing the path guard times out on the cross-instance write lock.
         File path = getTmpDir();
         AtomicReference<SingleChronicleQueue> secondReference = new AtomicReference<>();
 
@@ -758,8 +784,8 @@ public class ContextListenerCoreTest extends QueueTestCommon {
              SingleChronicleQueue second = builder(alias.toFile()).timeoutMS(100).build()) {
             aliasQueue.set(second);
 
-            //! Callback isolation is keyed by physical Queue identity, not the spelling used to
-            //! open it; an alias must fail before touching the cross-process write lock.
+            // Callback isolation is keyed by physical Queue identity, not the spelling used to
+            // open it; an alias must fail before touching the cross-process write lock.
             primary.createAppender().writeMessage("message", "application");
 
             assertTrue(aliasFailure.get() instanceof IllegalStateException);
@@ -770,7 +796,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test(timeout = 5_000)
     public void otherThreadUsingSamePathFailsImmediatelyDuringCallback() throws Exception {
-        //! Pins process-wide path isolation rather than a thread-local-only callback guard.
+        // Pins process-wide path isolation rather than a thread-local-only callback guard.
         File path = getTmpDir();
         CountDownLatch callbackStarted = new CountDownLatch(1);
         CountDownLatch releaseCallback = new CountDownLatch(1);
@@ -808,7 +834,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void appendLockRejectionDoesNotConsumeListenerRegistration() {
-        //! Keeps rejected preflight outside the listener's started/attempt lifecycle.
+        // Keeps rejected preflight outside the listener's started/attempt lifecycle.
         try (SingleChronicleQueue queue = builder(getTmpDir()).timeoutMS(100).build()) {
             StoreAppender appender = (StoreAppender) queue.createAppender();
             WriteLock appendLock = queue.appendLock();
@@ -829,7 +855,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerClosePreservesNestingForDocumentWrite() {
-        //! Pins listener close/commit without consuming the outer application document nesting.
+        // Pins listener close/commit without consuming the outer application document nesting.
         try (ChronicleQueue queue = builder(getTmpDir())
                 .timeoutMS(100)
                 .contextListener(Events.class,
@@ -841,7 +867,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerClosePreservesNestingAfterRawWrite() {
-        //! Pins the same count restoration for sequential raw output.
+        // Pins the same count restoration for sequential raw output.
         try (ChronicleQueue queue = builder(getTmpDir())
                 .timeoutMS(100)
                 .contextListener(Events.class,
@@ -861,7 +887,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerDocumentResetCommitsContextBeforeApplicationData() {
-        //! Fails if reset clears the holder before committing the active listener document.
+        // Fails if reset clears the holder before committing the active listener document.
         File path = getTmpDir();
 
         try (ChronicleQueue queue = builder(path)
@@ -890,7 +916,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerDocumentResetMakesNestedAutomaticClosesHarmless() {
-        //! Mutation-removing closesAfterReset produces a spurious no-document-open failure.
+        // Mutation-removing closesAfterReset produces a spurious no-document-open failure.
         File path = getTmpDir();
 
         try (ChronicleQueue queue = builder(path)
@@ -922,7 +948,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerRollbackThenResetPoisonsContextAndAutomaticCloseIsHarmless() {
-        //! Pins rollback intent across reset while absorbing already-satisfied automatic closes.
+        // Pins rollback intent across reset while absorbing already-satisfied automatic closes.
         AtomicInteger attempts = new AtomicInteger();
 
         try (ChronicleQueue queue = builder(getTmpDir())
@@ -947,7 +973,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void listenerRemainsCallerOwned() {
-        //! Guards the ownership contract: Queue retains but never closes the supplied listener.
+        // Guards the ownership contract: Queue retains but never closes the supplied listener.
         CloseableListener listener = new CloseableListener();
 
         try (ChronicleQueue queue = builder(getTmpDir())
@@ -961,7 +987,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void rejectsDoubleBuffering() {
-        //! Pins rejection because buffered destination selection occurs after notification time.
+        // Pins rejection because buffered destination selection occurs after notification time.
         assertThrows(UnsupportedOperationException.class, () -> builder(getTmpDir())
                 .doubleBuffer(true)
                 .contextListener(Events.class, writer -> { })
@@ -975,7 +1001,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void rejectsEveryUnsupportedEffectiveQueueMode() {
-        //! Mutation-removing any compatibility branch admits a mode without same-Wire ordering.
+        // Mutation-removing any compatibility branch admits a mode without same-Wire ordering.
         assertThrows(UnsupportedOperationException.class,
                 () -> SingleChronicleQueue.validateContextListenerCompatibility(true, false, false));
         assertThrows(UnsupportedOperationException.class,
@@ -986,7 +1012,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void validatesModesLoadedDuringPreBuildAndClosesMetadata() {
-        //! Pins post-preBuild validation and exceptional metadata cleanup.
+        // Pins post-preBuild validation and exceptional metadata cleanup.
         SingleChronicleQueueBuilder delayedMode = new SingleChronicleQueueBuilder() {
             @Override
             protected void preBuild() {
@@ -1006,7 +1032,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void encodesContextWithQueueWireType() {
-        //! Distinguishes Queue's configured Wire type from a hard-coded listener format.
+        // Distinguishes Queue's configured Wire type from a hard-coded listener format.
         File path = getTmpDir();
 
         try (ChronicleQueue queue = builder(path, WireType.BINARY_LIGHT)
@@ -1029,7 +1055,7 @@ public class ContextListenerCoreTest extends QueueTestCommon {
 
     @Test
     public void tailerDocumentsExposeTheirActualCycle() {
-        //! Mutation-returning a constant/unavailable count fails for present documents across rolls.
+        // Mutation-returning a constant/unavailable count fails for present documents across rolls.
         final File path = getTmpDir();
         try (ChronicleQueue queue = builder(path).build();
              ExcerptAppender appender = queue.createAppender()) {
@@ -1082,8 +1108,8 @@ public class ContextListenerCoreTest extends QueueTestCommon {
             if (!queueListener)
                 appender.contextListener(ProgressiveEvents.class, listener);
 
-            //! Each reset satisfies one active document but every enclosing try-with-resources
-            //! scope still closes later; deferred close accounting must accumulate across resets.
+            // Each reset satisfies one active document but every enclosing try-with-resources
+            // scope still closes later; deferred close accounting must accumulate across resets.
             if (queueListener)
                 appender.methodWriter(Events.class).message(new Message("application"));
             else


### PR DESCRIPTION
This is the single complete listener-lifecycle delivery on #1745, using merged Wire #1280 (`3dd7fe5983c0133703ee72f57bced9a25270eb6f`). Older #1725 remains a source/reference, not a parallel delivery.

The intended policy keeps exact-index recovery from consuming ordinary listener registration. Review builder configuration, first notification, context counts, nesting, rollback, retained writers, callback escapes and re-entry as one coherent lifecycle. In particular, retain `indexedWriteDoesNotNotifyOrConsumeListenerRegistration` and `exactHistoricalRecoveryDoesNotChangeOrdinaryContext` together with their production behaviour.

Head `c5d85cc45cffa55127386ddc1ae1147e47f5e019`, including the lower stack, is also the declared Queue runtime/test source for CQE #956/#957 composition. Those CQE PRs remain separate reviews but one release unit. Snapshot coordinates alone do not identify this exact source tuple.

No source restack or new validation is claimed by this review-map update.


<details>
<summary>Existing implementation and validation receipt (restructuring changes only the review map)</summary>

## Purpose

QUEUE-144 context listeners as a literal descendant of QUEUE-143 and QUEUE-146. Keep draft for independent review of both the feature and its composition with the lower stack.

## Scope

- Resolve the authoritative ordinary-write destination before notification, and keep listener context and triggering data in that cycle under the Queue write lock.
- Use appender-local lifecycle state and actual cycle identity; metadata and exact-index recovery do not notify or consume ordinary listener registration.
- Fail closed on callback failure, incomplete output and explicit rollback. Successful committed listener output remains successful if subsequent application-header acquisition fails.
- Guard callback escape through mutable Queue/appender operations, including other instances on the same canonical path, while retaining internal indexing access under the held lock.
- Preserve caller ownership, nested/held document handling, retained method writers, reset semantics and delayed automatic closes.
- Reject unsupported encoded, encrypted, asynchronous and double-buffered modes consistently. Named-tailer context reconstruction and buffered listener support remain deferred.

## Review corrections and evidence

- `documentApplicationHeaderFailureDoesNotRepeatSuccessfulListener` and `rawApplicationHeaderFailureDoesNotRepeatSuccessfulListener` inject both a runtime exception and an Error at application `enterHeader`, after listener context has committed and before an application header is written. They check unchanged committed context, absent failed application data, released lock, restored count/header state, same-cycle reuse and no duplicate listener notification.
- Injection is test-only; no production fault-injection seam was added. These tests establish this specific acquisition boundary, not every possible partial Wire mutation.
- The sparse-index fallback now cites the actual discriminators: `notifiesEachAppenderWithItsOwnContextOncePerRoll` and `sequentialResetsPreserveAutomaticClosesForAppenderListener`.
- The separate index-mismatch diagnostic branch explicitly states that healthy listener tests do not reach it and explains why a public callback guard must not obscure the original index inconsistency.
- Restored inherited Q1/Q2 call-site evidence beside listener-free document and byte branches. Independent listener registration and failure policies retain separate notes.
- Moved the stranded `writeHeader` Javadoc back to its method; no artificial justification was added for that documentation-only tidy.

## Exact ancestry and local validation

- Base (#1745): `2238ed5af92863d820d96753bd07ed9f89f13b0a`.
- Head: `c5d85cc45cffa55127386ddc1ae1147e47f5e019`.
- Base equals merge base; 25 commits in the comparison, 10 changed files and no POM delta. The update preserves branch history through a normal forward merge.
- Resolved the acquisition-cleanup conflict by retaining the listener-aware `Throwable` handling and both listener and listener-free regression notes.
- Full `mvn verify` on Linux/OpenJDK 21.0.12 passed: 1,295 reported tests, zero failures/errors, 52 skipped, retries disabled. Checkstyle, Javadocs, packaging and binary compatibility passed. The `install` lifecycle also published runtime/test artifacts to an isolated local Maven repository. All 55 `ContextListenerCoreTest` methods passed.
- Wire `2026.10-SNAPSHOT` was rebuilt from merged #1280 commit `3dd7fe5983c0133703ee72f57bced9a25270eb6f`; runtime JAR SHA-256 `92803fb011f5071900f5c3b1b637cf39f6254e86b4e29f77f1256ecc96dde755`.
- CQE #957's buffered context-count test passes against this exact composed dependency: five applicable cases in each acceptor mode; two non-buffered cases are skipped per mode. The larger CQE module run remains separately qualified.

## Merge gates

Keep draft. Require fresh exact-head review, green supported-platform TeamCity results or explicit human disposition, the reviewed lower stack, the merged Wire #1280 source and immutable release dependency coordinates. The staged coordinate delta remains isolated in #1750. Local Linux success is not a supported-platform matrix and does not explain generic TeamCity failures.


</details>
