### PR TITLE
QUEUE-146: promote Queue staged/develop to develop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,10 @@
     </parent>
 
     <artifactId>chronicle-queue</artifactId>
-    <version>2026.7-SNAPSHOT</version>
+    <!-- //! This coordinated artifact line publishes the mapped highest-cycle contract used by the
+         //! QUEUE-146 stack; retaining 2026.7 would publish the changed Queue behaviour under the
+         //! superseded release coordinate. Maven coordinates have no Java-level discriminator. -->
+    <version>2026.10-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>OpenHFT/Chronicle Queue</name>
     <description>Java library for persisted low latency messaging (Java 8+)</description>
@@ -65,6 +68,9 @@
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-wire</artifactId>
+            <!-- //! Context-listener compilation requires Wire's new lifecycle API; remove this
+                 //! direct pin once the BOM includes the coordinated QUEUE-144 Wire artifact. -->
+            <version>2026.10-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,6 @@
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-wire</artifactId>
-            <!-- //! Context-listener compilation requires Wire's new lifecycle API; remove this
-                 //! direct pin once the BOM includes the coordinated QUEUE-144 Wire artifact. -->
-            <version>2026.10-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Keep Queue at the staged `2026.10-SNAPSHOT` coordinate, resolving Wire through the staged BOM. This POM PR does not contain the required Queue feature stack. The current-head Windows and Mac status failures remain unclassified without their TeamCity logs.

Keep this coordinate-only PR draft. Promotion needs one receipt binding the exact Wire, Queue and CQE sources to effective Maven models, resolved classpaths, co-built Queue main/test JARs, CQE compilation/tests and packaging. Equal snapshot names or equal main/test-JAR versions do not establish identical source or a co-build. Packaging with tests skipped does not qualify tests.

The semantic prerequisite order is merged Wire #1280, Queue #1739/#1740/#1741, Queue #1745/#1746, and CQE #956/#957, with a refreshed #960 where required. The `DelegatingAppender.contextCount()` production repair belongs in CQE #956. Do not move it into this coordinate change.

The 9 September failure below concerns the recorded older dependency composition. It is not a demonstrated compiler failure for today's feature heads, and it does not classify TeamCity failures. Later targeted feature receipts are also not a replacement for a passing full CQE run: the preceding full run recorded 1,160 executions, two failures, one error and 122 skips; its second complete acceptor-mode run did not execute. No new full composition qualification or remote publication was performed in this follow-up.

<details>
<summary>Historical 9 September staging receipt (older composition)</summary>

Keep Queue's staged artifact line at `2026.10-SNAPSHOT` so the coordinated feature layers can be exercised before develop promotion. Remove the temporary direct Wire version: it resolves to the same `2026.10-SNAPSHOT` through the actually installed staged BOM from [OpenHFT #329](https://github.com/OpenHFT/OpenHFT/pull/329).

The branch remains draft. Feature layers #1739, #1740, #1741, #1745 and #1746 remain separately reviewed; this POM PR does not incorporate their behaviour changes.

Local validation on 9 September 2026, Linux/OpenJDK 21/Maven 3.9.11: effective dependency models before/after override removal match. `mvn -o -B -Dmaven.repo.local=<isolated-repository> -DskipTests install` passes, compiling main/test sources, packaging and installing the Queue runtime/test JARs and passing binary compatibility. Tests were skipped; this is not a supported-platform or integration test receipt.

The isolated build uses BOM POM SHA-256 `d35ed429e0edcbcf771426f8a3220674223ed6aba3472b9b789ce9e7c16efc34` and Wire JAR SHA-256 `49fd03ac07e36d7289f70beb77f217c32c992b4c4ed6416259a65c0d3b7c0b3f`. The Wire artifact does not establish its immutable source revision. No remote artifacts were published.

[CQE #963](https://github.com/ChronicleEnterprise/Chronicle-Queue-Enterprise/pull/963) fails compilation against this composition because three appender classes inherit conflicting `contextCount()` defaults. Keep promotion draft until the intended Wire/Queue/CQE source stack compiles, passes coordinated tests and has recorded artifact/source identities. The locally installed BOM is the verified dependency input; shared remote BOM contents are not assumed equivalent.

</details>
