### PR TITLE
QUEUE-148: remediate table-store corruption handling

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/TableStore.java
@@ -73,6 +73,9 @@ public interface TableStore<T extends Metadata> extends CommonStore, ManagedClos
      * @param <R>  result type
      * @return result of code block execution
      */
+    //! SingleTableStoreLockTest#exclusiveBodyRunsOnceAndPreservesRuntimeExceptionAndErrorIdentity and
+    //! #sharedBodyRunsOnceAndPreservesRuntimeExceptionAndErrorIdentity prove that a protected body runs once and its
+    //! original failure escapes. Treating a body failure as lock contention can repeat mutations before timing out.
     <R> R doWithExclusiveLock(Function<TableStore<T>, ? extends R> code);
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -19,6 +19,7 @@ import net.openhft.chronicle.core.util.ObjectUtils;
 import net.openhft.chronicle.core.util.Updater;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.queue.impl.*;
+import net.openhft.chronicle.queue.impl.table.CorruptTableStoreException;
 import net.openhft.chronicle.queue.impl.table.ReadonlyTableStore;
 import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
 import net.openhft.chronicle.queue.internal.domestic.QueueOffsetSpec;
@@ -32,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.crypto.spec.SecretKeySpec;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.time.LocalTime;
@@ -564,9 +566,8 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
         validateRollCycle(metapath);
         SCQMeta metadata = new SCQMeta(new SCQRoll(rollCycle(), epoch(), rollTime, rollTimeZone),
                 sourceId());
+        final boolean readOnly = readOnly();
         try {
-
-            boolean readOnly = readOnly();
             metaStore = SingleTableBuilder.binary(metapath, metadata).readOnly(readOnly).build();
             // check if metadata was overridden
             SCQMeta newMeta = metaStore.metadata();
@@ -583,18 +584,37 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
             rollTime = newMeta.roll().rollTime();
             rollTimeZone = newMeta.roll().rollTimeZone();
             epoch = newMeta.roll().epoch();
+        //! Corruption remains an IORuntimeException for caller compatibility but must never enter the legacy read-only fallback:
+        //! a synthetic store would hide the damaged metadata rather than make it readable. The
+        //! SingleChronicleQueueCorruptMetadataTest#corruptMetadataBypassesReadonlyFallbackAndRemainsAnIORuntimeException test
+        //! fails if this catch is removed or reordered.
+        } catch (CorruptTableStoreException ex) {
+            throw ex;
         } catch (IORuntimeException ex) {
-            // readonly=true and file doesn't exist
-            if (OS.isWindows())
-                throw ex; // we cant have a read-only table store on windows so we have no option but to throw the ex.
-            if (ex.getMessage().equals("Metadata file not found in readOnly mode"))
-                Jvm.warn().on(getClass(), "Failback to readonly tablestore " + ex);
-            else
-                Jvm.warn().on(getClass(), "Failback to readonly tablestore", ex);
+            //! Read-only fallback exists for unavailable or not-yet-published metadata, not for arbitrary decode failures.
+            //! Falling back after a parser failure hides corrupt content behind synthetic metadata.
+            //! ReadWriteTest#testNotInitializedMetadataFile and #testNonWriteableFilesSetToReadOnly retain the intended
+            //! availability cases; the corruption tests prove malformed content still escapes.
+            final boolean missing = "Metadata file not found in readOnly mode".equals(ex.getMessage());
+            final boolean notInitialized =
+                    "Metadata file found in readOnly mode, but not initialized yet".equals(ex.getMessage());
+            final boolean inaccessible = hasCause(ex, FileNotFoundException.class);
+            if (OS.isWindows() || (!missing && !notInitialized && !inaccessible))
+                throw ex;
+
+            Jvm.warn().on(getClass(), "Failback to readonly tablestore " + ex);
 
             // Fallback to read-only table store if metadata file is not found
             metaStore = new ReadonlyTableStore<>(metadata);
         }
+    }
+
+    private static boolean hasCause(Throwable failure, Class<? extends Throwable> causeType) {
+        for (Throwable cause = failure; cause != null && cause != cause.getCause(); cause = cause.getCause()) {
+            if (causeType.isInstance(cause))
+                return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.queue.impl.*;
 import net.openhft.chronicle.queue.impl.table.CorruptTableStoreException;
 import net.openhft.chronicle.queue.impl.table.ReadonlyTableStore;
 import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
+import net.openhft.chronicle.queue.impl.table.TableStoreUnavailableException;
 import net.openhft.chronicle.queue.internal.domestic.QueueOffsetSpec;
 import net.openhft.chronicle.threads.MediumEventLoop;
 import net.openhft.chronicle.threads.Pauser;
@@ -33,7 +34,6 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.crypto.spec.SecretKeySpec;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.time.LocalTime;
@@ -558,8 +558,10 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     }
 
     /**
-     * Initializes the metadata for the queue, including roll cycle and metadata overrides.
-     * If in read-only mode and the metadata file is not found, falls back to a read-only table store.
+     * Initializes the queue metadata and applies its persisted roll-cycle and source-id overrides.
+     * On non-Windows platforms, a provenance-bearing table-store availability failure while opening or awaiting the
+     * metadata file uses caller-supplied metadata through a synthetic read-only store. This includes a writable request
+     * whose metadata file cannot be opened for writing. Corrupt content and failures after the store has opened propagate.
      */
     protected void initializeMetadata() {
         File metapath = metapath();
@@ -569,37 +571,20 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
         final boolean readOnly = readOnly();
         try {
             metaStore = SingleTableBuilder.binary(metapath, metadata).readOnly(readOnly).build();
-            // check if metadata was overridden
-            SCQMeta newMeta = metaStore.metadata();
-            sourceId(newMeta.sourceId());
-
-            // If the roll cycle has been overridden, adjust it
-            String format = newMeta.roll().format();
-            if (!format.equals(rollCycle().format())) {
-                // roll cycle changed
-                overrideRollCycleForFileName(format);
-            }
-
-            // if it was overridden - reset
-            rollTime = newMeta.roll().rollTime();
-            rollTimeZone = newMeta.roll().rollTimeZone();
-            epoch = newMeta.roll().epoch();
         //! Corruption remains an IORuntimeException for caller compatibility but must never enter the legacy read-only fallback:
         //! a synthetic store would hide the damaged metadata rather than make it readable. The
         //! SingleChronicleQueueCorruptMetadataTest#corruptMetadataBypassesReadonlyFallbackAndRemainsAnIORuntimeException test
         //! fails if this catch is removed or reordered.
         } catch (CorruptTableStoreException ex) {
             throw ex;
-        } catch (IORuntimeException ex) {
-            //! Read-only fallback exists for unavailable or not-yet-published metadata, not for arbitrary decode failures.
-            //! Falling back after a parser failure hides corrupt content behind synthetic metadata.
-            //! ReadWriteTest#testNotInitializedMetadataFile and #testNonWriteableFilesSetToReadOnly retain the intended
-            //! availability cases; the corruption tests prove malformed content still escapes.
-            final boolean missing = "Metadata file not found in readOnly mode".equals(ex.getMessage());
-            final boolean notInitialized =
-                    "Metadata file found in readOnly mode, but not initialized yet".equals(ex.getMessage());
-            final boolean inaccessible = hasCause(ex, FileNotFoundException.class);
-            if (OS.isWindows() || (!missing && !notInitialized && !inaccessible))
+        } catch (TableStoreUnavailableException ex) {
+            //! Fall back only on non-Windows for the dedicated availability failure emitted while opening or awaiting the
+            //! metadata file. A writable request whose existing metadata is not writable deliberately becomes read-only.
+            //! Walking arbitrary decoder causes for FileNotFoundException lets persisted constructors disguise malformed
+            //! content as absence. SingleChronicleQueueCorruptMetadataTest
+            //! #nestedFileNotFoundFromMetadataDoesNotActivateReadonlyFallback and
+            //! ReadWriteTest#testNonWriteableFilesSetToReadOnly discriminate the provenance boundary.
+            if (OS.isWindows())
                 throw ex;
 
             Jvm.warn().on(getClass(), "Failback to readonly tablestore " + ex);
@@ -607,14 +592,26 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
             // Fallback to read-only table store if metadata file is not found
             metaStore = new ReadonlyTableStore<>(metadata);
         }
-    }
 
-    private static boolean hasCause(Throwable failure, Class<? extends Throwable> causeType) {
-        for (Throwable cause = failure; cause != null && cause != cause.getCause(); cause = cause.getCause()) {
-            if (causeType.isInstance(cause))
-                return true;
+        //! Keep availability handling around the provenance-known build call only. Metadata access and roll/source overrides
+        //! are extensible post-open policy; a TableStoreUnavailableException thrown there must not activate synthetic fallback.
+        //! SingleChronicleQueueCorruptMetadataTest#metadataAccessorUnavailabilityDoesNotActivateReadonlyFallback
+        //! discriminates this catch-scope boundary.
+        // check if metadata was overridden
+        SCQMeta newMeta = metaStore.metadata();
+        sourceId(newMeta.sourceId());
+
+        // If the roll cycle has been overridden, adjust it
+        String format = newMeta.roll().format();
+        if (!format.equals(rollCycle().format())) {
+            // roll cycle changed
+            overrideRollCycleForFileName(format);
         }
-        return false;
+
+        // if it was overridden - reset
+        rollTime = newMeta.roll().rollTime();
+        rollTimeZone = newMeta.roll().rollTimeZone();
+        epoch = newMeta.roll().epoch();
     }
 
     /**
@@ -1507,9 +1504,13 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
     protected void preBuild() {
         try {
             initializeMetadata();
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
+            //! Metadata access remains extensible after the store opens and can throw any Throwable through sneaky-throw APIs.
+            //! Close the assigned store without replacing its exact failure.
+            //! SingleChronicleQueueCorruptMetadataTest#metadataAccessorFailuresRetainIdentityAndReleaseTheMapping
+            //! covers Error and checked-exception identities.
             Closeable.closeQuietly(metaStore);
-            throw ex;
+            throw Jvm.rethrow(ex);
         }
         if ((epoch == null || epoch == 0) && (rollTime != null && rollTimeZone != null))
             // Reset roll time if epoch is unset but rollTime and rollTimeZone are provided

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/CorruptTableStoreException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/CorruptTableStoreException.java
@@ -3,19 +3,24 @@
  */
 package net.openhft.chronicle.queue.impl.table;
 
+import net.openhft.chronicle.core.io.IORuntimeException;
+
 import java.io.File;
 
+//! Keep corruption in the established IORuntimeException family so existing broad caller catches remain compatible.
+//! SingleChronicleQueueCorruptMetadataTest#corruptMetadataBypassesReadonlyFallbackAndRemainsAnIORuntimeException
+//! fails if the queue builder hides this subtype behind its read-only fallback or the subtype leaves that family.
 /**
  * Thrown when a table store file cannot be read because its content is not consistent.
  * <p>
  * The queue throws this as soon as it finds the fault. It does not retry, because no
  * number of retries makes a corrupt file readable.
  * <p>
- * This is not an {@link net.openhft.chronicle.core.io.IORuntimeException}. The queue builder
- * catches that type and falls back to a read-only table store. Corruption must not take that
- * path.
+ * This subtype remains an {@link IORuntimeException} so existing broad I/O failure handlers
+ * continue to catch it. Queue construction nevertheless propagates corruption instead of
+ * activating the legacy read-only table-store fallback.
  */
-public class CorruptTableStoreException extends IllegalStateException {
+public class CorruptTableStoreException extends IORuntimeException {
     private static final long serialVersionUID = 0L;
 
     /**

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
@@ -4,6 +4,7 @@
 package net.openhft.chronicle.queue.impl.table;
 
 import net.openhft.chronicle.bytes.MappedBytes;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.Closeable;
@@ -81,6 +82,11 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
 
     @NotNull
     public TableStore<T> build() {
+        //! Table stores require a bounded, addressable long representation. Text-family wires can write a binding outside
+        //! the declared body, while auto-detect cannot define a write format. RAW retains its bounded legacy initial-open
+        //! path; its pre-existing typed-header reopen limitation is separate. SingleTableStoreCorruptRecordTest
+        //! #unsupportedWireTypesAreRejectedBeforeCreatingAFile proves fail-fast has no filesystem side effect.
+        SingleTableStore.requireSupportedWireType(wireType);
         if (readOnly) {
             if (!file.exists())
                 throw new IORuntimeException("Metadata file not found in readOnly mode");
@@ -97,7 +103,10 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         }
 
         MappedBytes bytes = null;
-        boolean built = false;
+        //! The builder owns this mapping until a complete TableStore is returned; every earlier failure must close it.
+        //! SingleTableBuilderCorruptMetadataTest#failedHeaderDecodePreservesTheFileAndReleasesTheMapping fails if this
+        //! ownership guard is removed, because the failed mapping keeps the table-store file open on affected platforms.
+        boolean handedOver = false;
         try {
             if (!readOnly && file.createNewFile() && !file.canWrite()) {
                 throw new IllegalStateException("Cannot write to tablestore file " + file);
@@ -134,53 +143,125 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
                     }
                 }, () -> null);
             }
-            built = true;
+            //! Transfer mapping ownership only after the locked body returns a complete store; doing so earlier leaks failures
+            //! from first-header decoding or metadata override. The
+            //! SingleTableBuilderCorruptMetadataTest#metadataOverrideFailureRetainsIdentityAndReleasesTheMapping test
+            //! discriminates this ordering.
+            handedOver = true;
             return store;
         } catch (IOException e) {
             throw new IORuntimeException("file=" + file.getAbsolutePath(), e);
         } finally {
             if (bytes != null) {
-                bytes.singleThreadedCheckReset();
-                // no table store took ownership of the mapping, so nothing else will release it
-                if (!built)
-                    bytes.close();
+                // A provisional store closes the same mapping when construction fails after deserialisation.
+                if (!bytes.isClosed()) {
+                    bytes.singleThreadedCheckReset();
+                    // no table store took ownership of the mapping, so nothing else will release it
+                    if (!handedOver)
+                        bytes.close();
+                }
             }
         }
     }
 
     @NotNull
     private TableStore<T> readTableStore(Wire wire) throws StreamCorruptedException {
+        final TableStore<T> existing = decodeTableStore(wire);
+        boolean handedOver = false;
+        try {
+            //! Metadata override is caller policy, not evidence that bytes on disk are corrupt; it must retain its original
+            //! failure type. SingleTableBuilderCorruptMetadataTest#metadataOverrideFailureRetainsIdentityAndReleasesTheMapping
+            //! fails if override is moved back inside first-header corruption translation.
+            metadata.overrideFrom(existing.metadata());
+            handedOver = true;
+            return existing;
+        } finally {
+            //! Deserialisation can create a TableStore before a later policy failure, so close that provisional owner unless
+            //! returned. SingleTableBuilderCorruptMetadataTest#metadataOverrideFailureRetainsIdentityAndReleasesTheMapping
+            //! fails if this cleanup is removed.
+            if (!handedOver)
+                Closeable.closeQuietly(existing);
+        }
+    }
+
+    @NotNull
+    @SuppressWarnings("unchecked")
+    private TableStore<T> decodeTableStore(Wire wire) throws StreamCorruptedException {
+        Object decoded = null;
         TableStore<T> existing = null;
         boolean handedOver = false;
         try {
+            //! Confine corruption translation to failures that identify the bounded on-disk header or its required type.
+            //! Persisted constructors are application hooks, so an arbitrary RuntimeException from one must retain Wire's
+            //! original failure chain rather than being relabelled as disk corruption.
+            //! SingleTableBuilderCorruptMetadataTest#unknownTypeAliasIsReportedAsCorruption and
+            //! #nestedMetadataAliasAndConstructorFailuresAreNotMisreportedAsCorruption discriminate the outer/nested
+            //! classification boundary;
+            //! SingleChronicleQueueCorruptMetadataTest#aCorruptFirstHeaderFailsWithoutWaitingForTheTableStoreLock
+            //! fails if the terminal decode failure is allowed to re-enter lock acquisition.
             wire.readFirstHeader();
             // readFirstHeader limits the read to the length that the first header declares
             final long declaredEnd = wire.bytes().readLimit();
 
             final ValueIn valueIn = readTableStoreValue(wire);
-            existing = valueIn.typedMarshallable();
-            if (existing == null)
-                throw new CorruptTableStoreException(file, "the first header holds no table store");
+            decoded = valueIn.typedMarshallable();
+            //! Decode without an inferred TableStore cast, then validate the result explicitly; otherwise a valid typed value
+            //! of the wrong class escapes as ClassCastException and can activate the queue builder's read-only fallback.
+            //! SingleTableBuilderCorruptMetadataTest#nullAndWrongTypedHeaderValuesAreReportedAsCorruption covers both forms.
+            if (!(decoded instanceof TableStore)) {
+                final String actualType = decoded == null ? "null" : decoded.getClass().getName();
+                throw new CorruptTableStoreException(file,
+                        "the first header holds " + actualType + " instead of a table store");
+            }
+            existing = (TableStore<T>) decoded;
 
             // Every later scan of this file uses the declared length. If the length disagrees with
             // the content that it describes, the whole file is misaligned.
+            //! Later record scans begin at the declared end, so a decoded header must consume that boundary exactly; accepting
+            //! trailing or over-consumed bytes misaligns every record.
+            //! SingleChronicleQueueCorruptMetadataTest#aCorruptFirstHeaderThrowsCorruptTableStoreException discriminates the
+            //! declared-versus-consumed check; #anIntactMetadataFileStillBuildsAndReadsBack guards the current healthy encoding.
             final long actualEnd = wire.bytes().readPosition();
             if (actualEnd != declaredEnd)
                 throw new CorruptTableStoreException(file, "the first header declares " + declaredEnd
                         + " bytes but its content ends at " + actualEnd);
 
-            metadata.overrideFrom(existing.metadata());
             handedOver = true;
             return existing;
-        } catch (StreamCorruptedException | BufferUnderflowException | OverlappingFileLockException e) {
-            // a corrupt length can move the read past the mapped region, and the mapping then takes
-            // a file lock that overlaps the lock this thread already holds
+        } catch (CorruptTableStoreException e) {
+            throw e;
+        } catch (StreamCorruptedException | BufferUnderflowException | ClassNotFoundRuntimeException |
+                 OverlappingFileLockException e) {
+            //! Event-name, type-alias and bounded-underflow failures arise before any caller policy hook and identify an
+            //! unreadable first header. A malformed nested length can also force mapped-chunk acquisition while this file's
+            //! table-store lock is held and surface OverlappingFileLockException at this exact boundary.
+            //! SingleTableBuilderCorruptMetadataTest#malformedFirstEventNameIsReportedAsCorruption
+            //! and SingleChronicleQueueCorruptMetadataTest#aCorruptHeaderBodyIsReportedAsCorruptionAndReleasesTheMapping
+            //! distinguish these parser failures from metadata-constructor and override failures; the nested-constructor
+            //! test proves an application-thrown overlap signal remains outside this direct decode classification.
             throw new CorruptTableStoreException(file, "the first header does not hold a readable table store", e);
+        } catch (RuntimeException e) {
+            final CorruptTableStoreException corruption = findCorruption(e);
+            if (corruption != null)
+                throw corruption;
+            throw e;
         } finally {
-            // the caller takes ownership of the table store only when this method returns it
+            //! A typed value can construct a closeable object before type or boundary validation fails; the outer builder
+            //! cannot close an object it never receives. SingleTableBuilderCorruptMetadataTest
+            //! #wrongCloseableHeaderValueIsClosedOnRejection and
+            //! #partialStoreConstructionIsCorruptionAndReleasesTheMapping exercise the wrong-type and provisional-store
+            //! cleanup edges.
             if (!handedOver)
-                Closeable.closeQuietly(existing);
+                Closeable.closeQuietly(existing != null ? existing : decoded);
         }
+    }
+
+    private CorruptTableStoreException findCorruption(Throwable failure) {
+        for (Throwable cause = failure; cause != null && cause != cause.getCause(); cause = cause.getCause()) {
+            if (cause instanceof CorruptTableStoreException)
+                return (CorruptTableStoreException) cause;
+        }
+        return null;
     }
 
     private ValueIn readTableStoreValue(@NotNull Wire wire) throws StreamCorruptedException {
@@ -196,10 +277,21 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
 
     @NotNull
     private TableStore<T> writeTableStore(MappedBytes bytes, Wire wire) {
-        TableStore<T> store = new SingleTableStore<>(wireType, bytes, metadata);
-        wire.writeEventName("header").object(store);
-        wire.updateFirstHeader();
-        return store;
+        final TableStore<T> store = new SingleTableStore<>(wireType, bytes, metadata);
+        boolean handedOver = false;
+        try {
+            wire.writeEventName("header").object(store);
+            wire.updateFirstHeader();
+            handedOver = true;
+            return store;
+        } finally {
+            //! Construction registers the new store before caller metadata is serialised and the first header is published.
+            //! SingleTableBuilderCorruptMetadataTest#failedInitialMetadataWriteClosesTheProvisionalStore fails through
+            //! resource tracing if metadata serialisation leaves that unreachable store open. Header-publication failure
+            //! follows the same finally edge but has no injectable public seam.
+            if (!handedOver)
+                Closeable.closeQuietly(store);
+        }
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
@@ -4,13 +4,14 @@
 package net.openhft.chronicle.queue.impl.table;
 
 import net.openhft.chronicle.bytes.MappedBytes;
-import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
+import net.openhft.chronicle.bytes.PageUtil;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.scoped.ScopedResource;
 import net.openhft.chronicle.core.util.Builder;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import net.openhft.chronicle.core.util.StringUtils;
 import net.openhft.chronicle.queue.impl.TableStore;
 import net.openhft.chronicle.queue.impl.single.MetaDataKeys;
@@ -23,8 +24,11 @@ import net.openhft.chronicle.wire.Wires;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.io.StreamCorruptedException;
+import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Path;
@@ -33,6 +37,19 @@ import java.util.concurrent.TimeoutException;
 
 import static net.openhft.chronicle.core.pool.ClassAliasPool.CLASS_ALIASES;
 
+/**
+ * Builds the Queue table store persisted in a {@code .cq4t} file.
+ *
+ * <p>{@link WireType#BINARY_LIGHT} is the canonical format. {@link WireType#BINARY} remains an accepted
+ * legacy selector, but table stores use only the subset shared with {@code BINARY_LIGHT}.
+ * {@link WireType#READ_ANY} may select an existing read-only store; it is never a persisted format.
+ * Other Wire types are not supported for table stores, even when they are supported for queue data.</p>
+ *
+ * <p>An existing first header must contain Queue's {@link SingleTableStore} persisted schema.
+ * Implementations of the broader {@link TableStore} interface are not accepted from disk.</p>
+ *
+ * @param <T> metadata type stored in the table header
+ */
 public class SingleTableBuilder<T extends Metadata> implements Builder<TableStore<T>> {
 
     static {
@@ -53,6 +70,17 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         this.metadata = metadata;
     }
 
+    /**
+     * Creates a builder with an explicit table-store format selector.
+     *
+     * @param file     table-store file
+     * @param wireType {@code BINARY_LIGHT}, the legacy {@code BINARY} selector restricted to the same common subset,
+     *                 or {@code READ_ANY} for read-only opening
+     * @param metadata metadata used for a new store and overridden from an existing store
+     * @param <T>      metadata type
+     * @return a new builder
+     * @throws IllegalArgumentException if {@code file} is not a {@code .cq4t} path
+     */
     @NotNull
     public static <T extends Metadata> SingleTableBuilder<T> builder(@NotNull File file, @NotNull WireType wireType, @NotNull T metadata) {
         if (file.isDirectory()) {
@@ -80,16 +108,26 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         return builder(basePathFile, WireType.BINARY_LIGHT, metadata);
     }
 
+    /**
+     * Opens or creates the configured table store.
+     *
+     * @return the opened store
+     * @throws IllegalArgumentException if the selected Wire type is unsupported or {@code READ_ANY} is writable
+     * @throws CorruptTableStoreException if an existing first header violates the table-store schema
+     * @throws TableStoreUnavailableException if the metadata file is unavailable at the file-opening boundary, or a read-only
+     *                                        file is absent or uninitialized
+     */
     @NotNull
     public TableStore<T> build() {
-        //! Table stores require a bounded, addressable long representation. Text-family wires can write a binding outside
-        //! the declared body, while auto-detect cannot define a write format. RAW retains its bounded legacy initial-open
-        //! path; its pre-existing typed-header reopen limitation is separate. SingleTableStoreCorruptRecordTest
-        //! #unsupportedWireTypesAreRejectedBeforeCreatingAFile proves fail-fast has no filesystem side effect.
-        SingleTableStore.requireSupportedWireType(wireType);
+        //! Separate read detection from persistent write formats. READ_ANY may inspect an existing read-only binary store but
+        //! cannot select the encoding for a new or writable store. BINARY_LIGHT is canonical; BINARY is a legacy-compatible
+        //! selector, but table stores use no BINARY-only features. Fieldless, compressed, RAW and text are unsupported here.
+        //! SingleTableStoreCorruptRecordTest#readAnyReopensExistingBinaryTableStore and
+        //! #unsupportedWritableWireTypesFailBeforeCreatingAFile discriminate the two capabilities.
+        SingleTableStore.requireSelectedWireType(wireType, readOnly);
         if (readOnly) {
             if (!file.exists())
-                throw new IORuntimeException("Metadata file not found in readOnly mode");
+                throw new TableStoreUnavailableException(file, "Metadata file not found in readOnly mode");
 
             // Wait a short time for the file to be initialized
             TimingPauser pauser = Pauser.balanced();
@@ -98,7 +136,8 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
                     pauser.pause(1, TimeUnit.SECONDS);
                 }
             } catch (TimeoutException e) {
-                throw new IORuntimeException("Metadata file found in readOnly mode, but not initialized yet");
+                throw new TableStoreUnavailableException(file,
+                        "Metadata file found in readOnly mode, but not initialized yet", e);
             }
         }
 
@@ -108,23 +147,88 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         //! ownership guard is removed, because the failed mapping keeps the table-store file open on affected platforms.
         boolean handedOver = false;
         try {
-            if (!readOnly && file.createNewFile() && !file.canWrite()) {
-                throw new IllegalStateException("Cannot write to tablestore file " + file);
+            final int mappingPageSize = PageUtil.getPageSize(file.getAbsolutePath());
+            final long mappedChunkSize = OS.mapAlign(OS.SAFE_PAGE_SIZE, mappingPageSize);
+            final long firstWritableMappingSize = 2L * mappedChunkSize;
+            if (!readOnly) {
+                final boolean created = file.createNewFile();
+                if (created && !file.canWrite())
+                    throw new IllegalStateException("Cannot write to tablestore file " + file);
+
+                //! A writable mapping grows a short file while acquiring its first chunk. Reject a ready first header whose
+                //! declared body is physically truncated before mapping, while retaining compact files whose header is whole.
+                //! SingleTableBuilderCorruptMetadataTest#failedWritableOpenDoesNotGrowTruncatedMetadata discriminates
+                //! this pre-mapping boundary; #compactCompleteTableStoreReopensReadOnly records the positive compact case.
+                if (!created && file.length() > 0L && file.length() < firstWritableMappingSize)
+                    validateFirstHeaderBeforeWritableMapping();
             }
             // TODO Change this to a single chunk file in x.28
-            bytes = MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, readOnly);
+            final long readBound;
+            try {
+                if (readOnly) {
+                    final long physicalLength = file.length();
+                    //! Inspect a ready first header before creating a rounded native read-only mapping. This makes a declared
+                    //! end beyond EOF a Java-level corruption result on every platform rather than relying on an OS mapping.
+                    //! SingleTableBuilderCorruptMetadataTest#readOnlyOpenRejectsHeaderBeyondPhysicalFileWithoutMutation
+                    //! exercises the pre-mapping boundary and verifies that the original file is unchanged.
+                    validateFirstHeaderBeforeMapping(physicalLength);
+                    //! A page-aligned compact store can use an exact single read-only mapping without mapping beyond EOF; it
+                    //! is an opening snapshot. Normal preallocated stores retain chunked mappings so long-lived readers can
+                    //! observe later appends and growth.
+                    //! SingleTableBuilderCorruptMetadataTest#readOnlyOpenRejectsHeaderBeyondPhysicalFileWithoutMutation
+                    //! exercises the pre-map bound; #compactCompleteTableStoreReopensReadOnly covers the compact snapshot and
+                    //! SingleTableStoreCorruptRecordTest#readOnlyStoreOpenedBeforeGrowthSeesLaterKeys protects normal growth.
+                    final boolean compactSnapshot = physicalLength < firstWritableMappingSize
+                            && physicalLength % mappingPageSize == 0L;
+                    bytes = compactSnapshot
+                            ? MappedBytes.singleMappedBytes(file, physicalLength, true)
+                            : MappedBytes.mappedBytes(
+                                    file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, mappingPageSize, true);
+                    if (compactSnapshot)
+                        bytes.writeLimit(physicalLength);
+                    bytes.readLimit(physicalLength);
+                    readBound = physicalLength;
+                } else {
+                    bytes = MappedBytes.mappedBytes(
+                            file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, mappingPageSize, false);
+                    // A concurrent creator can publish the first header while this builder waits for the lock.
+                    // The current physical bound is therefore captured inside the exclusive body below.
+                    readBound = -1L;
+                }
+            } catch (FileNotFoundException e) {
+                //! Translate only the file-opening boundary to availability. Decoder constructors may themselves nest a
+                //! FileNotFoundException, but that does not prove the metadata file was absent or inaccessible.
+                //! SingleChronicleQueueCorruptMetadataTest#nestedFileNotFoundFromMetadataDoesNotActivateReadonlyFallback
+                //! fails if cause provenance is inferred outside this scope.
+                throw new TableStoreUnavailableException(file, "Metadata file is unavailable", e);
+            }
             // these MappedBytes are shared, but the assumption is they shouldn't grow. Supports 2K entries.
             bytes.singleThreadedCheckDisabled(true);
 
-            // eagerly initialize backing MappedFile page - otherwise wire.writeFirstHeader() will try to lock the file
-            // to allocate the first byte store and that will cause lock overlap
-            bytes.readVolatileInt(0);
-            Wire wire = wireType.apply(bytes);
+            // Writable mappings must initialize their first page before taking the table-store lock; otherwise
+            // wire.writeFirstHeader() can take the mapped-file growth lock underneath it. Read-only mappings never grow.
+            if (!readOnly)
+                bytes.readVolatileInt(0);
+            //! BINARY is retained as a selector/header label only. Use the BINARY_LIGHT codec for both labels so a future
+            //! legacy codec change cannot introduce BINARY-only features into table-store content.
+            //! SingleTableStoreCorruptRecordTest#canonicalAndLegacySelectorsCrossOpenWritableAndReadOnlyStores covers both.
+            Wire wire = (wireType == WireType.READ_ANY ? WireType.READ_ANY : WireType.BINARY_LIGHT).apply(bytes);
             final TableStore<T> store;
             if (readOnly) {
+                final MappedBytes readOnlyBytes = bytes;
                 store = SingleTableStore.doWithSharedLock(file, v -> {
                     try {
-                        return readTableStore(wire);
+                        //! Re-clamp the snapshot after taking the cooperative table-store lock, before the first mapped read.
+                        //! A process that ignores this lock can still truncate an active mapping; Queue does not claim to make
+                        //! arbitrary external file mutation safe. The physical-bound and compact-positive tests cover the
+                        //! deterministic boundaries under Queue's locking protocol.
+                        final long lockedReadBound = Math.min(
+                                readBound, readOnlyBytes.mappedFile().actualSize());
+                        //! Clamp the captured Bytes directly. Calling ReadAnyWire.bytes() first can trigger format detection
+                        //! against the old limit and touch stale mapped bytes before this bound takes effect.
+                        readOnlyBytes.readPosition(0L);
+                        readOnlyBytes.readLimit(lockedReadBound);
+                        return readTableStore(readOnlyBytes, wire, lockedReadBound);
                     } catch (IOException ex) {
                         throw Jvm.rethrow(ex);
                     }
@@ -136,7 +240,11 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
                         if (wire.writeFirstHeader()) {
                             return writeTableStore(finalBytes, wire);
                         } else {
-                            return readTableStore(wire);
+                            //! A builder can observe the file before a concurrent creator publishes its first header, then
+                            //! acquire the lock afterwards. Read the mapped channel's size under that lock rather than reusing
+                            //! the pre-lock observation. RollCycleMultiThreadStressTest#stress exercises that publication race.
+                            final long lockedReadBound = finalBytes.mappedFile().actualSize();
+                            return readTableStore(finalBytes, wire, lockedReadBound);
                         }
                     } catch (IOException ex) {
                         throw Jvm.rethrow(ex);
@@ -165,16 +273,23 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
     }
 
     @NotNull
-    private TableStore<T> readTableStore(Wire wire) throws StreamCorruptedException {
-        final TableStore<T> existing = decodeTableStore(wire);
+    private TableStore<T> readTableStore(MappedBytes mappedBytes,
+                                         Wire wire,
+                                         long readBound) throws StreamCorruptedException {
+        final TableStore<T> existing = decodeTableStore(mappedBytes, wire, readBound);
         boolean handedOver = false;
         try {
-            //! Metadata override is caller policy, not evidence that bytes on disk are corrupt; it must retain its original
-            //! failure type. SingleTableBuilderCorruptMetadataTest#metadataOverrideFailureRetainsIdentityAndReleasesTheMapping
+            //! Metadata override is caller policy, not evidence that bytes on disk are corrupt; ordinary failures retain their
+            //! original type. SingleTableBuilderCorruptMetadataTest#metadataOverrideFailureRetainsIdentityAndReleasesTheMapping
             //! fails if override is moved back inside first-header corruption translation.
             metadata.overrideFrom(existing.metadata());
             handedOver = true;
             return existing;
+        } catch (TableStoreUnavailableException e) {
+            //! Only file opening may authorize synthetic fallback. An override can rethrow an availability signal obtained
+            //! from another operation, so preserve that reserved type as a cause rather than as this build's opening outcome.
+            //! SingleTableBuilderCorruptMetadataTest#metadataOverrideCannotOriginateAnAvailabilitySignal loses this boundary.
+            throw new IORuntimeException("Persisted table-store metadata override failed", e);
         } finally {
             //! Deserialisation can create a TableStore before a later policy failure, so close that provisional owner unless
             //! returned. SingleTableBuilderCorruptMetadataTest#metadataOverrideFailureRetainsIdentityAndReleasesTheMapping
@@ -185,52 +300,115 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
     }
 
     @NotNull
-    @SuppressWarnings("unchecked")
-    private TableStore<T> decodeTableStore(Wire wire) throws StreamCorruptedException {
-        Object decoded = null;
+    private TableStore<T> decodeTableStore(MappedBytes mappedBytes,
+                                           Wire wire,
+                                           long readBound) throws StreamCorruptedException {
         TableStore<T> existing = null;
         boolean handedOver = false;
         try {
             //! Confine corruption translation to failures that identify the bounded on-disk header or its required type.
-            //! Persisted constructors are application hooks, so an arbitrary RuntimeException from one must retain Wire's
-            //! original failure chain rather than being relabelled as disk corruption.
+            //! Persisted constructors are application hooks, so their RuntimeException chain or Error cause must not be
+            //! relabelled as disk corruption. #metadataConstructorErrorRetainsCauseAndReleasesTheMapping covers Error;
             //! SingleTableBuilderCorruptMetadataTest#unknownTypeAliasIsReportedAsCorruption and
             //! #nestedMetadataAliasAndConstructorFailuresAreNotMisreportedAsCorruption discriminate the outer/nested
             //! classification boundary;
             //! SingleChronicleQueueCorruptMetadataTest#aCorruptFirstHeaderFailsWithoutWaitingForTheTableStoreLock
             //! fails if the terminal decode failure is allowed to re-enter lock acquisition.
+            //! READ_ANY must not inspect the SPB header as if it were the first Wire token. Validate through the captured
+            //! Bytes, then let readFirstHeader move to the body before READ_ANY performs format detection.
+            //! SingleTableStoreCorruptRecordTest#readAnyIgnoresFieldCodeBytesInTheFirstHeader loses this ordering.
+            validateFirstHeaderPhysicalBound(mappedBytes, readBound);
             wire.readFirstHeader();
             // readFirstHeader limits the read to the length that the first header declares
             final long declaredEnd = wire.bytes().readLimit();
 
-            final ValueIn valueIn = readTableStoreValue(wire);
-            decoded = valueIn.typedMarshallable();
-            //! Decode without an inferred TableStore cast, then validate the result explicitly; otherwise a valid typed value
-            //! of the wrong class escapes as ClassCastException and can activate the queue builder's read-only fallback.
-            //! SingleTableBuilderCorruptMetadataTest#nullAndWrongTypedHeaderValuesAreReportedAsCorruption covers both forms.
-            if (!(decoded instanceof TableStore)) {
-                final String actualType = decoded == null ? "null" : decoded.getClass().getName();
-                throw new CorruptTableStoreException(file,
-                        "the first header holds " + actualType + " instead of a table store");
+            final long previousWriteLimit = mappedBytes.writeLimit();
+            try {
+                //! BinaryWire's nested-marshallable reader may otherwise raise readLimit as far as writeLimit. Hard-cap the
+                //! containing first header so a forged STStore length cannot borrow preallocated or later-file bytes, grow a
+                //! writable mapping, or invoke a constructor outside the declared document.
+                //! SingleTableBuilderCorruptMetadataTest#outerTableStoreFramingFailureIsCorruptionWithoutConstruction and
+                //! #oversizedOuterTableStoreLengthCannotEscapeTheFirstHeader discriminate the bounded document behavior.
+                mappedBytes.writeLimit(declaredEnd);
+
+                final ValueIn valueIn = readTableStoreValue(wire);
+                preflightTableStoreType(valueIn);
+                //! Only the trusted mapping-owning SingleTableStore schema may receive this builder mapping. Accepting any
+                //! TableStore can return an object that neither retains nor closes these MappedBytes. Consume the allowlisted
+                //! prefix and construct SingleTableStore directly so a mutable global alias cannot substitute a foreign class.
+                //! SingleTableBuilderCorruptMetadataTest#foreignTableStoreIsRejectedAndReleasesTheMapping discriminates
+                //! the persisted-schema and ownership boundaries; #remappedTableStoreAliasCannotConstructForeignImplementation
+                //! covers the global-alias losing case.
+                existing = valueIn.applyToMarshallable(nestedWire -> {
+                    final long containingWriteLimit = mappedBytes.writeLimit();
+                    try {
+                        //! Cap nested metadata parsing to the STStore marshallable body. SingleTableStore applies a still
+                        //! narrower cap before invoking an extensible metadata constructor.
+                        mappedBytes.writeLimit(mappedBytes.readLimit());
+                        try {
+                            final SingleTableStore<T> decoded = new SingleTableStore<T>(nestedWire);
+                            //! Wire normally skips unread marshallable fields. The Queue-owned STStore schema instead requires
+                            //! its complete body to be consumed, so unknown trailing fields cannot hide inside a valid outer end.
+                            //! SingleTableBuilderCorruptMetadataTest#trailingTableStoreFieldAfterMetadataIsCorruption
+                            //! fails if the enclosing Wire reader is allowed to skip those fields.
+                            if (mappedBytes.readPosition() != mappedBytes.readLimit()) {
+                                Closeable.closeQuietly(decoded);
+                                throw new SingleTableStore.SchemaCorruptionException(
+                                        "the table-store body length does not match its decoded content");
+                            }
+                            return decoded;
+                        } catch (SingleTableStore.SchemaCorruptionException e) {
+                            throw e;
+                        } catch (SingleTableStore.MetadataConstructorFailed e) {
+                            throw new TableStoreConstructorFailed(e.getCause());
+                        } catch (RuntimeException e) {
+                            throw new SingleTableStore.SchemaCorruptionException(
+                                    "the first header does not hold a readable table store", e);
+                        }
+                    } finally {
+                        mappedBytes.writeLimit(containingWriteLimit);
+                    }
+                });
+
+                // Every later scan of this file uses the declared length. If the length disagrees with
+                // the content that it describes, the whole file is misaligned.
+                //! Later record scans begin at the declared end, so a decoded header must consume that boundary exactly;
+                //! accepting trailing or over-consumed bytes misaligns every record.
+                //! SingleChronicleQueueCorruptMetadataTest#aCorruptFirstHeaderThrowsCorruptTableStoreException discriminates
+                //! the declared-versus-consumed check; #anIntactMetadataFileStillBuildsAndReadsBack guards the healthy encoding.
+                final long actualEnd = mappedBytes.readPosition();
+                if (actualEnd != declaredEnd)
+                    throw new SingleTableStore.SchemaCorruptionException(
+                            "the first header length does not match its decoded content");
+
+                handedOver = true;
+                return existing;
+            } finally {
+                mappedBytes.writeLimit(previousWriteLimit);
             }
-            existing = (TableStore<T>) decoded;
-
-            // Every later scan of this file uses the declared length. If the length disagrees with
-            // the content that it describes, the whole file is misaligned.
-            //! Later record scans begin at the declared end, so a decoded header must consume that boundary exactly; accepting
-            //! trailing or over-consumed bytes misaligns every record.
-            //! SingleChronicleQueueCorruptMetadataTest#aCorruptFirstHeaderThrowsCorruptTableStoreException discriminates the
-            //! declared-versus-consumed check; #anIntactMetadataFileStillBuildsAndReadsBack guards the current healthy encoding.
-            final long actualEnd = wire.bytes().readPosition();
-            if (actualEnd != declaredEnd)
-                throw new CorruptTableStoreException(file, "the first header declares " + declaredEnd
-                        + " bytes but its content ends at " + actualEnd);
-
-            handedOver = true;
-            return existing;
+        } catch (SingleTableStore.SchemaCorruptionException e) {
+            throw new CorruptTableStoreException(file, e.getMessage(), e);
+        } catch (TableStoreConstructorFailed e) {
+            final Throwable constructorFailure = e.getCause();
+            if (constructorFailure instanceof Error)
+                throw (Error) constructorFailure;
+            if (constructorFailure instanceof IORuntimeException
+                    && !(constructorFailure instanceof CorruptTableStoreException)
+                    && !(constructorFailure instanceof TableStoreUnavailableException))
+                throw (IORuntimeException) constructorFailure;
+            //! A metadata constructor can throw public Queue exception types, but that does not give the failure file-open
+            //! provenance. Preserve it as application-constructor context so it cannot activate read-only fallback.
+            //! SingleChronicleQueueCorruptMetadataTest#constructorAvailabilitySignalDoesNotActivateReadonlyFallback
+            //! discriminates this boundary.
+            throw new IORuntimeException("Persisted table-store constructor failed", constructorFailure);
         } catch (CorruptTableStoreException e) {
-            throw e;
-        } catch (StreamCorruptedException | BufferUnderflowException | ClassNotFoundRuntimeException |
+            //! CorruptTableStoreException is public, so extensible metadata code can throw it too. Queue-generated failures
+            //! use the package-owned marker above; preserve an application-created instance as constructor failure context
+            //! rather than promoting it as Queue's disk diagnosis.
+            //! SingleTableBuilderCorruptMetadataTest#applicationCorruptionExceptionIsNotPromoted covers direct and wrapped
+            //! application failures.
+            throw new IORuntimeException("Persisted table-store constructor threw a corruption exception", e);
+        } catch (StreamCorruptedException | BufferUnderflowException | BufferOverflowException | ClassNotFoundRuntimeException |
                  OverlappingFileLockException e) {
             //! Event-name, type-alias and bounded-underflow failures arise before any caller policy hook and identify an
             //! unreadable first header. A malformed nested length can also force mapped-chunk acquisition while this file's
@@ -239,37 +417,115 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
             //! and SingleChronicleQueueCorruptMetadataTest#aCorruptHeaderBodyIsReportedAsCorruptionAndReleasesTheMapping
             //! distinguish these parser failures from metadata-constructor and override failures; the nested-constructor
             //! test proves an application-thrown overlap signal remains outside this direct decode classification.
-            throw new CorruptTableStoreException(file, "the first header does not hold a readable table store", e);
+            throw new CorruptTableStoreException(file, "the first header does not hold a readable table store",
+                    redactedDecodeCause(e));
         } catch (RuntimeException e) {
-            final CorruptTableStoreException corruption = findCorruption(e);
-            if (corruption != null)
-                throw corruption;
-            throw e;
+            //! All extensible-constructor failures have crossed the origin marker above. Any remaining RuntimeException in
+            //! this scope came from Queue/Wire decoding or boundary enforcement and is a redacted corruption diagnosis.
+            //! SingleTableBuilderCorruptMetadataTest#outerTableStoreFramingFailureIsCorruptionWithoutConstruction
+            //! and #metadataFieldFramingFailureIsCorruptionWithoutConstruction cover the two framing levels.
+            throw new CorruptTableStoreException(file, "the first header does not hold a readable table store",
+                    redactedDecodeCause(e));
         } finally {
-            //! A typed value can construct a closeable object before type or boundary validation fails; the outer builder
-            //! cannot close an object it never receives. SingleTableBuilderCorruptMetadataTest
-            //! #wrongCloseableHeaderValueIsClosedOnRejection and
-            //! #partialStoreConstructionIsCorruptionAndReleasesTheMapping exercise the wrong-type and provisional-store
-            //! cleanup edges.
+            //! The alias preflight prevents wrong outer types from being constructed. A trusted STStore can still register
+            //! itself before a nested field or boundary fails, so close every provisional object that reached this scope.
+            //! SingleTableBuilderCorruptMetadataTest#wrongCloseableHeaderValueIsNotConstructed and
+            //! #partialStoreConstructionIsCorruptionAndReleasesTheMapping cover both ownership edges.
             if (!handedOver)
-                Closeable.closeQuietly(existing != null ? existing : decoded);
+                Closeable.closeQuietly(existing);
         }
     }
 
-    private CorruptTableStoreException findCorruption(Throwable failure) {
-        for (Throwable cause = failure; cause != null && cause != cause.getCause(); cause = cause.getCause()) {
-            if (cause instanceof CorruptTableStoreException)
-                return (CorruptTableStoreException) cause;
+    private IORuntimeException redactedDecodeCause(Throwable failure) {
+        //! Persisted event names, aliases and byte dumps must not enter the throwable chain that normal logging renders.
+        //! Preserve the decoder's failure class as bounded diagnostic context without retaining its data-bearing message.
+        //! SingleTableBuilderCorruptMetadataTest#corruptionCauseChainDoesNotExposeStoredContent covers event and alias input.
+        return new IORuntimeException("First-header decoding failed with " + failure.getClass().getName());
+    }
+
+    private void validateFirstHeaderPhysicalBound(MappedBytes mappedBytes, long readBound) {
+        if (readBound < Integer.BYTES)
+            throw new SingleTableStore.SchemaCorruptionException(
+                    "the file does not contain a complete first header");
+        final int header = mappedBytes.readVolatileInt(0L);
+        if (Wires.isReady(header) && Wires.lengthOf(header) > readBound - Integer.BYTES)
+            throw new SingleTableStore.SchemaCorruptionException(
+                    "the first header extends beyond the physical file");
+    }
+
+    private void validateFirstHeaderBeforeWritableMapping() throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+            if (raf.length() < Integer.BYTES)
+                throw new CorruptTableStoreException(file, "the file does not contain a complete first header");
+            final int header = Integer.reverseBytes(raf.readInt());
+            //! A short existing file with a nonzero unfinished header cannot be repaired by preallocating it. The regular
+            //! writer maps its initial allocation before publishing this marker; preserve the short failed-publication file.
+            //! SingleTableBuilderCorruptMetadataTest#failedWritableOpenDoesNotGrowAnIncompleteFirstHeader loses this guard.
+            if (header != 0 && !Wires.isReady(header))
+                throw new CorruptTableStoreException(file, "the file does not contain a ready first header");
+            if (Wires.isReady(header) && Wires.lengthOf(header) > raf.length() - Integer.BYTES)
+                throw new CorruptTableStoreException(file, "the first header extends beyond the physical file");
+        } catch (FileNotFoundException e) {
+            throw new TableStoreUnavailableException(file, "Metadata file is unavailable", e);
         }
-        return null;
+    }
+
+    private void validateFirstHeaderBeforeMapping(long physicalLength) throws IOException {
+        if (physicalLength < Integer.BYTES)
+            throw new CorruptTableStoreException(file,
+                    "the file does not contain a complete first header");
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+            final int header = Integer.reverseBytes(raf.readInt());
+            if (Wires.isReady(header) && Wires.lengthOf(header) > physicalLength - Integer.BYTES)
+                throw new CorruptTableStoreException(file,
+                        "the first header extends beyond the physical file");
+        }
+    }
+
+    private void preflightTableStoreType(ValueIn valueIn) {
+        //! Validate the persisted alias before reflective construction. A post-construction instanceof check still lets an
+        //! arbitrary TableStore constructor execute and temporarily hands it the builder's mapping.
+        //! SingleTableBuilderCorruptMetadataTest#nullAndWrongTypedHeaderValuesAreReportedAsCorruption covers null, scalar
+        //! and typed-but-foreign values without granting any of them construction or mapping ownership.
+        //! SingleTableBuilderCorruptMetadataTest#foreignTableStoreIsRejectedAndReleasesTheMapping fails if that constructor
+        //! runs, while direct SingleTableStore construction protects the mutable-alias case.
+        try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
+            if (!valueIn.isTyped())
+                throw new SingleTableStore.SchemaCorruptionException(
+                        "the first header does not hold the table-store schema");
+            final StringBuilder typeName = stlSb.get();
+            try {
+                valueIn.typePrefix(typeName, StringBuilder::append);
+            } catch (RuntimeException e) {
+                throw new SingleTableStore.SchemaCorruptionException(
+                        "the first header does not hold a readable table-store schema", e);
+            }
+            if (!StringUtils.isEqual(typeName, "STStore")
+                    && !StringUtils.isEqual(typeName, SingleTableStore.class.getName()))
+                throw new SingleTableStore.SchemaCorruptionException(
+                        "the first header does not hold the table-store schema");
+        }
+    }
+
+    private static final class TableStoreConstructorFailed extends RuntimeException {
+        private static final long serialVersionUID = 0L;
+
+        TableStoreConstructorFailed(Throwable cause) {
+            super(cause);
+        }
     }
 
     private ValueIn readTableStoreValue(@NotNull Wire wire) throws StreamCorruptedException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
+            //! The table-store writer emits an EVENT_NAME token for the outer `header`. BinaryWire's general read method also
+            //! accepts field names/numbers and leading comments, so validate the exact Queue-owned token before invoking it.
+            //! SingleTableBuilderCorruptMetadataTest#outerHeaderRequiresTheCanonicalEventNameToken loses this guard.
+            if (wire.bytes().peekUnsignedByte() != net.openhft.chronicle.wire.BinaryWireCode.EVENT_NAME)
+                throw new StreamCorruptedException("The first event is not encoded as the table-store header event");
             StringBuilder name = stlSb.get();
-            ValueIn valueIn = wire.readEventName(name);
+            ValueIn valueIn = wire.read(name);
             if (!StringUtils.isEqual(name, MetaDataKeys.header.name())) {
-                throw new StreamCorruptedException("The first message should be the header, was " + name);
+                throw new StreamCorruptedException("The first event name is not the table-store header");
             }
             return valueIn;
         }
@@ -303,6 +559,14 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         return wireType;
     }
 
+    /**
+     * Selects the table-store format. Use {@code BINARY_LIGHT} for new stores. {@code BINARY} remains only as a legacy
+     * selector whose table-store layout uses the same common subset; {@code READ_ANY} is valid only together with
+     * {@link #readOnly(boolean) readOnly(true)}.
+     *
+     * @param wireType format selector
+     * @return this builder
+     */
     public SingleTableBuilder<T> wireType(WireType wireType) {
         this.wireType = wireType;
         return this;

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -13,6 +13,7 @@ import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.io.ClosedIllegalStateException;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.scoped.ScopedResource;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import net.openhft.chronicle.core.util.StringUtils;
 import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.impl.TableStore;
@@ -52,6 +53,30 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     private static final long EXCLUSIVE_LOCK_START = Long.MAX_VALUE - EXCLUSIVE_LOCK_SIZE;
 
     private static final long timeoutMS = Jvm.getLong("chronicle.table.store.timeoutMS", 10_000L);
+
+    //! Use a package-owned marker for Queue-established schema failures during reflective construction. Searching for the
+    //! public corruption API in arbitrary constructor causes lets application code relabel its own failure as disk corruption.
+    //! SingleTableBuilderCorruptMetadataTest#applicationCorruptionExceptionIsNotPromoted protects that origin boundary.
+    static final class SchemaCorruptionException extends RuntimeException {
+        private static final long serialVersionUID = 0L;
+
+        SchemaCorruptionException(String message) {
+            super(message);
+        }
+
+        SchemaCorruptionException(String message, Throwable observed) {
+            super(message + " (decoder reported " + observed.getClass().getName() + ")");
+        }
+    }
+
+    static final class MetadataConstructorFailed extends RuntimeException {
+        private static final long serialVersionUID = 0L;
+
+        MetadataConstructorFailed(Throwable cause) {
+            super(cause);
+        }
+    }
+
     @NotNull
     private final WireType wireType;
     @NotNull
@@ -70,7 +95,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
      */
     @SuppressWarnings({"unused", "unchecked"})
     @UsedViaReflection
-    private SingleTableStore(@NotNull final WireIn wire) {
+    SingleTableStore(@NotNull final WireIn wire) {
         try {
             this.mappedBytes = (MappedBytes) (wire.bytes());
             this.mappedFile = mappedBytes.mappedFile();
@@ -78,37 +103,68 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             final WireType decodedWireType;
             try {
                 decodedWireType = Objects.requireNonNull(
-                        wire.read(MetaDataField.wireType).object(WireType.class),
+                        readTableStoreField(wire, MetaDataField.wireType).object(WireType.class),
                         "the table-store header has no wire type");
-            } catch (CorruptTableStoreException e) {
-                throw e;
             } catch (RuntimeException e) {
                 //! The wire type is Queue-owned schema, not an extensible constructor hook. A missing or unreadable value
                 //! proves that this header cannot describe a table store; retrying the file lock cannot repair it.
                 //! SingleTableBuilderCorruptMetadataTest#partialStoreConstructionIsCorruptionAndReleasesTheMapping
                 //! discriminates this field boundary and its partial-instance cleanup.
-                throw new CorruptTableStoreException(mappedFile.file(),
-                        "the first header has no readable wire type", e);
+                throw new SchemaCorruptionException("the first header has no readable wire type", e);
             }
             try {
-                this.wireType = requireSupportedWireType(decodedWireType);
+                this.wireType = requirePersistedWireType(decodedWireType);
             } catch (IllegalArgumentException e) {
-                throw new CorruptTableStoreException(mappedFile.file(),
-                        "the first header uses unsupported wire type " + decodedWireType, e);
+                throw new SchemaCorruptionException("the first header uses an unsupported wire type", e);
             }
 
-            wire.consumePadding();
-            if (wire.bytes().readRemaining() > 0) {
-                final Object decodedMetadata = wire.read(MetaDataField.metadata).typedMarshallable();
+            final ValueIn metadataValue;
+            try {
+                consumeTableStorePadding(wire);
+                metadataValue = wire.bytes().readRemaining() > 0
+                        ? readTableStoreField(wire, MetaDataField.metadata)
+                        : null;
+            } catch (RuntimeException e) {
+                //! Padding and the metadata field token belong to Queue's persisted schema, before any extensible constructor
+                //! is entered. SingleTableBuilderCorruptMetadataTest
+                //! #metadataFieldFramingFailureIsCorruptionWithoutConstruction fails if malformed framing is attributed to
+                //! application code or allowed to invoke that code.
+                throw new SchemaCorruptionException("the first header does not hold readable metadata", e);
+            }
+            if (metadataValue != null) {
+                final Class<? extends Metadata> metadataType = preflightMetadataType(metadataValue);
+                final Object decodedMetadata;
+                try {
+                    decodedMetadata = metadataValue.applyToMarshallable(nestedWire -> {
+                        final long containingWriteLimit = mappedBytes.writeLimit();
+                        try {
+                            //! Constrain ordinary Wire framing and reads to the metadata body's declared boundary. This is not a
+                            //! sandbox for an extensible constructor that deliberately mutates the Bytes cursor or limits.
+                            //! The outer builder has already capped this value to the containing STStore marshallable.
+                            mappedBytes.writeLimit(mappedBytes.readLimit());
+                            return Demarshallable.newInstance(metadataType, nestedWire);
+                        } catch (Throwable e) {
+                            throw new MetadataConstructorFailed(e);
+                        } finally {
+                            mappedBytes.writeLimit(containingWriteLimit);
+                        }
+                    });
+                } catch (MetadataConstructorFailed e) {
+                    throw e;
+                } catch (RuntimeException e) {
+                    //! Framing around the nested marshallable is persisted Queue schema, while only the callback invokes
+                    //! extensible application code. Keep the two origins distinct and redact parser diagnostics.
+                    //! SingleTableBuilderCorruptMetadataTest#nestedMetadataFramingFailureIsCorruptionAndRedacted
+                    //! fails if malformed framing is returned as an application failure or leaks persisted content.
+                    throw new SchemaCorruptionException("the first header does not hold readable metadata", e);
+                }
                 if (!(decodedMetadata instanceof Metadata)) {
                     //! Decode extensible metadata without an inferred cast, then reject and close the wrong type explicitly.
                     //! Otherwise the compiler-generated cast loses a decoded Closeable and leaks it behind a generic CCE.
                     //! SingleTableBuilderCorruptMetadataTest#nullAndWrongTypedNestedMetadataAreReportedAsCorruption
                     //! covers null and closeable wrong-type values.
                     Closeable.closeQuietly(decodedMetadata);
-                    throw new CorruptTableStoreException(mappedFile.file(),
-                            "the first header holds " + (decodedMetadata == null
-                                    ? "null" : decodedMetadata.getClass().getName()) + " instead of metadata");
+                    throw new SchemaCorruptionException("the first header does not hold metadata");
                 }
                 this.metadata = (T) decodedMetadata;
             } else {
@@ -117,7 +173,18 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                 this.metadata = instance;
             }
 
-            mappedWire = wireType.apply(mappedBytes);
+            try {
+                //! The Queue-owned STStore body may end with BinaryWire alignment padding, but not comments, an unrecognised
+                //! field or an arbitrary trailing value. Consume only explicit padding before the builder verifies the body end.
+                //! SingleTableBuilderCorruptMetadataTest#trailingTableStoreCommentIsCorruption loses a generic consumePadding.
+                //! #writerProducedFinalPaddingAcrossAllAlignmentsReopens covers the current writer's four alignment outcomes;
+                //! it is current-encoding compatibility evidence, not a claim about released historical fixtures.
+                consumeTableStorePadding(wire);
+            } catch (RuntimeException e) {
+                throw new SchemaCorruptionException("the table-store body has unreadable trailing padding", e);
+            }
+
+            mappedWire = WireType.BINARY_LIGHT.apply(mappedBytes);
             mappedWire.usePadding(true);
         } catch (RuntimeException | Error e) {
             //! Demarshallable construction registers this closeable before all persisted fields are decoded. If decoding
@@ -133,6 +200,69 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         singleThreadedCheckDisabled(true);
     }
 
+    private static Class<? extends Metadata> preflightMetadataType(ValueIn metadataValue) {
+        //! Resolve the persisted metadata alias before invoking its extensible constructor. This lets an unavailable alias
+        //! be reported without retaining attacker-controlled text, while a ClassNotFoundRuntimeException thrown by a known
+        //! metadata constructor remains that application's failure. SingleTableBuilderCorruptMetadataTest
+        //! #nestedMetadataAliasAndConstructorFailuresAreNotMisreportedAsCorruption discriminates both origins.
+        try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
+            if (!metadataValue.isTyped())
+                throw new SchemaCorruptionException("the first header does not hold metadata");
+            final StringBuilder typeName = stlSb.get();
+            try {
+                metadataValue.typePrefix(typeName, StringBuilder::append);
+            } catch (RuntimeException e) {
+                throw new SchemaCorruptionException("the first header does not hold readable metadata", e);
+            }
+            final Class<?> metadataType;
+            try {
+                metadataType = metadataValue.classLookup().forName(typeName);
+            } catch (ClassNotFoundRuntimeException e) {
+                throw new MetadataConstructorFailed(
+                        new IORuntimeException("The persisted table-store metadata type is unavailable"));
+            }
+            if (!Metadata.class.isAssignableFrom(metadataType))
+                throw new SchemaCorruptionException("the first header does not hold metadata");
+            return metadataType.asSubclass(Metadata.class);
+        }
+    }
+
+    private static void consumeTableStorePadding(WireIn wire) {
+        while (wire.bytes().readRemaining() > 0) {
+            final int code = wire.bytes().peekUnsignedByte();
+            if (code == BinaryWireCode.PADDING) {
+                wire.bytes().readSkip(1L);
+                continue;
+            }
+            if (code != BinaryWireCode.PADDING32)
+                return;
+            if (wire.bytes().readRemaining() < 5L)
+                throw new SchemaCorruptionException("the table-store body ends inside a padding header");
+            wire.bytes().readSkip(1L);
+            final long padding = wire.bytes().readUnsignedInt();
+            if (padding > wire.bytes().readRemaining())
+                throw new SchemaCorruptionException("the table-store body has padding beyond its declared end");
+            wire.bytes().readSkip(padding);
+        }
+    }
+
+    private static ValueIn readTableStoreField(WireIn wire, MetaDataField expected) {
+        //! STStore is a closed, ordered Queue-owned schema: general WireKey lookup scans over unknown fields and makes their
+        //! acceptance depend on where they occur. Read the immediate field and validate its name instead.
+        //! SingleTableBuilderCorruptMetadataTest#unknownTableStoreFieldsAreRejectedAtEveryPosition loses this boundary.
+        final int code = wire.bytes().peekUnsignedByte();
+        if (code != BinaryWireCode.FIELD_NAME_ANY
+                && (code < BinaryWireCode.FIELD_NAME0 || code > BinaryWireCode.FIELD_NAME31))
+            throw new SchemaCorruptionException("the table-store body does not contain the expected field");
+        try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
+            final StringBuilder actual = stlSb.get();
+            final ValueIn value = wire.read(actual);
+            if (!StringUtils.isEqual(actual, expected.name()))
+                throw new SchemaCorruptionException("the table-store body does not contain the expected field");
+            return value;
+        }
+    }
+
     /**
      * Constructs a {@code SingleTableStore} with the provided wire type, mapped bytes, and metadata.
      *
@@ -143,38 +273,49 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     SingleTableStore(@NotNull final WireType wireType,
                      @NotNull final MappedBytes mappedBytes,
                      @NotNull final T metadata) {
-        this.wireType = requireSupportedWireType(wireType);
+        this.wireType = requirePersistedWireType(wireType);
         this.metadata = metadata;
         this.mappedBytes = mappedBytes;
         this.mappedFile = mappedBytes.mappedFile();
-        mappedWire = wireType.apply(mappedBytes);
+        //! Retain the BINARY label when reading/writing its header, but use only the canonical BINARY_LIGHT record codec.
+        //! SingleTableStoreCorruptRecordTest#canonicalAndLegacyBinarySelectorsRoundTripTheCommonSubset covers both labels.
+        mappedWire = WireType.BINARY_LIGHT.apply(mappedBytes);
         mappedWire.usePadding(true);
 
         singleThreadedCheckDisabled(true);
     }
 
-    //! Apply the same fail-closed format gate to newly selected and persisted wire types. Otherwise a crafted first header
-    //! can bypass the builder's pre-file check and recreate an unbounded record reader after deserialisation.
-    //! SingleTableStoreCorruptRecordTest#unsupportedWireTypesAreRejectedBeforeCreatingAFile and
-    //! SingleTableBuilderCorruptMetadataTest#unsupportedPersistedWireTypeIsCorruptionAndReleasesTheMapping cover both edges.
-    //! SingleTableStoreCorruptRecordTest#supportedBinaryWireTypesRoundTripBoundValues proves the four BinaryWire variants
-    //! share the tagged bound-long grammar; #rawTableStoreStillScansValuesWrittenDuringItsInitialOpen preserves bounded RAW.
-    static WireType requireSupportedWireType(WireType wireType) {
+    //! BINARY_LIGHT is the canonical table-store format. BINARY remains a legacy selector, but table stores use only the
+    //! common BinaryWire subset; READ_ANY is only a selector for an existing read-only header and is never persisted.
+    //! SingleTableStoreCorruptRecordTest#unsupportedWritableWireTypesFailBeforeCreatingAFile and
+    //! #readAnyReopensExistingBinaryTableStore distinguish selection from persistence, while
+    //! SingleTableBuilderCorruptMetadataTest#unsupportedPersistedWireTypeIsCorruptionAndReleasesTheMapping covers the header.
+    //! SingleTableStoreCorruptRecordTest#canonicalAndLegacyBinarySelectorsRoundTripTheCommonSubset exercises the retained pair
+    //! against the resolved Wire version; it is not released-file evidence.
+    //! #canonicalAndLegacySelectorsCrossOpenWritableAndReadOnlyStores protects current cross-selector behavior, while
+    //! #unsupportedWritableWireTypesFailBeforeCreatingAFile covers fieldless, compressed, RAW and text families.
+    static WireType requireSelectedWireType(WireType wireType, boolean readOnly) {
+        if (readOnly && wireType == WireType.READ_ANY)
+            return wireType;
+        return requirePersistedWireType(wireType);
+    }
+
+    static WireType requirePersistedWireType(WireType wireType) {
         final WireType required = Objects.requireNonNull(wireType);
         switch (required) {
             case BINARY:
             case BINARY_LIGHT:
-            case FIELDLESS_BINARY:
-            case COMPRESSED_BINARY:
-            case RAW:
                 return required;
             default:
-                throw new IllegalArgumentException("Table stores require a binary or raw WireType, not " + required);
+                throw new IllegalArgumentException(
+                        "Table stores require BINARY_LIGHT or the legacy BINARY selector, not " + required);
         }
     }
 
     /**
      * Executes a code block with a shared lock on the specified file.
+     * A failure from the target supplier or body is rethrown as the original object after lock and channel cleanup is
+     * attempted; cleanup failures are attached to it as suppressed exceptions.
      *
      * @param file   The file to lock.
      * @param code   The function to execute with the locked file.
@@ -182,6 +323,8 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
      * @param <T>    Type of the target object.
      * @param <R>    Return type of the function.
      * @return The result of the function applied to the target.
+     * @throws IllegalStateException if lock acquisition times out, or lock/channel acquisition or cleanup fails without a
+     *                               body failure taking precedence
      */
     public static <T, R> R doWithSharedLock(@NotNull final File file,
                                             @NotNull final Function<T, ? extends R> code,
@@ -191,6 +334,8 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
     /**
      * Executes a code block with an exclusive lock on the specified file.
+     * A failure from the target supplier or body is rethrown as the original object after lock and channel cleanup is
+     * attempted; cleanup failures are attached to it as suppressed exceptions.
      *
      * @param file   The file to lock.
      * @param code   The function to execute with the locked file.
@@ -198,6 +343,8 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
      * @param <T>    Type of the target object.
      * @param <R>    Return type of the function.
      * @return The result of the function applied to the target.
+     * @throws IllegalStateException if lock acquisition times out, or lock/channel acquisition or cleanup fails without a
+     *                               body failure taking precedence
      */
     public static <T, R> R doWithExclusiveLock(@NotNull final File file,
                                                @NotNull final Function<T, ? extends R> code,
@@ -226,33 +373,51 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         final String type = shared ? "shared" : "exclusive";
         final StandardOpenOption readOrWrite = shared ? StandardOpenOption.READ : StandardOpenOption.WRITE;
 
+        try {
+            return doWithLock(file, code, target, shared, TimeUnit.MILLISECONDS.toNanos(timeoutMS),
+                    new FileChannelLockRuntime(file, readOrWrite, shared));
+        } catch (IOException e) {
+            throw new IllegalStateException("I/O failure while using the " + type + " file lock on " + file, e);
+        }
+    }
+
+    static <T, R> R doWithLock(@NotNull final File file,
+                               @NotNull final Function<T, ? extends R> code,
+                               @NotNull final Supplier<T> target,
+                               final boolean shared,
+                               final long timeoutNanos,
+                               @NotNull final LockRuntime lockRuntime) {
+        final String type = shared ? "shared" : "exclusive";
+
         //! A wall-clock correction could previously shorten the retry window or extend it indefinitely.
-        //! A monotonic elapsed-time comparison keeps the configured lock timeout stable. There is no
-        //! deterministic public seam for moving the wall clock during this private loop, so
-        //! SingleTableStoreLockTest's shared/exclusive contention cases retain integration evidence for the retry loop.
-        final long startNanos = System.nanoTime();
-        final long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMS);
+        //! A monotonic elapsed-time comparison keeps the configured lock timeout stable.
+        //! SingleTableStoreLockTest#scriptedTimeoutRetainsOverlapCause and
+        //! #scriptedNullContentionTimesOutWithoutInventingACause exercise the Queue-owned deadline branches; the
+        //! real-lock contention tests retain integration evidence without claiming control of the operating-system clock.
         Throwable lastAcquisitionFailure = null;
-        try (final FileChannel channel = FileChannel.open(file.toPath(), readOrWrite)) {
-            for (int count = 1; System.nanoTime() - startNanos < timeoutNanos; count++) {
-                FileLock fileLock = null;
+        try (LockRuntime runtime = lockRuntime) {
+            final long startNanos = runtime.nanoTime();
+            for (int count = 1; runtime.nanoTime() - startNanos < timeoutNanos; count++) {
+                boolean locked = false;
                 try {
-                    fileLock = channel.tryLock(EXCLUSIVE_LOCK_START, EXCLUSIVE_LOCK_SIZE, shared);
+                    locked = runtime.tryLock();
                 } catch (OverlappingFileLockException e) {
                     //! FileChannel.tryLock reports inter-process contention with null and same-JVM
-                    //! contention with OverlappingFileLockException. Both can clear, so retry them;
+                    //! contention with OverlappingFileLockException. Both can clear, so retry them.
+                    //! SingleTableStoreLockTest#scriptedNullContentionSignalsAttemptBeforeBodyAndThenSucceeds
+                    //! discriminates the null branch and its attempt-before-release scheduling boundary, while
                     //! SingleTableStoreLockTest.sharedContentionIsRetriedBeforeBodyRunsOnce and
                     //! exclusiveContentionIsRetriedBeforeBodyRunsOnce prove the same-JVM signal waits
-                    //! and then runs the body exactly once. Exercising null requires a subprocess and
-                    //! platform-specific file-lock fixture, so that specified API branch is not directly tested.
-                    //! In contrast, IOException is the API's terminal "other I/O error" signal; retrying
-                    //! it hid permanent failures and discarded their cause. A portable public API cannot
-                    //! deterministically inject that branch.
+                    //! and then runs the body exactly once with a real FileChannel. #subprocessContentionRetriesNullBeforeBody
+                    //! observes the null result while a separate JVM holds the range, then releases it before body execution.
+                    //! In contrast, IOException is the API's terminal "other I/O error" signal; the
+                    //! scriptedAcquisitionIOExceptionRetainsExactCauseAndSkipsBody test proves Queue propagates
+                    //! the exact cause without invoking either the target or body.
                     lastAcquisitionFailure = e;
                     // failed to acquire the lock, wait until other operation completes
                     if (count > 9) {
                         if (Jvm.isDebugEnabled(SingleTableStore.class)) {
-                            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+                            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(runtime.nanoTime() - startNanos);
                             final String message = "Failed to acquire " + type
                                     + " lock on the table store file. Retrying, file=" + file.getAbsolutePath()
                                     + ", count=" + count + ", elapsed=" + elapsedMs + " ms";
@@ -260,15 +425,17 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                         }
                     }
                 }
-                if (fileLock != null) {
+                if (locked) {
                     //! Keep the body outside the acquisition handlers so even an
                     //! OverlappingFileLockException thrown by user code is not mistaken for contention.
                     //! The BodyFailed boundary makes all body Throwables bypass the surrounding IOException
                     //! handler, while explicit cleanup retains lock/channel close failures as suppressed.
                     //! SingleTableStoreLockTest.exclusiveBodyRunsOnceAndPreservesRuntimeExceptionAndErrorIdentity
                     //! and sharedBodyRunsOnceAndPreservesRuntimeExceptionAndErrorIdentity prove one execution
-                    //! and the exact failure instance. FileLock/FileChannel do not offer a public, portable
-                    //! close-failure injection seam, so generated cleanup suppression is not directly tested.
+                    //! and the exact failure instance. #bodyFailureRetainsLockAndChannelCleanupFailures and
+                    //! #successfulBodyReportsLockCloseFailureWithChannelCloseSuppressed plus
+                    //! #successfulBodyReportsChannelCloseFailure exercise Queue's cleanup precedence through the
+                    //! package-private seam, not a platform-generated close failure.
                     BodyFailed bodyFailed = null;
                     try {
                         return code.apply(target.get());
@@ -277,7 +444,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                         throw bodyFailed;
                     } finally {
                         try {
-                            fileLock.close();
+                            runtime.closeLock();
                         } catch (Throwable closeFailure) {
                             if (bodyFailed != null)
                                 bodyFailed.addSuppressed(closeFailure);
@@ -287,13 +454,15 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                     }
                 }
                 int delay = Math.min(250, count * count);
-                Jvm.pause(delay);
+                runtime.pause(delay);
             }
             //! Preserve the last concrete same-JVM contention signal on timeout. Null is the only
             //! inter-process contention result exposed by FileChannel, so there is no cause to retain for it.
             //! Throw before the channel resource closes so a close failure is suppressed on the timeout
-            //! rather than replacing it. A fast deterministic test would require an injectable lock or
-            //! mutable static timeout; the contention tests retain the public surface without either seam.
+            //! rather than replacing it. SingleTableStoreLockTest#scriptedTimeoutRetainsOverlapCause and
+            //! #scriptedNullContentionTimesOutWithoutInventingACause discriminate both outcomes without claiming
+            //! that the injected null result proves an operating-system or subprocess lock implementation;
+            //! #timeoutRetainsChannelCloseFailureAsSuppressed covers the cleanup edge.
             final IllegalStateException timeout = new IllegalStateException(
                     "Unable to claim the " + type + " lock on file " + file);
             if (lastAcquisitionFailure != null)
@@ -310,8 +479,59 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         } catch (IOException e) {
             //! Once cleanup failures are no longer discarded, IOException can come from opening,
             //! acquiring, releasing, or closing the lock channel. Report that honest common boundary
-            //! and retain the concrete cause; the public FileChannel path has no portable failure injector.
+            //! and retain the concrete cause. SingleTableStoreLockTest's scripted acquisition and cleanup
+            //! tests discriminate Queue's propagation and suppression rules without claiming a platform failure.
             throw new IllegalStateException("I/O failure while using the " + type + " file lock on " + file, e);
+        }
+    }
+
+    interface LockRuntime extends java.io.Closeable {
+        long nanoTime();
+
+        boolean tryLock() throws IOException;
+
+        void closeLock() throws IOException;
+
+        void pause(int millis);
+    }
+
+    static final class FileChannelLockRuntime implements LockRuntime {
+        private final FileChannel channel;
+        private final boolean shared;
+        private FileLock fileLock;
+
+        FileChannelLockRuntime(File file, StandardOpenOption readOrWrite, boolean shared) throws IOException {
+            this.channel = FileChannel.open(file.toPath(), readOrWrite);
+            this.shared = shared;
+        }
+
+        @Override
+        public long nanoTime() {
+            return System.nanoTime();
+        }
+
+        @Override
+        public boolean tryLock() throws IOException {
+            fileLock = channel.tryLock(EXCLUSIVE_LOCK_START, EXCLUSIVE_LOCK_SIZE, shared);
+            return fileLock != null;
+        }
+
+        @Override
+        public void closeLock() throws IOException {
+            final FileLock acquired = fileLock;
+            fileLock = null;
+            if (acquired != null)
+                acquired.close();
+        }
+
+        @Override
+        public void pause(int millis) {
+            Jvm.pause(millis);
+        }
+
+        @Override
+        public void close() throws IOException {
+            channel.close();
         }
     }
 
@@ -434,7 +654,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             long start = mappedBytes.readPosition();
             mappedBytes.writePosition(start);
             final long pos = mappedWire.enterHeader(256L);
-            final LongValue longValue = wireType.newLongReference().get();
+            final LongValue longValue = WireType.BINARY_LIGHT.newLongReference().get();
             mappedWire.writeEventName(key).int64forBinding(defaultValue, longValue);
             mappedWire.writeAlignTo(Integer.BYTES, 0);
             mappedWire.updateHeader(pos, false, 0);
@@ -461,14 +681,19 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
             mappedBytes.readPosition(0);
             // A read limit above writeLimit can fail while another TableStore is being written.
-            //! Snapshot the logical write limit before scanning. Using real capacity alone lets a reader interpret
-            //! preallocated zero space, while a limit beyond writeLimit can fail during another process's publication.
-            //! SingleTableStoreCorruptRecordTest#anIntactTableStoreReadsBackEveryKeyItWrote exercises this scan through
-            //! missing-key creation, then matching and iteration callbacks after reopening the mapped file.
+            //! Capture one immutable scan bound no greater than either this Bytes view's write limit or mapped capacity.
+            //! This is a local bounds guarantee, not a durable logical EOF or a concurrent-publication barrier; the public
+            //! TableStore API does not expose the internal Bytes view needed for a direct losing test.
             final long scanLimit = Math.min(mappedBytes.writeLimit(), mappedBytes.realCapacity());
             mappedBytes.readLimit(scanLimit);
             positionAfterTableStoreHeader(scanLimit);
             while (true) {
+                final long bytesBeforeHeader = scanLimit - mappedBytes.readPosition();
+                if (bytesBeforeHeader == 0)
+                    break;
+                if (bytesBeforeHeader < Integer.BYTES)
+                    throw new CorruptTableStoreException(file(), "the table store ends with " + bytesBeforeHeader
+                            + " trailing bytes instead of a complete record header");
                 final WireIn.HeaderType headerType = mappedWire.readDataHeader(true);
                 if (headerType == WireIn.HeaderType.NONE || headerType == WireIn.HeaderType.EOF)
                     break;
@@ -494,11 +719,29 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                             + " declares a length of " + length + ", which does not fit inside the read limit of " + scanLimit);
 
                 final long recordEnd = bodyStart + length;
+                //! Each writer-produced record ends on the four-byte boundary where Wire may place the next header.
+                //! A merely in-range end can otherwise make the next scan align past bytes that belong to no record.
+                //! SingleTableStoreCorruptRecordTest#recordEndMustBeHeaderAligned rejects that silent gap.
+                if ((recordEnd & (Integer.BYTES - 1L)) != 0)
+                    throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                            + " declares an end that is not aligned for the next header");
+
                 final ValueIn valueIn;
                 final long valueStart;
                 mappedBytes.readLimit(recordEnd);
                 try {
+                    if (mappedBytes.peekUnsignedByte() != BinaryWireCode.EVENT_NAME)
+                        throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                                + " does not start with an event-name token");
                     valueIn = mappedWire.readEventName(sb);
+                    //! Both supported table-store selectors write EVENT_NAME. BinaryWire.readEventName also accepts field-name
+                    //! and field-number tokens as present identifiers, so ValueIn presence alone cannot enforce this schema.
+                    //! SingleTableStoreCorruptRecordTest#missingEventNameIsRejectedByEveryTraversal covers a value-only body;
+                    //! #nonCanonicalFieldNameTokenIsRejectedByEveryTraversal loses the exact-token guard; and
+                    //! #explicitEmptyEventNameRemainsValid proves presence, rather than key length, is the schema boundary.
+                    if (!valueIn.isPresent())
+                        throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                                + " has no present event name");
                     valueStart = mappedBytes.readPosition();
                     validateRecordConsumption(recordStart, recordEnd);
                 } catch (CorruptTableStoreException e) {
@@ -516,8 +759,9 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                 mappedBytes.readPosition(valueStart);
                 mappedBytes.readLimit(recordEnd);
                 try {
-                    //! Every supported record receives a bounded dry read before reset; callbacks may read or ignore the
-                    //! value but cannot influence the next record boundary. The intact-table test exercises both forms.
+                    //! Validate the value before invoking the callback so an iterator that ignores ValueIn cannot bypass
+                    //! corruption checks. SingleTableStoreCorruptRecordTest#nonLongValueCodeIsRejectedByEveryTraversal
+                    //! and #malformedBinaryPaddingIsRejected fail if validation is delegated to callback consumption.
                     final R result = reader.read(sb, valueIn);
                     if (result != null)
                         return result;
@@ -531,9 +775,10 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     }
 
     private void positionAfterTableStoreHeader(long scanLimit) throws EOFException {
-        //! The table-store schema permits metadata only in its first document. Validating that document explicitly prevents
-        //! the generic Wire scanner from skipping a misplaced metadata record and hiding a later key.
-        //! SingleTableStoreCorruptRecordTest#laterMetadataHeaderIsRejected discriminates that classification.
+        //! The first document is the table-store schema header; a data document there cannot establish the persisted wire
+        //! type or metadata. SingleTableStoreCorruptRecordTest#firstRecordMustBeMetadata discriminates this check.
+        if (scanLimit < Integer.BYTES)
+            throw new CorruptTableStoreException(file(), "the table store has no complete metadata header");
         final WireIn.HeaderType headerType = mappedWire.readDataHeader(true);
         if (headerType != WireIn.HeaderType.META_DATA)
             throw new CorruptTableStoreException(file(), "the first record is not table-store metadata");
@@ -541,10 +786,22 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         final int header = mappedBytes.readVolatileInt();
         final long bodyStart = mappedBytes.readPosition();
         final int length = Wires.lengthOf(header);
+        //! A ready zero-length metadata document cannot contain the persisted table-store schema. Advancing by zero would
+        //! make the data scanner reinterpret bytes outside that document as if the header had established a wire type.
+        //! SingleTableStoreCorruptRecordTest#firstMetadataLengthMustBePositive discriminates this boundary.
+        if (length <= 0)
+            throw new CorruptTableStoreException(file(), "the table-store metadata header has no body");
         if (length > scanLimit - bodyStart)
             throw new CorruptTableStoreException(file(), "the table-store header declares a length of " + length
                     + ", which does not fit inside the read limit of " + scanLimit);
-        mappedBytes.readPosition(bodyStart + length);
+        final long headerEnd = bodyStart + length;
+        //! A binary-family data-header reader starts at this declared end, so its metadata document must leave it on the
+        //! four-byte boundary used by the writer for every following header.
+        //! SingleTableStoreCorruptRecordTest#firstMetadataEndMustBeHeaderAligned rejects an otherwise silent alignment gap.
+        if ((headerEnd & (Integer.BYTES - 1L)) != 0)
+            throw new CorruptTableStoreException(file(),
+                    "the table-store metadata header end is not aligned for the first data header");
+        mappedBytes.readPosition(headerEnd);
     }
 
     //! SingleTableStoreCorruptRecordTest#longerInRangeRecordIsRejected discriminates exact body consumption, while
@@ -552,53 +809,37 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     //! Bounding the Wire before parsing prevents #shorterPositiveRecordIsRejected from borrowing successor bytes.
     //! Only Wire's explicit padding codes are accepted between the value and the declared end.
     private void validateRecordConsumption(long recordStart, long recordEnd) {
-        if (wireType == WireType.RAW) {
-            //! RAW encodes a bound long as eight untagged bytes followed by zero alignment padding. The
-            //! SingleTableStoreCorruptRecordTest#rawTableStoreStillScansValuesWrittenDuringItsInitialOpen test fails if
-            //! this bounded legacy path is rejected or sent through BinaryWire's tagged-value parser, while
-            //! #rawRecordLengthsAreBoundedDuringTheInitialOpen rejects short and long declared bodies without mutation.
-            validateRawRecordConsumption(recordStart, recordEnd);
-        } else {
-            consumeExplicitBinaryPadding(recordStart);
-            if (mappedBytes.readRemaining() == 0)
-                throw new CorruptTableStoreException(file(), "the record at " + recordStart + " holds no value");
+        consumeExplicitBinaryPadding(recordStart);
+        if (mappedBytes.readRemaining() == 0)
+            throw new CorruptTableStoreException(file(), "the record at " + recordStart + " holds no value");
 
-            //! TableStore records contain bound longs, not arbitrary same-width Wire values. The
-            //! SingleTableStoreCorruptRecordTest#nonLongValueCodeIsRejectedByEveryTraversal test replaces INT64 with
-            //! FLOAT64 without changing the record length and fails if generic skipValue validation is restored.
-            final int valueCode = mappedBytes.peekUnsignedByte();
-            if (valueCode != 0 && valueCode != BinaryWireCode.INT64)
-                throw new CorruptTableStoreException(file(), "the record at " + recordStart
-                        + " holds Wire type 0x" + Integer.toHexString(valueCode) + " instead of a bound long");
-            // BinaryWire's binding reader accepts zero as a legacy long marker and consumes its following eight bytes.
-            mappedBytes.readSkip(1L + Long.BYTES);
-            consumeExplicitBinaryPadding(recordStart);
-        }
+        //! TableStore records contain bound longs, not arbitrary same-width Wire values. The
+        //! SingleTableStoreCorruptRecordTest#nonLongValueCodeIsRejectedByEveryTraversal test replaces INT64 with
+        //! FLOAT64 without changing the record length and fails if generic skipValue validation is restored.
+        final long valueCodeAt = mappedBytes.readPosition();
+        final int valueCode = mappedBytes.peekUnsignedByte();
+        if (valueCode != 0 && valueCode != BinaryWireCode.INT64)
+            throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                    + " holds Wire type 0x" + Integer.toHexString(valueCode) + " instead of a bound long");
+
+        //! BinaryWire aligns the eight-byte bound-long payload, not its preceding type code. Bounded but non-canonical
+        //! padding can otherwise bind a live LongValue to an unaligned mapped address.
+        //! SingleTableStoreCorruptRecordTest#misalignedBoundLongIsRejected discriminates this addressability invariant.
+        final long payloadAt = valueCodeAt + 1L;
+        if ((payloadAt & (Long.BYTES - 1L)) != 0)
+            throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                    + " holds a bound long at an unaligned address");
+        if (mappedBytes.readRemaining() < 1L + Long.BYTES)
+            throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                    + " ends inside its bound long");
+        // BinaryWire's binding reader accepts zero as a legacy long marker and consumes its following eight bytes.
+        mappedBytes.readSkip(1L + Long.BYTES);
+        consumeExplicitBinaryPadding(recordStart);
 
         final long actualEnd = mappedBytes.readPosition();
         if (actualEnd != recordEnd)
             throw new CorruptTableStoreException(file(), "the record at " + recordStart + " declares an end at "
                     + recordEnd + " but its content ends at " + actualEnd);
-    }
-
-    private void validateRawRecordConsumption(long recordStart, long recordEnd) {
-        //! Enforce RAW's complete bound-long and exact zero-padding shape without changing its initial-open compatibility.
-        //! SingleTableStoreCorruptRecordTest#rawTableStoreStillScansValuesWrittenDuringItsInitialOpen guards that path;
-        //! reopening a RAW typed header remains a pre-existing RawWire limitation and is not reclassified here.
-        if (mappedBytes.readRemaining() < Long.BYTES)
-            throw new CorruptTableStoreException(file(), "the RAW record at " + recordStart
-                    + " ends before its bound long");
-        mappedBytes.readSkip(Long.BYTES);
-
-        final long expectedPadding = (-mappedBytes.readPosition()) & (Integer.BYTES - 1L);
-        if (mappedBytes.readRemaining() != expectedPadding)
-            throw new CorruptTableStoreException(file(), "the RAW record at " + recordStart + " declares an end at "
-                    + recordEnd + " but requires " + expectedPadding + " padding bytes");
-        while (mappedBytes.readRemaining() > 0) {
-            if (mappedBytes.readUnsignedByte() != 0)
-                throw new CorruptTableStoreException(file(), "the RAW record at " + recordStart
-                        + " contains non-zero alignment padding");
-        }
     }
 
     private void consumeExplicitBinaryPadding(long recordStart) {

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -30,6 +30,7 @@ import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.StandardOpenOption;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -67,17 +68,49 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
      *
      * @param wire The {@link WireIn} instance used to read the serialized data.
      */
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "unchecked"})
     @UsedViaReflection
     private SingleTableStore(@NotNull final WireIn wire) {
         try {
-            this.wireType = Objects.requireNonNull(wire.read(MetaDataField.wireType).object(WireType.class));
             this.mappedBytes = (MappedBytes) (wire.bytes());
             this.mappedFile = mappedBytes.mappedFile();
 
+            final WireType decodedWireType;
+            try {
+                decodedWireType = Objects.requireNonNull(
+                        wire.read(MetaDataField.wireType).object(WireType.class),
+                        "the table-store header has no wire type");
+            } catch (CorruptTableStoreException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                //! The wire type is Queue-owned schema, not an extensible constructor hook. A missing or unreadable value
+                //! proves that this header cannot describe a table store; retrying the file lock cannot repair it.
+                //! SingleTableBuilderCorruptMetadataTest#partialStoreConstructionIsCorruptionAndReleasesTheMapping
+                //! discriminates this field boundary and its partial-instance cleanup.
+                throw new CorruptTableStoreException(mappedFile.file(),
+                        "the first header has no readable wire type", e);
+            }
+            try {
+                this.wireType = requireSupportedWireType(decodedWireType);
+            } catch (IllegalArgumentException e) {
+                throw new CorruptTableStoreException(mappedFile.file(),
+                        "the first header uses unsupported wire type " + decodedWireType, e);
+            }
+
             wire.consumePadding();
             if (wire.bytes().readRemaining() > 0) {
-                this.metadata = Objects.requireNonNull(wire.read(MetaDataField.metadata).typedMarshallable());
+                final Object decodedMetadata = wire.read(MetaDataField.metadata).typedMarshallable();
+                if (!(decodedMetadata instanceof Metadata)) {
+                    //! Decode extensible metadata without an inferred cast, then reject and close the wrong type explicitly.
+                    //! Otherwise the compiler-generated cast loses a decoded Closeable and leaks it behind a generic CCE.
+                    //! SingleTableBuilderCorruptMetadataTest#nullAndWrongTypedNestedMetadataAreReportedAsCorruption
+                    //! covers null and closeable wrong-type values.
+                    Closeable.closeQuietly(decodedMetadata);
+                    throw new CorruptTableStoreException(mappedFile.file(),
+                            "the first header holds " + (decodedMetadata == null
+                                    ? "null" : decodedMetadata.getClass().getName()) + " instead of metadata");
+                }
+                this.metadata = (T) decodedMetadata;
             } else {
                 @SuppressWarnings("unchecked")
                 T instance = (T) Metadata.NoMeta.INSTANCE;
@@ -87,6 +120,10 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             mappedWire = wireType.apply(mappedBytes);
             mappedWire.usePadding(true);
         } catch (RuntimeException | Error e) {
+            //! Demarshallable construction registers this closeable before all persisted fields are decoded. If decoding
+            //! fails, no caller receives the partial store and only this path can retire it. The
+            //! SingleTableBuilderCorruptMetadataTest#partialStoreConstructionIsCorruptionAndReleasesTheMapping test
+            //! fails through resource tracing if the partial instance is left registered.
             // AbstractCloseable registered this instance before the read started. The caller never
             // receives a reference that it could close, so close it here.
             close();
@@ -106,7 +143,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     SingleTableStore(@NotNull final WireType wireType,
                      @NotNull final MappedBytes mappedBytes,
                      @NotNull final T metadata) {
-        this.wireType = wireType;
+        this.wireType = requireSupportedWireType(wireType);
         this.metadata = metadata;
         this.mappedBytes = mappedBytes;
         this.mappedFile = mappedBytes.mappedFile();
@@ -114,6 +151,26 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         mappedWire.usePadding(true);
 
         singleThreadedCheckDisabled(true);
+    }
+
+    //! Apply the same fail-closed format gate to newly selected and persisted wire types. Otherwise a crafted first header
+    //! can bypass the builder's pre-file check and recreate an unbounded record reader after deserialisation.
+    //! SingleTableStoreCorruptRecordTest#unsupportedWireTypesAreRejectedBeforeCreatingAFile and
+    //! SingleTableBuilderCorruptMetadataTest#unsupportedPersistedWireTypeIsCorruptionAndReleasesTheMapping cover both edges.
+    //! SingleTableStoreCorruptRecordTest#supportedBinaryWireTypesRoundTripBoundValues proves the four BinaryWire variants
+    //! share the tagged bound-long grammar; #rawTableStoreStillScansValuesWrittenDuringItsInitialOpen preserves bounded RAW.
+    static WireType requireSupportedWireType(WireType wireType) {
+        final WireType required = Objects.requireNonNull(wireType);
+        switch (required) {
+            case BINARY:
+            case BINARY_LIGHT:
+            case FIELDLESS_BINARY:
+            case COMPRESSED_BINARY:
+            case RAW:
+                return required;
+            default:
+                throw new IllegalArgumentException("Table stores require a binary or raw WireType, not " + required);
+        }
     }
 
     /**
@@ -169,44 +226,93 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         final String type = shared ? "shared" : "exclusive";
         final StandardOpenOption readOrWrite = shared ? StandardOpenOption.READ : StandardOpenOption.WRITE;
 
-        final long timeoutAt = System.currentTimeMillis() + timeoutMS;
-        final long startMs = System.currentTimeMillis();
+        //! A wall-clock correction could previously shorten the retry window or extend it indefinitely.
+        //! A monotonic elapsed-time comparison keeps the configured lock timeout stable. There is no
+        //! deterministic public seam for moving the wall clock during this private loop, so
+        //! SingleTableStoreLockTest's shared/exclusive contention cases retain integration evidence for the retry loop.
+        final long startNanos = System.nanoTime();
+        final long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMS);
+        Throwable lastAcquisitionFailure = null;
         try (final FileChannel channel = FileChannel.open(file.toPath(), readOrWrite)) {
-            for (int count = 1; System.currentTimeMillis() < timeoutAt; count++) {
+            for (int count = 1; System.nanoTime() - startNanos < timeoutNanos; count++) {
                 FileLock fileLock = null;
                 try {
                     fileLock = channel.tryLock(EXCLUSIVE_LOCK_START, EXCLUSIVE_LOCK_SIZE, shared);
-                } catch (IOException | OverlappingFileLockException e) {
+                } catch (OverlappingFileLockException e) {
+                    //! FileChannel.tryLock reports inter-process contention with null and same-JVM
+                    //! contention with OverlappingFileLockException. Both can clear, so retry them;
+                    //! SingleTableStoreLockTest.sharedContentionIsRetriedBeforeBodyRunsOnce and
+                    //! exclusiveContentionIsRetriedBeforeBodyRunsOnce prove the same-JVM signal waits
+                    //! and then runs the body exactly once. Exercising null requires a subprocess and
+                    //! platform-specific file-lock fixture, so that specified API branch is not directly tested.
+                    //! In contrast, IOException is the API's terminal "other I/O error" signal; retrying
+                    //! it hid permanent failures and discarded their cause. A portable public API cannot
+                    //! deterministically inject that branch.
+                    lastAcquisitionFailure = e;
                     // failed to acquire the lock, wait until other operation completes
                     if (count > 9) {
                         if (Jvm.isDebugEnabled(SingleTableStore.class)) {
-                            final long elapsedMs = System.currentTimeMillis() - startMs;
-                            final String message = "Failed to acquire " + type + " lock on the table store file. Retrying, file=" + file.getAbsolutePath() + ", count=" + count + ", elapsed=" + elapsedMs + " ms";
+                            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+                            final String message = "Failed to acquire " + type
+                                    + " lock on the table store file. Retrying, file=" + file.getAbsolutePath()
+                                    + ", count=" + count + ", elapsed=" + elapsedMs + " ms";
                             Jvm.debug().on(SingleTableStore.class, "", new StackTrace(message));
                         }
                     }
                 }
                 if (fileLock != null) {
-                    // the body runs outside the catch above, so that a failure inside it is never
-                    // mistaken for lock contention and retried
+                    //! Keep the body outside the acquisition handlers so even an
+                    //! OverlappingFileLockException thrown by user code is not mistaken for contention.
+                    //! The BodyFailed boundary makes all body Throwables bypass the surrounding IOException
+                    //! handler, while explicit cleanup retains lock/channel close failures as suppressed.
+                    //! SingleTableStoreLockTest.exclusiveBodyRunsOnceAndPreservesRuntimeExceptionAndErrorIdentity
+                    //! and sharedBodyRunsOnceAndPreservesRuntimeExceptionAndErrorIdentity prove one execution
+                    //! and the exact failure instance. FileLock/FileChannel do not offer a public, portable
+                    //! close-failure injection seam, so generated cleanup suppression is not directly tested.
+                    BodyFailed bodyFailed = null;
                     try {
                         return code.apply(target.get());
                     } catch (Throwable t) {
-                        throw new BodyFailed(t);
+                        bodyFailed = new BodyFailed(t);
+                        throw bodyFailed;
                     } finally {
-                        // release quietly, so that a failure here cannot replace a failure from the body
-                        Closeable.closeQuietly(fileLock);
+                        try {
+                            fileLock.close();
+                        } catch (Throwable closeFailure) {
+                            if (bodyFailed != null)
+                                bodyFailed.addSuppressed(closeFailure);
+                            else
+                                throw Jvm.rethrow(closeFailure);
+                        }
                     }
                 }
                 int delay = Math.min(250, count * count);
                 Jvm.pause(delay);
             }
+            //! Preserve the last concrete same-JVM contention signal on timeout. Null is the only
+            //! inter-process contention result exposed by FileChannel, so there is no cause to retain for it.
+            //! Throw before the channel resource closes so a close failure is suppressed on the timeout
+            //! rather than replacing it. A fast deterministic test would require an injectable lock or
+            //! mutable static timeout; the contention tests retain the public surface without either seam.
+            final IllegalStateException timeout = new IllegalStateException(
+                    "Unable to claim the " + type + " lock on file " + file);
+            if (lastAcquisitionFailure != null)
+                timeout.initCause(lastAcquisitionFailure);
+            throw timeout;
         } catch (BodyFailed e) {
-            throw Jvm.rethrow(e.getCause());
+            //! Lock and channel cleanup run while BodyFailed is primary, so Java attaches their failures
+            //! to the wrapper. Move those suppressed failures onto the original body Throwable before
+            //! rethrowing it; otherwise unwrapping would silently discard cleanup evidence.
+            final Throwable bodyFailure = e.getCause();
+            for (Throwable suppressed : e.getSuppressed())
+                bodyFailure.addSuppressed(suppressed);
+            throw Jvm.rethrow(bodyFailure);
         } catch (IOException e) {
-            throw new IllegalStateException("Could not take the " + type + " file lock on " + file, e);
+            //! Once cleanup failures are no longer discarded, IOException can come from opening,
+            //! acquiring, releasing, or closing the lock channel. Report that honest common boundary
+            //! and retain the concrete cause; the public FileChannel path has no portable failure injector.
+            throw new IllegalStateException("I/O failure while using the " + type + " file lock on " + file, e);
         }
-        throw new IllegalStateException("Unable to claim the " + type + " lock on file " + file);
     }
 
     /**
@@ -252,6 +358,9 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
     @Override
     protected void performClose() {
+        //! The partial-construction failure above can close this instance before mappedBytes is assigned. The
+        //! SingleTableBuilderCorruptMetadataTest#partialStoreConstructionIsCorruptionAndReleasesTheMapping test retains
+        //! the original decode failure and rejects an unexpected close-time NullPointerException if this guard is removed.
         // mappedBytes is null when the deserialization constructor failed before it assigned the field
         if (mappedBytes != null)
             mappedBytes.close();
@@ -310,26 +419,15 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
         mappedBytes.reserve(this);
         try {
-            mappedBytes.readPosition(0);
-            // if we set readLimit to realCapacity then we can run into DecoratedBufferUnderflowException: readLimit failed. Limit: xx > writeLimit: yy
-            // while reading from a TableStore which is being written to
-            mappedBytes.readLimit(Math.min(mappedBytes.writeLimit(), mappedBytes.realCapacity()));
-            while (mappedWire.readDataHeader()) {
-                final int header = mappedBytes.readVolatileInt();
-                if (Wires.isNotComplete(header))
-                    break;
-                final long readPosition = mappedBytes.readPosition();
-                final int length = Wires.lengthOf(header);
-                if (length <= 0 || readPosition + length > mappedBytes.readLimit())
-                    throw new CorruptTableStoreException(file(), "the record at " + (readPosition - 4)
-                            + " declares a length of " + length + ", which does not fit inside the read limit of "
-                            + mappedBytes.readLimit());
-                final ValueIn valueIn = readEventIfNameEquals(mappedWire, key);
-                if (valueIn != null) {
-                    return valueIn.int64ForBinding(null);
-                }
-                mappedBytes.readPosition(readPosition + length);
-            }
+            //! SingleTableStoreCorruptRecordTest#shorterPositiveRecordIsRejected proves matching, later-target and
+            //! missing-key lookups validate visited records; #laterCorruptRecordIsRejectedWhenVisited proves a healthy
+            //! earlier match may return while traversal to later or missing keys reaches and rejects the later fault.
+            //! #longerInRangeRecordIsRejected catches a declared end that silently misaligns the following scan.
+            final LongValue existing = readTableStoreRecords((recordKey, valueIn) ->
+                    StringUtils.equalsCaseIgnore(key, recordKey) ? valueIn.int64ForBinding(null) : null);
+            if (existing != null)
+                return existing;
+
             if (mappedBytes.isBackingFileReadOnly())
                 throw new IllegalStateException("key " + key + " does not exist in readOnly TableStore and cannot be created");
             mappedBytes.writeLimit(mappedBytes.realCapacity());
@@ -357,34 +455,194 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
     }
 
     @Nullable
-    private static ValueIn readEventIfNameEquals(WireIn wireIn, CharSequence expected) {
+    private <R> R readTableStoreRecords(TableStoreRecordReader<R> reader) throws EOFException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
             StringBuilder sb = stlSb.get();
-            final ValueIn valueIn = wireIn.readEventName(sb);
-            if (StringUtils.equalsCaseIgnore(expected, sb)) {
-                return valueIn;
+
+            mappedBytes.readPosition(0);
+            // A read limit above writeLimit can fail while another TableStore is being written.
+            //! Snapshot the logical write limit before scanning. Using real capacity alone lets a reader interpret
+            //! preallocated zero space, while a limit beyond writeLimit can fail during another process's publication.
+            //! SingleTableStoreCorruptRecordTest#anIntactTableStoreReadsBackEveryKeyItWrote exercises this scan through
+            //! missing-key creation, then matching and iteration callbacks after reopening the mapped file.
+            final long scanLimit = Math.min(mappedBytes.writeLimit(), mappedBytes.realCapacity());
+            mappedBytes.readLimit(scanLimit);
+            positionAfterTableStoreHeader(scanLimit);
+            while (true) {
+                final WireIn.HeaderType headerType = mappedWire.readDataHeader(true);
+                if (headerType == WireIn.HeaderType.NONE || headerType == WireIn.HeaderType.EOF)
+                    break;
+                final long recordStart = mappedBytes.readPosition();
+                //! Only the first document is table-store metadata. SingleTableStoreCorruptRecordTest
+                //! #laterMetadataHeaderIsRejected proves that asking Wire to skip all metadata would hide a corrupted record,
+                //! omit its key from iteration and allow acquisition to append a duplicate.
+                if (headerType != WireIn.HeaderType.DATA)
+                    throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                            + " is marked as metadata instead of data");
+
+                final int header = mappedBytes.readVolatileInt();
+                if (Wires.isNotComplete(header))
+                    break;
+
+                final long bodyStart = mappedBytes.readPosition();
+                final int length = Wires.lengthOf(header);
+                //! Subtraction avoids overflow while proving the declared end remains inside the snapshotted scan limit.
+                //! SingleTableStoreCorruptRecordTest#recordBeyondTheReadLimitIsRejected checks this exact diagnostic,
+                //! before Wire can turn the invalid boundary into an unrelated parsing failure.
+                if (length > scanLimit - bodyStart)
+                    throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                            + " declares a length of " + length + ", which does not fit inside the read limit of " + scanLimit);
+
+                final long recordEnd = bodyStart + length;
+                final ValueIn valueIn;
+                final long valueStart;
+                mappedBytes.readLimit(recordEnd);
+                try {
+                    valueIn = mappedWire.readEventName(sb);
+                    valueStart = mappedBytes.readPosition();
+                    validateRecordConsumption(recordStart, recordEnd);
+                } catch (CorruptTableStoreException e) {
+                    throw e;
+                } catch (RuntimeException e) {
+                    //! Parser failures while constrained to this record prove that its declared body is unreadable.
+                    //! SingleTableStoreCorruptRecordTest#shorterPositiveRecordIsRejected fails if an under-length body
+                    //! escapes as a lower-level Wire exception instead of the table-store corruption contract.
+                    throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                            + " cannot be read within its declared length of " + length, e);
+                } finally {
+                    mappedBytes.readLimit(scanLimit);
+                }
+
+                mappedBytes.readPosition(valueStart);
+                mappedBytes.readLimit(recordEnd);
+                try {
+                    //! Every supported record receives a bounded dry read before reset; callbacks may read or ignore the
+                    //! value but cannot influence the next record boundary. The intact-table test exercises both forms.
+                    final R result = reader.read(sb, valueIn);
+                    if (result != null)
+                        return result;
+                } finally {
+                    mappedBytes.readLimit(scanLimit);
+                    mappedBytes.readPosition(recordEnd);
+                }
             }
             return null;
         }
     }
 
+    private void positionAfterTableStoreHeader(long scanLimit) throws EOFException {
+        //! The table-store schema permits metadata only in its first document. Validating that document explicitly prevents
+        //! the generic Wire scanner from skipping a misplaced metadata record and hiding a later key.
+        //! SingleTableStoreCorruptRecordTest#laterMetadataHeaderIsRejected discriminates that classification.
+        final WireIn.HeaderType headerType = mappedWire.readDataHeader(true);
+        if (headerType != WireIn.HeaderType.META_DATA)
+            throw new CorruptTableStoreException(file(), "the first record is not table-store metadata");
+
+        final int header = mappedBytes.readVolatileInt();
+        final long bodyStart = mappedBytes.readPosition();
+        final int length = Wires.lengthOf(header);
+        if (length > scanLimit - bodyStart)
+            throw new CorruptTableStoreException(file(), "the table-store header declares a length of " + length
+                    + ", which does not fit inside the read limit of " + scanLimit);
+        mappedBytes.readPosition(bodyStart + length);
+    }
+
+    //! SingleTableStoreCorruptRecordTest#longerInRangeRecordIsRejected discriminates exact body consumption, while
+    //! #nonLongValueCodeIsRejectedByEveryTraversal and #malformedBinaryPaddingIsRejected cover value schema and padding.
+    //! Bounding the Wire before parsing prevents #shorterPositiveRecordIsRejected from borrowing successor bytes.
+    //! Only Wire's explicit padding codes are accepted between the value and the declared end.
+    private void validateRecordConsumption(long recordStart, long recordEnd) {
+        if (wireType == WireType.RAW) {
+            //! RAW encodes a bound long as eight untagged bytes followed by zero alignment padding. The
+            //! SingleTableStoreCorruptRecordTest#rawTableStoreStillScansValuesWrittenDuringItsInitialOpen test fails if
+            //! this bounded legacy path is rejected or sent through BinaryWire's tagged-value parser, while
+            //! #rawRecordLengthsAreBoundedDuringTheInitialOpen rejects short and long declared bodies without mutation.
+            validateRawRecordConsumption(recordStart, recordEnd);
+        } else {
+            consumeExplicitBinaryPadding(recordStart);
+            if (mappedBytes.readRemaining() == 0)
+                throw new CorruptTableStoreException(file(), "the record at " + recordStart + " holds no value");
+
+            //! TableStore records contain bound longs, not arbitrary same-width Wire values. The
+            //! SingleTableStoreCorruptRecordTest#nonLongValueCodeIsRejectedByEveryTraversal test replaces INT64 with
+            //! FLOAT64 without changing the record length and fails if generic skipValue validation is restored.
+            final int valueCode = mappedBytes.peekUnsignedByte();
+            if (valueCode != 0 && valueCode != BinaryWireCode.INT64)
+                throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                        + " holds Wire type 0x" + Integer.toHexString(valueCode) + " instead of a bound long");
+            // BinaryWire's binding reader accepts zero as a legacy long marker and consumes its following eight bytes.
+            mappedBytes.readSkip(1L + Long.BYTES);
+            consumeExplicitBinaryPadding(recordStart);
+        }
+
+        final long actualEnd = mappedBytes.readPosition();
+        if (actualEnd != recordEnd)
+            throw new CorruptTableStoreException(file(), "the record at " + recordStart + " declares an end at "
+                    + recordEnd + " but its content ends at " + actualEnd);
+    }
+
+    private void validateRawRecordConsumption(long recordStart, long recordEnd) {
+        //! Enforce RAW's complete bound-long and exact zero-padding shape without changing its initial-open compatibility.
+        //! SingleTableStoreCorruptRecordTest#rawTableStoreStillScansValuesWrittenDuringItsInitialOpen guards that path;
+        //! reopening a RAW typed header remains a pre-existing RawWire limitation and is not reclassified here.
+        if (mappedBytes.readRemaining() < Long.BYTES)
+            throw new CorruptTableStoreException(file(), "the RAW record at " + recordStart
+                    + " ends before its bound long");
+        mappedBytes.readSkip(Long.BYTES);
+
+        final long expectedPadding = (-mappedBytes.readPosition()) & (Integer.BYTES - 1L);
+        if (mappedBytes.readRemaining() != expectedPadding)
+            throw new CorruptTableStoreException(file(), "the RAW record at " + recordStart + " declares an end at "
+                    + recordEnd + " but requires " + expectedPadding + " padding bytes");
+        while (mappedBytes.readRemaining() > 0) {
+            if (mappedBytes.readUnsignedByte() != 0)
+                throw new CorruptTableStoreException(file(), "the RAW record at " + recordStart
+                        + " contains non-zero alignment padding");
+        }
+    }
+
+    private void consumeExplicitBinaryPadding(long recordStart) {
+        //! Accept only Wire's one-byte and length-prefixed padding encodings, and bound PADDING32 before skipping it.
+        //! Otherwise malformed padding can consume the next record while still satisfying the outer mapped-file limit.
+        //! SingleTableStoreCorruptRecordTest#malformedBinaryPaddingIsRejected covers truncated and oversized PADDING32.
+        while (mappedBytes.readRemaining() > 0) {
+            final int code = mappedBytes.peekUnsignedByte();
+            if (code == BinaryWireCode.PADDING) {
+                mappedBytes.readSkip(1);
+                continue;
+            }
+            if (code != BinaryWireCode.PADDING32)
+                return;
+
+            if (mappedBytes.readRemaining() < 5)
+                throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                        + " ends inside a padding header");
+            mappedBytes.readSkip(1);
+            final long padding = mappedBytes.readUnsignedInt();
+            if (padding > mappedBytes.readRemaining())
+                throw new CorruptTableStoreException(file(), "the record at " + recordStart
+                        + " declares " + padding + " padding bytes with only " + mappedBytes.readRemaining() + " remaining");
+            mappedBytes.readSkip(padding);
+        }
+    }
+
+    @FunctionalInterface
+    private interface TableStoreRecordReader<R> {
+        @Nullable
+        R read(CharSequence key, ValueIn valueIn);
+    }
+
     @Override
     public synchronized <T> void forEachKey(T accumulator, TableStoreIterator<T> tsIterator) {
         mappedBytes.reserve(this);
-        try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
-            StringBuilder sb = stlSb.get();
-            mappedBytes.readPosition(0);
-            mappedBytes.readLimit(mappedBytes.realCapacity());
-            while (mappedWire.readDataHeader()) {
-                final int header = mappedBytes.readVolatileInt();
-                if (Wires.isNotComplete(header))
-                    break;
-                final long readPosition = mappedBytes.readPosition();
-                final int length = Wires.lengthOf(header);
-                final ValueIn valueIn = mappedWire.readEventName(sb);
-                tsIterator.accept(accumulator, sb, valueIn);
-                mappedBytes.readPosition(readPosition + length);
-            }
+        try {
+            //! SingleTableStoreCorruptRecordTest#longerInRangeRecordIsRejected requires iteration to use the same exact
+            //! traversal as acquisition. #anIntactTableStoreReadsBackEveryKeyItWrote proves callbacks may consume or
+            //! ignore ValueIn: validation resets the reader before the callback, then advances to the declared end.
+            readTableStoreRecords((key, valueIn) -> {
+                tsIterator.accept(accumulator, key, valueIn);
+                return null;
+            });
 
         } catch (EOFException e) {
             throw new IORuntimeException(e);

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/TableStoreUnavailableException.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/TableStoreUnavailableException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.table;
+
+import net.openhft.chronicle.core.io.IORuntimeException;
+
+import java.io.File;
+
+//! Give read-only fallback a provenance-bearing signal emitted only while the metadata file is opened or awaited.
+//! SingleChronicleQueueCorruptMetadataTest#nestedFileNotFoundFromMetadataDoesNotActivateReadonlyFallback and
+//! #constructorAvailabilitySignalDoesNotActivateReadonlyFallback prevent decoder causes from masquerading as availability.
+//! The type is public so callers can distinguish availability, but its package-owned constructors reserve fallback authority
+//! to Queue's file-opening code.
+//! SingleChronicleQueueCorruptMetadataTest#metadataAccessorUnavailabilityDoesNotActivateReadonlyFallback proves that
+//! receiving this exact type later in queue setup does not broaden that authority.
+/**
+ * Indicates that a table-store file could not be opened or had not yet published enough data to be mapped.
+ *
+ * <p>This is distinct from {@link CorruptTableStoreException}: absence or an access failure may permit a queue to
+ * fall back to caller-supplied metadata in a synthetic read-only store, whereas inconsistent content never does.</p>
+ *
+ * <p>Construction is package-restricted so only Queue's table-store opening code can originate this signal.
+ * Callers may nevertheless catch the public type and distinguish it from persisted-content corruption.</p>
+ */
+public final class TableStoreUnavailableException extends IORuntimeException {
+    private static final long serialVersionUID = 0L;
+
+    /**
+     * @param file    the unavailable table-store file
+     * @param message the bounded availability reason
+     */
+    TableStoreUnavailableException(File file, String message) {
+        super(message + ": " + file);
+    }
+
+    /**
+     * @param file    the unavailable table-store file
+     * @param message the bounded availability reason
+     * @param cause   the failure observed at the file-opening boundary
+     */
+    TableStoreUnavailableException(File file, String message, Throwable cause) {
+        super(message + ": " + file, cause);
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCorruptMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCorruptMetadataTest.java
@@ -4,6 +4,7 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.table.CorruptTableStoreException;
@@ -12,9 +13,9 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -33,25 +34,13 @@ public class SingleChronicleQueueCorruptMetadataTest extends QueueTestCommon {
     public void aCorruptFirstHeaderFailsWithoutWaitingForTheTableStoreLock() {
         File queueDir = queueWithCorruptMetadataHeader();
 
-        long startMs = System.currentTimeMillis();
+        long startNanos = System.nanoTime();
         Throwable thrown = buildAndCaptureFailure(queueDir);
-        long elapsedMs = System.currentTimeMillis() - startMs;
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
 
         assertTrue("the build took " + elapsedMs + " ms, which is not less than the table store lock timeout of "
-                + TABLE_STORE_TIMEOUT_MS + " ms. Thrown: " + thrown, elapsedMs < TABLE_STORE_TIMEOUT_MS / 5);
-    }
-
-    /**
-     * The reported failure must name the corruption, not a lock that no other process holds.
-     */
-    @Test
-    public void aCorruptFirstHeaderIsReportedAsCorruptionNotAsLockContention() {
-        File queueDir = queueWithCorruptMetadataHeader();
-
-        Throwable thrown = buildAndCaptureFailure(queueDir);
-
-        assertFalse("the failure was reported as lock contention: " + chainOf(thrown),
-                chainOf(thrown).contains("Unable to claim"));
+                        + TABLE_STORE_TIMEOUT_MS + " ms. Thrown: " + thrown,
+                elapsedMs < Math.max(1L, TABLE_STORE_TIMEOUT_MS / 5));
     }
 
     /**
@@ -64,6 +53,22 @@ public class SingleChronicleQueueCorruptMetadataTest extends QueueTestCommon {
         Throwable thrown = buildAndCaptureFailure(queueDir);
 
         assertEquals("thrown was " + chainOf(thrown), CorruptTableStoreException.class, thrown.getClass());
+        assertTrue("the declared-length guard was not the failing decision: " + thrown,
+                thrown.getMessage().contains("bytes but its content ends at"));
+    }
+
+    /**
+     * Corruption remains in the established I/O exception family, but must not activate the queue
+     * builder's read-only fallback.
+     */
+    @Test
+    public void corruptMetadataBypassesReadonlyFallbackAndRemainsAnIORuntimeException() {
+        File queueDir = queueWithCorruptMetadataHeader();
+
+        Throwable thrown = buildAndCaptureFailure(queueDir, true);
+
+        assertEquals("thrown was " + chainOf(thrown), CorruptTableStoreException.class, thrown.getClass());
+        assertTrue("corruption left the established I/O exception family", thrown instanceof IORuntimeException);
     }
 
     /**
@@ -102,7 +107,11 @@ public class SingleChronicleQueueCorruptMetadataTest extends QueueTestCommon {
     }
 
     private Throwable buildAndCaptureFailure(File queueDir) {
-        try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
+        return buildAndCaptureFailure(queueDir, false);
+    }
+
+    private Throwable buildAndCaptureFailure(File queueDir, boolean readOnly) {
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).readOnly(readOnly).build()) {
             fail("the build accepted a corrupt metadata file: " + queue);
             return null;
         } catch (AssertionError e) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCorruptMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCorruptMetadataTest.java
@@ -4,18 +4,33 @@
 package net.openhft.chronicle.queue.impl.single;
 
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
+import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.table.CorruptTableStoreException;
+import net.openhft.chronicle.queue.impl.table.Metadata;
+import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
+import net.openhft.chronicle.queue.impl.table.TableStoreUnavailableException;
+import net.openhft.chronicle.wire.WireIn;
+import net.openhft.chronicle.wire.WireOut;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.lang.reflect.Constructor;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -54,7 +69,7 @@ public class SingleChronicleQueueCorruptMetadataTest extends QueueTestCommon {
 
         assertEquals("thrown was " + chainOf(thrown), CorruptTableStoreException.class, thrown.getClass());
         assertTrue("the declared-length guard was not the failing decision: " + thrown,
-                thrown.getMessage().contains("bytes but its content ends at"));
+                thrown.getMessage().contains("length does not match its decoded content"));
     }
 
     /**
@@ -69,6 +84,120 @@ public class SingleChronicleQueueCorruptMetadataTest extends QueueTestCommon {
 
         assertEquals("thrown was " + chainOf(thrown), CorruptTableStoreException.class, thrown.getClass());
         assertTrue("corruption left the established I/O exception family", thrown instanceof IORuntimeException);
+    }
+
+    @Test
+    public void nestedFileNotFoundFromMetadataDoesNotActivateReadonlyFallback() {
+        final File queueDir = getTmpDir();
+        assertTrue("could not create queue directory " + queueDir, queueDir.mkdirs() || queueDir.isDirectory());
+        final File metadataFile = new File(queueDir, SingleChronicleQueue.QUEUE_METADATA_FILE);
+        NestedFileNotFoundMetadata.FAILURE = null;
+        try (net.openhft.chronicle.queue.impl.TableStore<NestedFileNotFoundMetadata> setupStore =
+                     SingleTableBuilder.binary(metadataFile, new NestedFileNotFoundMetadata()).build()) {
+            // The first open writes a valid table-store header for the extensible metadata fixture.
+            assertTrue("metadata fixture store was closed during construction", !setupStore.isClosed());
+        }
+
+        final FileNotFoundException nested = new FileNotFoundException("constructor sentinel");
+        NestedFileNotFoundMetadata.FAILURE = new IORuntimeException(nested);
+        try {
+            final IORuntimeException thrown = assertThrows(IORuntimeException.class,
+                    () -> {
+                        try (ChronicleQueue unexpectedQueue = SingleChronicleQueueBuilder
+                                .binary(queueDir)
+                                .readOnly(true)
+                                .build()) {
+                            fail("decoder failure activated metadata-unavailable fallback: " + unexpectedQueue);
+                        }
+                    });
+            assertFalse("decoder failure activated metadata-unavailable fallback",
+                    thrown instanceof TableStoreUnavailableException);
+            assertSame("the constructor's nested cause was discarded", nested, rootCause(thrown));
+        } finally {
+            NestedFileNotFoundMetadata.FAILURE = null;
+        }
+    }
+
+    @Test
+    public void constructorAvailabilitySignalDoesNotActivateReadonlyFallback() {
+        final File queueDir = getTmpDir();
+        assertTrue("could not create queue directory " + queueDir, queueDir.mkdirs() || queueDir.isDirectory());
+        final File metadataFile = new File(queueDir, SingleChronicleQueue.QUEUE_METADATA_FILE);
+        NestedFileNotFoundMetadata.FAILURE = null;
+        try (net.openhft.chronicle.queue.impl.TableStore<NestedFileNotFoundMetadata> setupStore =
+                     SingleTableBuilder.binary(metadataFile, new NestedFileNotFoundMetadata()).build()) {
+            assertFalse("metadata fixture store was closed during construction", setupStore.isClosed());
+        }
+
+        final TableStoreUnavailableException fabricated = unavailable(metadataFile, "constructor sentinel");
+        NestedFileNotFoundMetadata.FAILURE = fabricated;
+        try {
+            final IORuntimeException thrown = assertThrows(IORuntimeException.class,
+                    () -> SingleChronicleQueueBuilder.binary(queueDir).readOnly(true).build());
+            assertFalse("constructor signal activated metadata-unavailable fallback",
+                    thrown instanceof TableStoreUnavailableException);
+            assertSame("the constructor's signal was discarded", fabricated, rootCause(thrown));
+        } finally {
+            NestedFileNotFoundMetadata.FAILURE = null;
+        }
+    }
+
+    @Test
+    public void metadataAccessorUnavailabilityDoesNotActivateReadonlyFallback() {
+        Assume.assumeFalse("Windows deliberately does not use the synthetic read-only fallback", OS.isWindows());
+        final File queueDir = getTmpDir();
+        assertTrue("could not create queue directory " + queueDir, queueDir.mkdirs() || queueDir.isDirectory());
+        final File metadataFile = new File(queueDir, SingleChronicleQueue.QUEUE_METADATA_FILE);
+        final SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.binary(queueDir).readOnly(true);
+        AccessFailingSCQMeta.FAILURE = null;
+        final AccessFailingSCQMeta fixture = new AccessFailingSCQMeta(
+                new SCQRoll(builder.rollCycle(), builder.epoch(), null, null), builder.sourceId());
+        try (net.openhft.chronicle.queue.impl.TableStore<AccessFailingSCQMeta> setupStore =
+                     SingleTableBuilder.binary(metadataFile, fixture).build()) {
+            assertFalse("metadata fixture store was closed during construction", setupStore.isClosed());
+        }
+
+        final TableStoreUnavailableException expected = unavailable(metadataFile, "accessor sentinel");
+        AccessFailingSCQMeta.FAILURE = expected;
+        try {
+            final TableStoreUnavailableException actual = assertThrows(
+                    TableStoreUnavailableException.class, builder::initializeMetadata);
+            assertSame("post-open availability signal activated fallback", expected, actual);
+        } finally {
+            AccessFailingSCQMeta.FAILURE = null;
+            Closeable.closeQuietly(builder.metaStore());
+        }
+    }
+
+    @Test
+    public void metadataAccessorFailuresRetainIdentityAndReleaseTheMapping() {
+        assertMetadataAccessorFailureRetainsIdentity(new AssertionError("metadata accessor error"), "error");
+        assertMetadataAccessorFailureRetainsIdentity(new IOException("metadata accessor checked failure"), "checked");
+    }
+
+    private void assertMetadataAccessorFailureRetainsIdentity(Throwable expected, String stem) {
+        final File queueDir = new File(getTmpDir(), stem);
+        assertTrue("could not create queue directory " + queueDir, queueDir.mkdirs() || queueDir.isDirectory());
+        final File metadataFile = new File(queueDir, SingleChronicleQueue.QUEUE_METADATA_FILE);
+        final SingleChronicleQueueBuilder builder = SingleChronicleQueueBuilder.binary(queueDir).readOnly(true);
+        AccessFailingSCQMeta.FAILURE = null;
+        final AccessFailingSCQMeta fixture = new AccessFailingSCQMeta(
+                new SCQRoll(builder.rollCycle(), builder.epoch(), null, null), builder.sourceId());
+        try (net.openhft.chronicle.queue.impl.TableStore<AccessFailingSCQMeta> setupStore =
+                     SingleTableBuilder.binary(metadataFile, fixture).build()) {
+            assertFalse("metadata fixture store was closed during construction", setupStore.isClosed());
+        }
+
+        AccessFailingSCQMeta.FAILURE = expected;
+        try {
+            final Throwable actual = assertThrows(expected.getClass(), builder::build);
+            assertSame("metadata accessor failure was wrapped or replaced", expected, actual);
+            BackgroundResourceReleaser.releasePendingResources();
+            assertTrue("failed queue build retained the metadata mapping", metadataFile.delete());
+        } finally {
+            AccessFailingSCQMeta.FAILURE = null;
+            Closeable.closeQuietly(builder.metaStore());
+        }
     }
 
     /**
@@ -166,5 +295,61 @@ public class SingleChronicleQueueCorruptMetadataTest extends QueueTestCommon {
         for (Throwable t = thrown; t != null; t = t.getCause())
             sb.append(t).append(" <- ");
         return sb.toString();
+    }
+
+    private Throwable rootCause(Throwable failure) {
+        Throwable result = failure;
+        while (result.getCause() != null && result.getCause() != result)
+            result = result.getCause();
+        return result;
+    }
+
+    private TableStoreUnavailableException unavailable(File file, String message) {
+        try {
+            final Constructor<TableStoreUnavailableException> constructor =
+                    TableStoreUnavailableException.class.getDeclaredConstructor(File.class, String.class);
+            constructor.setAccessible(true);
+            return constructor.newInstance(file, message);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("could not create the package-owned availability signal", e);
+        }
+    }
+
+    public static final class NestedFileNotFoundMetadata implements Metadata {
+        private static RuntimeException FAILURE;
+
+        public NestedFileNotFoundMetadata() {
+        }
+
+        @SuppressWarnings("unused")
+        public NestedFileNotFoundMetadata(@NotNull WireIn wire) {
+            if (FAILURE != null)
+                throw FAILURE;
+        }
+
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            // No persisted fields are needed to exercise exception provenance.
+        }
+    }
+
+    public static final class AccessFailingSCQMeta extends SCQMeta {
+        private static Throwable FAILURE;
+
+        AccessFailingSCQMeta(@NotNull SCQRoll roll, int sourceId) {
+            super(roll, sourceId);
+        }
+
+        @SuppressWarnings("unused")
+        AccessFailingSCQMeta(@NotNull WireIn wire) {
+            super(wire);
+        }
+
+        @Override
+        public int sourceId() {
+            if (FAILURE != null)
+                throw Jvm.rethrow(FAILURE);
+            return super.sourceId();
+        }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilderCorruptMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilderCorruptMetadataTest.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.table;
+
+import net.openhft.chronicle.bytes.MappedBytes;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
+import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.queue.impl.TableStore;
+import net.openhft.chronicle.queue.impl.single.MetaDataField;
+import net.openhft.chronicle.wire.SelfDescribingMarshallable;
+import net.openhft.chronicle.wire.ValueOut;
+import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireIn;
+import net.openhft.chronicle.wire.WireOut;
+import net.openhft.chronicle.wire.WireType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Exercises the first-header classification and ownership boundaries without passing through the
+ * queue builder's read-only fallback.
+ */
+public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
+
+    @Test
+    public void nullAndWrongTypedHeaderValuesAreReportedAsCorruption() throws IOException {
+        final File nullValue = writeFirstHeader("null-value", "header", ValueOut::nu11);
+        final CorruptTableStoreException nullFailure = assertCorruption(nullValue, false);
+        assertTrue("message was " + nullFailure.getMessage(),
+                nullFailure.getMessage().contains("holds null instead of a table store"));
+        assertCorruption(nullValue, true);
+
+        final File wrongType = writeFirstHeader("wrong-type", "header",
+                value -> value.typedMarshallable(new WrongHeaderValue()));
+        final CorruptTableStoreException wrongTypeFailure = assertCorruption(wrongType, false);
+        assertTrue("message was " + wrongTypeFailure.getMessage(),
+                wrongTypeFailure.getMessage().contains(WrongHeaderValue.class.getName()));
+        assertFalse("diagnostic exposed application content: " + wrongTypeFailure.getMessage(),
+                wrongTypeFailure.getMessage().contains(WrongHeaderValue.SECRET));
+        assertCorruption(wrongType, true);
+    }
+
+    @Test
+    public void wrongCloseableHeaderValueIsClosedOnRejection() throws IOException {
+        CloseableWrongHeaderValue.CLOSE_COUNT.set(0);
+        final File file = writeFirstHeader("wrong-closeable-type", "header",
+                value -> value.typedMarshallable(new CloseableWrongHeaderValue()));
+
+        assertCorruption(file, false);
+
+        assertEquals("the rejected decoded value was not closed", 1, CloseableWrongHeaderValue.CLOSE_COUNT.get());
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void nullAndWrongTypedNestedMetadataAreReportedAsCorruption() throws IOException {
+        final File nullMetadata = writeTableStoreHeader("null-nested-metadata", ValueOut::nu11);
+        final CorruptTableStoreException nullFailure = assertCorruption(nullMetadata, false);
+        assertTrue("message was " + nullFailure.getMessage(),
+                nullFailure.getMessage().contains("holds null instead of metadata"));
+
+        CloseableWrongHeaderValue.CLOSE_COUNT.set(0);
+        final File wrongMetadata = writeTableStoreHeader("wrong-nested-metadata",
+                value -> value.typedMarshallable(new CloseableWrongHeaderValue()));
+        final CorruptTableStoreException wrongFailure = assertCorruption(wrongMetadata, false);
+        assertTrue("message was " + wrongFailure.getMessage(),
+                wrongFailure.getMessage().contains(CloseableWrongHeaderValue.class.getName()));
+        assertEquals("the rejected nested metadata was not closed",
+                1, CloseableWrongHeaderValue.CLOSE_COUNT.get());
+        assertFileCanBeDeleted(nullMetadata);
+        assertFileCanBeDeleted(wrongMetadata);
+    }
+
+    @Test
+    public void unknownTypeAliasIsReportedAsCorruption() throws IOException {
+        final File file = writeFirstHeader("unknown-alias", "header",
+                value -> value.typedMarshallable("missing.queue.table.store.Type", wire -> {
+                }));
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertNotNull("the parser failure was not retained", thrown.getCause());
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("does not hold a readable table store"));
+    }
+
+    @Test
+    public void malformedFirstEventNameIsReportedAsCorruption() throws IOException {
+        final File file = writeFirstHeader("wrong-event", "not-header",
+                value -> value.typedMarshallable(new WrongHeaderValue()));
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertNotNull("the event-name failure was not retained", thrown.getCause());
+        assertTrue("cause was " + thrown.getCause(),
+                thrown.getCause().getMessage().contains("first message should be the header"));
+    }
+
+    @Test
+    public void partialStoreConstructionIsCorruptionAndReleasesTheMapping() throws IOException {
+        final File file = writeFirstHeader("partial-store", "header",
+                value -> value.typedMarshallable("STStore",
+                        wire -> wire.write(MetaDataField.wireType).nu11()));
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertNotNull("the partial-construction failure was not retained", thrown.getCause());
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void unsupportedPersistedWireTypeIsCorruptionAndReleasesTheMapping() throws IOException {
+        final File file = writeFirstHeader("unsupported-persisted-wire", "header",
+                value -> value.typedMarshallable("STStore",
+                        wire -> wire.write(MetaDataField.wireType).object(WireType.TEXT)));
+        final byte[] before = Files.readAllBytes(file.toPath());
+
+        final CorruptTableStoreException thrown = assertThrows(CorruptTableStoreException.class,
+                () -> SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build());
+
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("unsupported wire type " + WireType.TEXT));
+        assertTrue("root cause was " + rootCause(thrown), rootCause(thrown) instanceof IllegalArgumentException);
+        assertTrue("message was " + rootCause(thrown).getMessage(),
+                rootCause(thrown).getMessage().contains(WireType.TEXT.name()));
+        assertArrayEquals("rejecting the unsupported persisted format changed the file",
+                before, Files.readAllBytes(file.toPath()));
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void metadataOverrideFailureRetainsIdentityAndReleasesTheMapping() throws IOException {
+        final File file = newTableStoreFile("override-failure");
+        try (TableStore<OverrideFailingMetadata> store = SingleTableBuilder
+                .binary(file, new OverrideFailingMetadata((BufferUnderflowException) null))
+                .build()) {
+            assertNotNull("the valid setup store was not built", store);
+        }
+        final BufferUnderflowException expected = new BufferUnderflowException();
+
+        final BufferUnderflowException thrown = assertThrows(BufferUnderflowException.class,
+                () -> SingleTableBuilder.binary(file, new OverrideFailingMetadata(expected)).build());
+
+        assertSame("metadata policy failure was translated or wrapped", expected, thrown);
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void nestedMetadataAliasAndConstructorFailuresAreNotMisreportedAsCorruption() throws IOException {
+        final File file = newTableStoreFile("metadata-constructor-failure");
+        ReadFailingMetadata.FAILURE = null;
+        try (TableStore<ReadFailingMetadata> store = SingleTableBuilder
+                .binary(file, new ReadFailingMetadata())
+                .build()) {
+            assertNotNull(store);
+        }
+
+        final UnsupportedOperationException applicationFailure =
+                new UnsupportedOperationException("deliberate application metadata failure");
+        final BufferUnderflowException boundsFailure = new BufferUnderflowException();
+        final OverlappingFileLockException overlapFailure = new OverlappingFileLockException();
+        try {
+            assertMetadataConstructorFailureNotCorrupt(file, applicationFailure);
+            assertMetadataConstructorFailureNotCorrupt(file, boundsFailure);
+            assertMetadataConstructorFailureNotCorrupt(file, overlapFailure);
+            assertFileCanBeDeleted(file);
+        } finally {
+            ReadFailingMetadata.FAILURE = null;
+        }
+
+        final File unknownNestedAlias = writeTableStoreHeader("unknown-nested-metadata",
+                value -> value.typedMarshallable("missing.queue.metadata.Type", wire -> {
+                }));
+        final IORuntimeException aliasFailure = assertThrows(IORuntimeException.class,
+                () -> SingleTableBuilder.binary(unknownNestedAlias, Metadata.NoMeta.INSTANCE).build());
+        assertFalse("an unavailable extensible metadata type was labelled as disk corruption",
+                aliasFailure instanceof CorruptTableStoreException);
+        assertFileCanBeDeleted(unknownNestedAlias);
+    }
+
+    private void assertMetadataConstructorFailureNotCorrupt(File file, RuntimeException expected) {
+        ReadFailingMetadata.FAILURE = expected;
+        final IORuntimeException thrown = assertThrows(IORuntimeException.class,
+                () -> SingleTableBuilder.binary(file, new ReadFailingMetadata()).build());
+        assertFalse("application failure was labelled as disk corruption",
+                thrown instanceof CorruptTableStoreException);
+        assertSame("application constructor failure lost its identity", expected, rootCause(thrown));
+    }
+
+    @Test
+    public void failedHeaderDecodePreservesTheFileAndReleasesTheMapping() throws IOException {
+        final File file = writeFirstHeader("preserved", "header",
+                value -> value.typedMarshallable(new WrongHeaderValue()));
+        final byte[] before = Files.readAllBytes(file.toPath());
+
+        assertCorruption(file, false);
+
+        assertArrayEquals("a failed writable open changed the table-store bytes",
+                before, Files.readAllBytes(file.toPath()));
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void failedInitialMetadataWriteClosesTheProvisionalStore() throws IOException {
+        final File file = newTableStoreFile("write-failure");
+        final AssertionError expected = new AssertionError("deliberate metadata write failure");
+
+        final AssertionError thrown = assertThrows(AssertionError.class,
+                () -> SingleTableBuilder.binary(file, new WriteFailingMetadata(expected)).build());
+
+        assertSame("the metadata failure was replaced", expected, thrown);
+        assertFileCanBeDeleted(file);
+    }
+
+    private CorruptTableStoreException assertCorruption(File file, boolean readOnly) {
+        final CorruptTableStoreException thrown = assertThrows(CorruptTableStoreException.class,
+                () -> {
+                    try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
+                            .binary(file, Metadata.NoMeta.INSTANCE)
+                            .readOnly(readOnly)
+                            .build()) {
+                        fail("the builder accepted corrupt metadata: " + store);
+                    }
+                });
+        assertNotNull("corruption had no message", thrown.getMessage());
+        return thrown;
+    }
+
+    private File writeFirstHeader(String stem, String eventName, Consumer<ValueOut> valueWriter) throws IOException {
+        final File file = newTableStoreFile(stem);
+        try (MappedBytes bytes = MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, false)) {
+            bytes.singleThreadedCheckDisabled(true);
+            try {
+                final Wire wire = WireType.BINARY_LIGHT.apply(bytes);
+                assertTrue("a new file already held a first header", wire.writeFirstHeader());
+                valueWriter.accept(wire.writeEventName(eventName));
+                wire.updateFirstHeader();
+            } finally {
+                bytes.singleThreadedCheckReset();
+            }
+        }
+        return file;
+    }
+
+    private File writeTableStoreHeader(String stem, Consumer<ValueOut> metadataWriter) throws IOException {
+        return writeFirstHeader(stem, "header", value -> value.typedMarshallable("STStore", wire -> {
+            wire.write(MetaDataField.wireType).object(WireType.BINARY_LIGHT);
+            metadataWriter.accept(wire.write(MetaDataField.metadata));
+        }));
+    }
+
+    private File newTableStoreFile(String stem) throws IOException {
+        final File dir = getTmpDir();
+        Files.createDirectories(dir.toPath());
+        final File file = new File(dir, stem + SingleTableStore.SUFFIX);
+        assertTrue("could not create " + file, file.createNewFile());
+        return file;
+    }
+
+    private void assertFileCanBeDeleted(File file) {
+        BackgroundResourceReleaser.releasePendingResources();
+        assertTrue("failed construction retained the mapping for " + file, file.delete());
+    }
+
+    private Throwable rootCause(Throwable failure) {
+        Throwable result = failure;
+        while (result.getCause() != null && result.getCause() != result)
+            result = result.getCause();
+        return result;
+    }
+
+    public static final class WrongHeaderValue extends SelfDescribingMarshallable {
+        private static final String SECRET = "header-secret-must-not-appear";
+
+        private String payload = SECRET;
+    }
+
+    public static final class CloseableWrongHeaderValue extends SelfDescribingMarshallable implements java.io.Closeable {
+        private static final AtomicInteger CLOSE_COUNT = new AtomicInteger();
+
+        @Override
+        public void close() {
+            CLOSE_COUNT.incrementAndGet();
+        }
+    }
+
+    public static final class WriteFailingMetadata implements Metadata {
+        private final transient AssertionError failure;
+
+        private WriteFailingMetadata(AssertionError failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            throw failure;
+        }
+    }
+
+    public static final class OverrideFailingMetadata implements Metadata {
+        private final transient BufferUnderflowException failure;
+
+        private OverrideFailingMetadata(BufferUnderflowException failure) {
+            this.failure = failure;
+        }
+
+        @SuppressWarnings("unused")
+        public OverrideFailingMetadata(@NotNull WireIn wire) {
+            this.failure = null;
+        }
+
+        @Override
+        public <T extends Metadata> void overrideFrom(T metadata) {
+            if (failure != null)
+                throw failure;
+        }
+
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            // no persisted fields are needed for this ownership test
+        }
+    }
+
+    public static final class ReadFailingMetadata implements Metadata {
+        private static RuntimeException FAILURE;
+
+        public ReadFailingMetadata() {
+        }
+
+        @SuppressWarnings("unused")
+        public ReadFailingMetadata(@NotNull WireIn wire) {
+            if (FAILURE != null)
+                throw FAILURE;
+        }
+
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            // no persisted fields are needed for this classification test
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilderCorruptMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilderCorruptMetadataTest.java
@@ -4,18 +4,24 @@
 package net.openhft.chronicle.queue.impl.table;
 
 import net.openhft.chronicle.bytes.MappedBytes;
+import net.openhft.chronicle.bytes.PageUtil;
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
 import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
+import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.TableStore;
 import net.openhft.chronicle.queue.impl.single.MetaDataField;
+import net.openhft.chronicle.wire.BinaryWireCode;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.ValueOut;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireIn;
 import net.openhft.chronicle.wire.WireOut;
 import net.openhft.chronicle.wire.WireType;
+import net.openhft.chronicle.wire.Wires;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
@@ -24,9 +30,16 @@ import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import static net.openhft.chronicle.core.pool.ClassAliasPool.CLASS_ALIASES;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -41,34 +54,44 @@ import static org.junit.Assert.fail;
  * queue builder's read-only fallback.
  */
 public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
+    private static final int LENGTH_MASK = 0x3FFFFFFF;
 
     @Test
     public void nullAndWrongTypedHeaderValuesAreReportedAsCorruption() throws IOException {
         final File nullValue = writeFirstHeader("null-value", "header", ValueOut::nu11);
         final CorruptTableStoreException nullFailure = assertCorruption(nullValue, false);
         assertTrue("message was " + nullFailure.getMessage(),
-                nullFailure.getMessage().contains("holds null instead of a table store"));
+                nullFailure.getMessage().contains("does not hold the table-store schema"));
         assertCorruption(nullValue, true);
 
         final File wrongType = writeFirstHeader("wrong-type", "header",
                 value -> value.typedMarshallable(new WrongHeaderValue()));
         final CorruptTableStoreException wrongTypeFailure = assertCorruption(wrongType, false);
         assertTrue("message was " + wrongTypeFailure.getMessage(),
-                wrongTypeFailure.getMessage().contains(WrongHeaderValue.class.getName()));
+                wrongTypeFailure.getMessage().contains("does not hold the table-store schema"));
         assertFalse("diagnostic exposed application content: " + wrongTypeFailure.getMessage(),
                 wrongTypeFailure.getMessage().contains(WrongHeaderValue.SECRET));
         assertCorruption(wrongType, true);
+
+        final File scalarValue = writeFirstHeader("scalar-value", "header", value -> value.int32(17));
+        assertCorruption(scalarValue, false);
+        assertCorruption(scalarValue, true);
     }
 
     @Test
-    public void wrongCloseableHeaderValueIsClosedOnRejection() throws IOException {
+    public void wrongCloseableHeaderValueIsNotConstructed() throws IOException {
+        CloseableWrongHeaderValue.CONSTRUCT_COUNT.set(0);
         CloseableWrongHeaderValue.CLOSE_COUNT.set(0);
         final File file = writeFirstHeader("wrong-closeable-type", "header",
                 value -> value.typedMarshallable(new CloseableWrongHeaderValue()));
+        CloseableWrongHeaderValue.CONSTRUCT_COUNT.set(0);
+        CloseableWrongHeaderValue.CLOSE_COUNT.set(0);
 
         assertCorruption(file, false);
 
-        assertEquals("the rejected decoded value was not closed", 1, CloseableWrongHeaderValue.CLOSE_COUNT.get());
+        assertEquals("the rejected outer type was constructed", 0,
+                CloseableWrongHeaderValue.CONSTRUCT_COUNT.get());
+        assertEquals("a rejected outer object was closed", 0, CloseableWrongHeaderValue.CLOSE_COUNT.get());
         assertFileCanBeDeleted(file);
     }
 
@@ -77,18 +100,27 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
         final File nullMetadata = writeTableStoreHeader("null-nested-metadata", ValueOut::nu11);
         final CorruptTableStoreException nullFailure = assertCorruption(nullMetadata, false);
         assertTrue("message was " + nullFailure.getMessage(),
-                nullFailure.getMessage().contains("holds null instead of metadata"));
+                nullFailure.getMessage().contains("does not hold metadata"));
 
+        CloseableWrongHeaderValue.CONSTRUCT_COUNT.set(0);
         CloseableWrongHeaderValue.CLOSE_COUNT.set(0);
         final File wrongMetadata = writeTableStoreHeader("wrong-nested-metadata",
                 value -> value.typedMarshallable(new CloseableWrongHeaderValue()));
+        CloseableWrongHeaderValue.CONSTRUCT_COUNT.set(0);
+        CloseableWrongHeaderValue.CLOSE_COUNT.set(0);
         final CorruptTableStoreException wrongFailure = assertCorruption(wrongMetadata, false);
         assertTrue("message was " + wrongFailure.getMessage(),
-                wrongFailure.getMessage().contains(CloseableWrongHeaderValue.class.getName()));
-        assertEquals("the rejected nested metadata was not closed",
-                1, CloseableWrongHeaderValue.CLOSE_COUNT.get());
+                wrongFailure.getMessage().contains("does not hold metadata"));
+        assertEquals("the rejected nested metadata type was constructed",
+                0, CloseableWrongHeaderValue.CONSTRUCT_COUNT.get());
+        assertEquals("a rejected nested metadata object was closed",
+                0, CloseableWrongHeaderValue.CLOSE_COUNT.get());
+
+        final File scalarMetadata = writeTableStoreHeader("scalar-nested-metadata", value -> value.int32(17));
+        assertCorruption(scalarMetadata, false);
         assertFileCanBeDeleted(nullMetadata);
         assertFileCanBeDeleted(wrongMetadata);
+        assertFileCanBeDeleted(scalarMetadata);
     }
 
     @Test
@@ -101,7 +133,8 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
 
         assertNotNull("the parser failure was not retained", thrown.getCause());
         assertTrue("message was " + thrown.getMessage(),
-                thrown.getMessage().contains("does not hold a readable table store"));
+                thrown.getMessage().contains("does not hold the table-store schema"));
+        assertThrowableChainOmits(thrown, "missing.queue.table.store.Type");
     }
 
     @Test
@@ -112,8 +145,26 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
         final CorruptTableStoreException thrown = assertCorruption(file, false);
 
         assertNotNull("the event-name failure was not retained", thrown.getCause());
-        assertTrue("cause was " + thrown.getCause(),
-                thrown.getCause().getMessage().contains("first message should be the header"));
+        assertThrowableChainOmits(thrown, "not-header");
+    }
+
+    @Test
+    public void outerHeaderRequiresTheCanonicalEventNameToken() throws IOException {
+        final File file = writeFirstHeader("non-canonical-header-token", "header",
+                value -> value.typedMarshallable("STStore",
+                        wire -> wire.write(MetaDataField.wireType).object(WireType.BINARY_LIGHT)));
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            raf.seek(Integer.BYTES);
+            assertEquals("fixture did not use EVENT_NAME", BinaryWireCode.EVENT_NAME, raf.readUnsignedByte());
+            raf.seek(Integer.BYTES);
+            raf.write(BinaryWireCode.FIELD_NAME_ANY);
+        }
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("does not hold a readable table store"));
+        assertFileCanBeDeleted(file);
     }
 
     @Test
@@ -129,23 +180,28 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void unsupportedPersistedWireTypeIsCorruptionAndReleasesTheMapping() throws IOException {
-        final File file = writeFirstHeader("unsupported-persisted-wire", "header",
-                value -> value.typedMarshallable("STStore",
-                        wire -> wire.write(MetaDataField.wireType).object(WireType.TEXT)));
-        final byte[] before = Files.readAllBytes(file.toPath());
+        for (WireType wireType : new WireType[]{
+                WireType.TEXT,
+                WireType.FIELDLESS_BINARY,
+                WireType.COMPRESSED_BINARY,
+                WireType.RAW
+        }) {
+            final File file = writeFirstHeader("unsupported-persisted-" + wireType.name().toLowerCase(), "header",
+                    value -> value.typedMarshallable("STStore",
+                            wire -> wire.write(MetaDataField.wireType).object(wireType)));
+            final byte[] before = Files.readAllBytes(file.toPath());
 
-        final CorruptTableStoreException thrown = assertThrows(CorruptTableStoreException.class,
-                () -> SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build());
+            final CorruptTableStoreException thrown = assertThrows(CorruptTableStoreException.class,
+                    () -> SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build());
 
-        assertTrue("message was " + thrown.getMessage(),
-                thrown.getMessage().contains("unsupported wire type " + WireType.TEXT));
-        assertTrue("root cause was " + rootCause(thrown), rootCause(thrown) instanceof IllegalArgumentException);
-        assertTrue("message was " + rootCause(thrown).getMessage(),
-                rootCause(thrown).getMessage().contains(WireType.TEXT.name()));
-        assertArrayEquals("rejecting the unsupported persisted format changed the file",
-                before, Files.readAllBytes(file.toPath()));
-        assertFileCanBeDeleted(file);
+            assertTrue("message was " + thrown.getMessage(),
+                    thrown.getMessage().contains("unsupported wire type"));
+            assertArrayEquals("rejecting " + wireType + " changed the file",
+                    before, Files.readAllBytes(file.toPath()));
+            assertFileCanBeDeleted(file);
+        }
     }
 
     @Test
@@ -166,6 +222,25 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
     }
 
     @Test
+    public void metadataOverrideCannotOriginateAnAvailabilitySignal() throws IOException {
+        final File file = newTableStoreFile("override-availability");
+        try (TableStore<OverrideFailingMetadata> store = SingleTableBuilder
+                .binary(file, new OverrideFailingMetadata((RuntimeException) null))
+                .build()) {
+            assertNotNull("the valid setup store was not built", store);
+        }
+        final TableStoreUnavailableException expected = new TableStoreUnavailableException(file, "override sentinel");
+
+        final IORuntimeException thrown = assertThrows(IORuntimeException.class,
+                () -> SingleTableBuilder.binary(file, new OverrideFailingMetadata(expected)).build());
+
+        assertFalse("metadata override impersonated the file-opening boundary", thrown instanceof TableStoreUnavailableException);
+        assertFalse("metadata policy was classified as disk corruption", thrown instanceof CorruptTableStoreException);
+        assertSame("the override failure was discarded", expected, thrown.getCause());
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
     public void nestedMetadataAliasAndConstructorFailuresAreNotMisreportedAsCorruption() throws IOException {
         final File file = newTableStoreFile("metadata-constructor-failure");
         ReadFailingMetadata.FAILURE = null;
@@ -179,10 +254,13 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
                 new UnsupportedOperationException("deliberate application metadata failure");
         final BufferUnderflowException boundsFailure = new BufferUnderflowException();
         final OverlappingFileLockException overlapFailure = new OverlappingFileLockException();
+        final ClassNotFoundRuntimeException applicationClassFailure =
+                new ClassNotFoundRuntimeException(new ClassNotFoundException("application constructor sentinel"));
         try {
             assertMetadataConstructorFailureNotCorrupt(file, applicationFailure);
             assertMetadataConstructorFailureNotCorrupt(file, boundsFailure);
             assertMetadataConstructorFailureNotCorrupt(file, overlapFailure);
+            assertMetadataConstructorFailureNotCorrupt(file, applicationClassFailure);
             assertFileCanBeDeleted(file);
         } finally {
             ReadFailingMetadata.FAILURE = null;
@@ -195,7 +273,288 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
                 () -> SingleTableBuilder.binary(unknownNestedAlias, Metadata.NoMeta.INSTANCE).build());
         assertFalse("an unavailable extensible metadata type was labelled as disk corruption",
                 aliasFailure instanceof CorruptTableStoreException);
+        assertThrowableChainOmits(aliasFailure, "missing.queue.metadata.Type");
         assertFileCanBeDeleted(unknownNestedAlias);
+    }
+
+    @Test
+    public void metadataConstructorErrorRetainsCauseAndReleasesTheMapping() throws IOException {
+        final File file = tableStoreWithReadFailingMetadata("metadata-constructor-error");
+        final AssertionError expected = new AssertionError("deliberate metadata constructor error");
+        ReadFailingMetadata.FAILURE = expected;
+        try {
+            final IORuntimeException actual = assertThrows(IORuntimeException.class,
+                    () -> SingleTableBuilder.binary(file, new ReadFailingMetadata()).build());
+            assertSame("metadata constructor Error was discarded", expected, rootCause(actual));
+            assertFileCanBeDeleted(file);
+        } finally {
+            ReadFailingMetadata.FAILURE = null;
+        }
+    }
+
+    @Test
+    public void nestedMetadataFramingFailureIsCorruptionAndRedacted() throws IOException {
+        final File file = newTableStoreFile("nested-metadata-framing");
+        try (TableStore<SecretMetadata> store = SingleTableBuilder.binary(file, new SecretMetadata()).build()) {
+            assertNotNull(store);
+        }
+        final long lengthCodeAt = nestedMetadataLengthCodeAt(file);
+        overwriteLengthWithMaximum(file, lengthCodeAt);
+        final long corruptedLength = Files.size(file.toPath());
+        SecretMetadata.READ_COUNT.set(0);
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("does not hold readable metadata"));
+        assertEquals("malformed metadata framing invoked its constructor", 0, SecretMetadata.READ_COUNT.get());
+        assertEquals("failed nested framing decode grew the file", corruptedLength, Files.size(file.toPath()));
+        assertThrowableChainOmits(thrown, SecretMetadata.SECRET);
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void outerTableStoreFramingFailureIsCorruptionWithoutConstruction() throws IOException {
+        final File file = newTableStoreFile("outer-table-store-framing");
+        try (TableStore<SecretMetadata> store = SingleTableBuilder.binary(file, new SecretMetadata()).build()) {
+            assertNotNull(store);
+        }
+        increaseLengthByOne(file, outerTableStoreLengthCodeAt(file));
+        final long corruptedLength = Files.size(file.toPath());
+        SecretMetadata.READ_COUNT.set(0);
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("does not hold a readable table store"));
+        assertEquals("out-of-header STStore framing invoked metadata", 0, SecretMetadata.READ_COUNT.get());
+        assertEquals("failed outer framing decode grew the file", corruptedLength, Files.size(file.toPath()));
+        assertThrowableChainOmits(thrown, SecretMetadata.SECRET);
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void oversizedOuterTableStoreLengthCannotEscapeTheFirstHeader() throws IOException {
+        final File file = newTableStoreFile("oversized-outer-table-store-framing");
+        try (TableStore<SecretMetadata> store = SingleTableBuilder.binary(file, new SecretMetadata()).build()) {
+            assertNotNull(store);
+        }
+        overwriteLengthWithMaximum(file, outerTableStoreLengthCodeAt(file));
+        final long corruptedLength = Files.size(file.toPath());
+        SecretMetadata.READ_COUNT.set(0);
+
+        assertCorruption(file, false);
+
+        assertEquals("oversized STStore framing invoked metadata", 0, SecretMetadata.READ_COUNT.get());
+        assertEquals("oversized STStore framing grew the file", corruptedLength, Files.size(file.toPath()));
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void metadataFieldFramingFailureIsCorruptionWithoutConstruction() throws IOException {
+        final File file = newTableStoreFile("metadata-field-framing");
+        try (TableStore<SecretMetadata> store = SingleTableBuilder.binary(file, new SecretMetadata()).build()) {
+            assertNotNull(store);
+        }
+        final long fieldCodeAt = metadataFieldCodeAt(file);
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            raf.seek(fieldCodeAt);
+            raf.write(BinaryWireCode.PADDING32);
+            raf.writeInt(Integer.reverseBytes(LENGTH_MASK));
+        }
+        SecretMetadata.READ_COUNT.set(0);
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertEquals("malformed metadata field framing invoked its constructor", 0, SecretMetadata.READ_COUNT.get());
+        assertThrowableChainOmits(thrown, SecretMetadata.SECRET);
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void trailingTableStoreFieldAfterMetadataIsCorruption() throws IOException {
+        final File file = writeFirstHeader("trailing-table-store-field", "header",
+                value -> value.typedMarshallable("STStore", wire -> {
+                    wire.write(MetaDataField.wireType).object(WireType.BINARY_LIGHT);
+                    wire.write(MetaDataField.metadata).typedMarshallable(new SecretMetadata());
+                    wire.write("unexpected").int32(17);
+                }));
+        SecretMetadata.READ_COUNT.set(0);
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("table-store body length does not match its decoded content"));
+        assertEquals("the valid metadata body was not read", 1, SecretMetadata.READ_COUNT.get());
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void unknownTableStoreFieldsAreRejectedAtEveryPosition() throws IOException {
+        final File beforeWireType = writeFirstHeader("unknown-before-wire-type", "header",
+                value -> value.typedMarshallable("STStore", wire -> {
+                    wire.write("unexpected").int32(1);
+                    wire.write(MetaDataField.wireType).object(WireType.BINARY_LIGHT);
+                }));
+        final File beforeMetadata = writeFirstHeader("unknown-before-metadata", "header",
+                value -> value.typedMarshallable("STStore", wire -> {
+                    wire.write(MetaDataField.wireType).object(WireType.BINARY_LIGHT);
+                    wire.write("unexpected").int32(2);
+                    wire.write(MetaDataField.metadata).typedMarshallable(new SecretMetadata());
+                }));
+
+        assertCorruption(beforeWireType, false);
+        assertCorruption(beforeMetadata, false);
+
+        assertFileCanBeDeleted(beforeWireType);
+        assertFileCanBeDeleted(beforeMetadata);
+    }
+
+    @Test
+    public void trailingTableStoreCommentIsCorruption() throws IOException {
+        final File file = writeFirstHeader("trailing-table-store-comment", "header",
+                value -> value.typedMarshallable("STStore", wire -> {
+                    wire.write(MetaDataField.wireType).object(WireType.BINARY_LIGHT);
+                    wire.write(MetaDataField.metadata).typedMarshallable(new SecretMetadata());
+                    wire.writeComment("comment-not-produced-by-table-store-writer");
+                }));
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("table-store body length does not match its decoded content"));
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void writerProducedFinalPaddingAcrossAllAlignmentsReopens() throws IOException {
+        final boolean[] observedPadding = new boolean[Integer.BYTES];
+        for (int payloadLength = 0; payloadLength < 16; payloadLength++) {
+            final File file = newTableStoreFile("final-padding-" + payloadLength);
+            try (TableStore<PaddingMetadata> store = SingleTableBuilder
+                    .binary(file, new PaddingMetadata(payloadLength))
+                    .build()) {
+                assertNotNull(store);
+            }
+            final int paddingBytes = tableStoreTrailingPaddingBytes(file);
+            assertTrue("writer produced unexpected final padding length " + paddingBytes,
+                    paddingBytes >= 0 && paddingBytes < Integer.BYTES);
+            observedPadding[paddingBytes] = true;
+            try (TableStore<PaddingMetadata> store = SingleTableBuilder
+                    .binary(file, new PaddingMetadata(0))
+                    .build()) {
+                assertEquals(payloadLength, store.metadata().payload.length());
+            }
+            assertFileCanBeDeleted(file);
+        }
+        for (int paddingBytes = 0; paddingBytes < observedPadding.length; paddingBytes++)
+            assertTrue("no fixture exercised " + paddingBytes + " final padding bytes", observedPadding[paddingBytes]);
+    }
+
+    @Test
+    public void foreignTableStoreIsRejectedAndReleasesTheMapping() throws IOException {
+        ForeignTableStore.CONSTRUCT_COUNT.set(0);
+        ForeignTableStore.CLOSE_COUNT.set(0);
+        final ForeignTableStore fixture = new ForeignTableStore();
+        final File file;
+        try {
+            file = writeFirstHeader("foreign-table-store", "header",
+                    value -> value.typedMarshallable(ForeignTableStore.class.getName(), fixture));
+        } finally {
+            fixture.close();
+        }
+        ForeignTableStore.CONSTRUCT_COUNT.set(0);
+        ForeignTableStore.CLOSE_COUNT.set(0);
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("does not hold the table-store schema"));
+        assertEquals("the foreign table store constructor ran", 0, ForeignTableStore.CONSTRUCT_COUNT.get());
+        assertEquals("a rejected foreign table store was closed", 0, ForeignTableStore.CLOSE_COUNT.get());
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void remappedTableStoreAliasCannotConstructForeignImplementation() throws IOException {
+        final File file = newTableStoreFile("remapped-table-store-alias");
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build()) {
+            assertEquals(SingleTableStore.class, store.getClass());
+        }
+
+        expectException("Replaced class net.openhft.chronicle.queue.impl.table.SingleTableStore with class "
+                + ForeignTableStore.class.getName());
+        expectException("Replaced class " + ForeignTableStore.class.getName()
+                + " with class net.openhft.chronicle.queue.impl.table.SingleTableStore");
+        ForeignTableStore.CONSTRUCT_COUNT.set(0);
+        ForeignTableStore.CLOSE_COUNT.set(0);
+        CLASS_ALIASES.addAlias(ForeignTableStore.class, "STStore");
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build()) {
+            assertEquals("mutable alias substituted a foreign implementation", SingleTableStore.class, store.getClass());
+            assertEquals("remapped foreign table store was constructed", 0, ForeignTableStore.CONSTRUCT_COUNT.get());
+        } finally {
+            CLASS_ALIASES.addAlias(SingleTableStore.class, "STStore");
+        }
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void applicationCorruptionExceptionIsNotPromoted() throws IOException {
+        final File file = tableStoreWithReadFailingMetadata("application-corruption");
+        final CorruptTableStoreException direct =
+                new CorruptTableStoreException(file, "application-created sentinel");
+        try {
+            ReadFailingMetadata.FAILURE = direct;
+            final IORuntimeException directFailure = assertThrows(IORuntimeException.class,
+                    () -> SingleTableBuilder.binary(file, new ReadFailingMetadata()).build());
+            assertFalse("application exception was promoted as Queue's diagnosis",
+                    directFailure instanceof CorruptTableStoreException);
+            assertSame("the direct application failure was lost", direct, rootCause(directFailure));
+
+            final CorruptTableStoreException nested =
+                    new CorruptTableStoreException(file, "nested application-created sentinel");
+            final IORuntimeException wrapper = new IORuntimeException("application wrapper", nested);
+            ReadFailingMetadata.FAILURE = wrapper;
+            final IORuntimeException wrappedFailure = assertThrows(IORuntimeException.class,
+                    () -> SingleTableBuilder.binary(file, new ReadFailingMetadata()).build());
+            assertFalse("wrapped application exception was promoted as Queue's diagnosis",
+                    wrappedFailure instanceof CorruptTableStoreException);
+            assertSame("the application wrapper was removed", wrapper, findInChain(wrappedFailure, wrapper));
+            assertSame("the nested application failure was lost", nested, rootCause(wrappedFailure));
+
+            final SingleTableStore.SchemaCorruptionException unrelatedMarker =
+                    new SingleTableStore.SchemaCorruptionException("unrelated table-store failure");
+            final CorruptTableStoreException unrelatedCorruption =
+                    new CorruptTableStoreException(file, "unrelated corruption", unrelatedMarker);
+            final IORuntimeException launderingWrapper =
+                    new IORuntimeException("application-carried corruption", unrelatedCorruption);
+            ReadFailingMetadata.FAILURE = launderingWrapper;
+            final IORuntimeException launderingFailure = assertThrows(IORuntimeException.class,
+                    () -> SingleTableBuilder.binary(file, new ReadFailingMetadata()).build());
+            assertFalse("an unrelated Queue marker was promoted as this file's diagnosis",
+                    launderingFailure instanceof CorruptTableStoreException);
+            assertSame("the application wrapper carrying the unrelated failure was removed",
+                    launderingWrapper, findInChain(launderingFailure, launderingWrapper));
+        } finally {
+            ReadFailingMetadata.FAILURE = null;
+        }
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void corruptionCauseChainDoesNotExposeStoredContent() throws IOException {
+        final String eventSecret = "stored-event-name-secret";
+        final File wrongEvent = writeFirstHeader("redacted-event", eventSecret,
+                value -> value.typedMarshallable(new WrongHeaderValue()));
+        assertThrowableChainOmits(assertCorruption(wrongEvent, false), eventSecret);
+
+        final String aliasSecret = "stored.alias.secret.Type";
+        final File wrongAlias = writeFirstHeader("redacted-alias", "header",
+                value -> value.typedMarshallable(aliasSecret, wire -> {
+                }));
+        assertThrowableChainOmits(assertCorruption(wrongAlias, false), aliasSecret);
+        assertFileCanBeDeleted(wrongEvent);
+        assertFileCanBeDeleted(wrongAlias);
     }
 
     private void assertMetadataConstructorFailureNotCorrupt(File file, RuntimeException expected) {
@@ -204,7 +563,156 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
                 () -> SingleTableBuilder.binary(file, new ReadFailingMetadata()).build());
         assertFalse("application failure was labelled as disk corruption",
                 thrown instanceof CorruptTableStoreException);
-        assertSame("application constructor failure lost its identity", expected, rootCause(thrown));
+        assertSame("application constructor failure lost its identity", expected, findInChain(thrown, expected));
+    }
+
+    private File tableStoreWithReadFailingMetadata(String stem) throws IOException {
+        final File file = newTableStoreFile(stem);
+        ReadFailingMetadata.FAILURE = null;
+        try (TableStore<ReadFailingMetadata> store = SingleTableBuilder
+                .binary(file, new ReadFailingMetadata())
+                .build()) {
+            assertNotNull(store);
+        }
+        return file;
+    }
+
+    private long nestedMetadataLengthCodeAt(File file) throws IOException {
+        final long[] result = {-1L};
+        try (MappedBytes bytes = MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, true)) {
+            bytes.singleThreadedCheckDisabled(true);
+            try {
+                final Wire wire = WireType.BINARY_LIGHT.apply(bytes);
+                wire.readFirstHeader();
+                final net.openhft.chronicle.wire.ValueIn storeValue = wire.read("header");
+                storeValue.typePrefix(new StringBuilder(), StringBuilder::append);
+                storeValue.applyToMarshallable(storeWire -> {
+                    storeWire.read(MetaDataField.wireType).object(WireType.class);
+                    final net.openhft.chronicle.wire.ValueIn metadataValue =
+                            storeWire.read(MetaDataField.metadata);
+                    metadataValue.typePrefix(new StringBuilder(), StringBuilder::append);
+                    result[0] = storeWire.bytes().readPosition();
+                    return null;
+                });
+            } finally {
+                bytes.singleThreadedCheckReset();
+            }
+        }
+        assertTrue("metadata length code was not located", result[0] >= 0L);
+        return result[0];
+    }
+
+    private long outerTableStoreLengthCodeAt(File file) throws IOException {
+        try (MappedBytes bytes = MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, true)) {
+            bytes.singleThreadedCheckDisabled(true);
+            try {
+                final Wire wire = WireType.BINARY_LIGHT.apply(bytes);
+                wire.readFirstHeader();
+                final net.openhft.chronicle.wire.ValueIn storeValue = wire.read("header");
+                storeValue.typePrefix(new StringBuilder(), StringBuilder::append);
+                return wire.bytes().readPosition();
+            } finally {
+                bytes.singleThreadedCheckReset();
+            }
+        }
+    }
+
+    private long metadataFieldCodeAt(File file) throws IOException {
+        final long[] result = {-1L};
+        try (MappedBytes bytes = MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, true)) {
+            bytes.singleThreadedCheckDisabled(true);
+            try {
+                final Wire wire = WireType.BINARY_LIGHT.apply(bytes);
+                wire.readFirstHeader();
+                final net.openhft.chronicle.wire.ValueIn storeValue = wire.read("header");
+                storeValue.typePrefix(new StringBuilder(), StringBuilder::append);
+                storeValue.applyToMarshallable(storeWire -> {
+                    storeWire.read(MetaDataField.wireType).object(WireType.class);
+                    storeWire.consumePadding();
+                    result[0] = storeWire.bytes().readPosition();
+                    return null;
+                });
+            } finally {
+                bytes.singleThreadedCheckReset();
+            }
+        }
+        assertTrue("metadata field code was not located", result[0] >= 0L);
+        return result[0];
+    }
+
+    private int tableStoreTrailingPaddingBytes(File file) throws IOException {
+        final int[] result = {-1};
+        try (MappedBytes bytes = MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, true)) {
+            bytes.singleThreadedCheckDisabled(true);
+            try {
+                final Wire wire = WireType.BINARY_LIGHT.apply(bytes);
+                wire.readFirstHeader();
+                final net.openhft.chronicle.wire.ValueIn storeValue = wire.read("header");
+                storeValue.typePrefix(new StringBuilder(), StringBuilder::append);
+                storeValue.applyToMarshallable(storeWire -> {
+                    storeWire.read(MetaDataField.wireType).object(WireType.class);
+                    storeWire.read(MetaDataField.metadata).typedMarshallable();
+                    result[0] = (int) storeWire.bytes().readRemaining();
+                    return null;
+                });
+            } finally {
+                bytes.singleThreadedCheckReset();
+            }
+        }
+        assertTrue("table-store trailing padding was not measured", result[0] >= 0);
+        return result[0];
+    }
+
+    private void increaseLengthByOne(File file, long lengthCodeAt) throws IOException {
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            raf.seek(lengthCodeAt);
+            final int code = raf.readUnsignedByte();
+            switch (code) {
+                case BinaryWireCode.BYTES_LENGTH8: {
+                    final int length = raf.readUnsignedByte();
+                    assertTrue("cannot increase an 8-bit maximum length", length < 0xff);
+                    raf.seek(lengthCodeAt + 1L);
+                    raf.write(length + 1);
+                    break;
+                }
+                case BinaryWireCode.BYTES_LENGTH16: {
+                    final long length = readUnsignedLittleEndian(raf, 2);
+                    assertTrue("cannot increase a 16-bit maximum length", length < 0xffff);
+                    raf.seek(lengthCodeAt + 1L);
+                    writeUnsignedLittleEndian(raf, length + 1L, 2);
+                    break;
+                }
+                case BinaryWireCode.BYTES_LENGTH32: {
+                    final long length = readUnsignedLittleEndian(raf, 4);
+                    assertTrue("cannot increase a 32-bit maximum length", length < 0xffffffffL);
+                    raf.seek(lengthCodeAt + 1L);
+                    writeUnsignedLittleEndian(raf, length + 1L, 4);
+                    break;
+                }
+                default:
+                    fail("expected a byte-length code at " + lengthCodeAt + ", found 0x" + Integer.toHexString(code));
+            }
+        }
+    }
+
+    private void overwriteLengthWithMaximum(File file, long lengthCodeAt) throws IOException {
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            raf.seek(lengthCodeAt);
+            raf.write(BinaryWireCode.BYTES_LENGTH32);
+            raf.writeInt(Integer.reverseBytes(LENGTH_MASK));
+        }
+    }
+
+    private long readUnsignedLittleEndian(java.io.RandomAccessFile raf, int width) throws IOException {
+        long value = 0L;
+        for (int i = 0; i < width; i++)
+            value |= (long) raf.readUnsignedByte() << (8 * i);
+        return value;
+    }
+
+    private void writeUnsignedLittleEndian(java.io.RandomAccessFile raf, long value, int width) throws IOException {
+        for (int i = 0; i < width; i++)
+            raf.write((int) (value >>> (8 * i)) & 0xff);
     }
 
     @Test
@@ -217,6 +725,120 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
 
         assertArrayEquals("a failed writable open changed the table-store bytes",
                 before, Files.readAllBytes(file.toPath()));
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void failedWritableOpenDoesNotGrowTruncatedMetadata() throws IOException {
+        final File file = newTableStoreFile("truncated");
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build()) {
+            assertNotNull(store);
+        }
+        final long truncatedLength;
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            final int header = Integer.reverseBytes(raf.readInt());
+            assertTrue("the fixture does not contain a ready metadata header",
+                    Wires.isReady(header) && (header & Wires.META_DATA) != 0);
+            truncatedLength = Integer.BYTES + Wires.lengthOf(header) - 1L;
+            assertTrue("the fixture's first header cannot be truncated positively", truncatedLength > Integer.BYTES);
+            raf.setLength(truncatedLength);
+        }
+        final byte[] before = Files.readAllBytes(file.toPath());
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue("message was " + thrown.getMessage(), thrown.getMessage().contains("extends beyond the physical file"));
+        assertEquals("failed writable open changed the file length", before.length, Files.size(file.toPath()));
+        assertArrayEquals("failed writable open changed the truncated bytes", before, Files.readAllBytes(file.toPath()));
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void compactCompleteTableStoreReopensReadOnly() throws IOException {
+        final File file = newTableStoreFile("compact-complete");
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build();
+             LongValue value = store.acquireValueFor("compact.key", 41L)) {
+            assertEquals(41L, value.getValue());
+        }
+        final long completeLength;
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            final int header = Integer.reverseBytes(raf.readInt());
+            assertTrue("the fixture does not contain a ready metadata header",
+                    Wires.isReady(header) && (header & Wires.META_DATA) != 0);
+            final long headerEnd = Integer.BYTES + Wires.lengthOf(header);
+            final long recordAt = (headerEnd + Integer.BYTES - 1L) & -Integer.BYTES;
+            raf.seek(recordAt);
+            final int recordHeader = Integer.reverseBytes(raf.readInt());
+            assertTrue("the fixture does not contain a ready data record",
+                    Wires.isReady(recordHeader) && Wires.isData(recordHeader));
+            final long usedEnd = recordAt + Integer.BYTES + Wires.lengthOf(recordHeader);
+            final int mappingPageSize = PageUtil.getPageSize(file.getAbsolutePath());
+            completeLength = ((usedEnd + mappingPageSize - 1L) / mappingPageSize) * mappingPageSize;
+            assertTrue("the fixture was not preallocated beyond its complete header", completeLength < raf.length());
+            assertTrue("compact fixture did not fit inside the ordinary two-chunk mapping",
+                    completeLength < 2L * OS.mapAlign(OS.SAFE_PAGE_SIZE, mappingPageSize));
+            raf.setLength(completeLength);
+        }
+
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
+                .builder(file, WireType.READ_ANY, Metadata.NoMeta.INSTANCE)
+                .readOnly(true)
+                .build();
+             LongValue value = store.acquireValueFor("compact.key", -1L)) {
+            assertEquals(Metadata.NoMeta.INSTANCE, store.metadata());
+            assertEquals(41L, value.getValue());
+            final Map<String, Long> entries = new LinkedHashMap<>();
+            store.forEachKey(entries, (result, key, valueIn) -> result.put(key.toString(), valueIn.int64()));
+            assertEquals(Long.valueOf(41L), entries.get("compact.key"));
+        }
+        assertEquals("read-only open changed the compact file", completeLength, Files.size(file.toPath()));
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void failedWritableOpenDoesNotGrowAnIncompleteFirstHeader() throws IOException {
+        final File file = newTableStoreFile("incomplete-first-header");
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            raf.writeInt(Integer.reverseBytes(Wires.NOT_COMPLETE_UNKNOWN_LENGTH));
+        }
+        final byte[] before = Files.readAllBytes(file.toPath());
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue(thrown.getMessage().contains("does not contain a ready first header"));
+        assertArrayEquals("failed open changed the incomplete file", before, Files.readAllBytes(file.toPath()));
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void readOnlyOpenRejectsHeaderBeyondPhysicalFileWithoutMutation() throws IOException {
+        final File file = newTableStoreFile("read-only-physical-bound");
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build()) {
+            assertNotNull(store);
+        }
+
+        final long compactLength = Math.max(OS.mapAlignment(), 4L * 1024L) + 37L;
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            final int header = Integer.reverseBytes(raf.readInt());
+            assertTrue("the fixture does not contain a ready metadata header",
+                    Wires.isReady(header) && (header & Wires.META_DATA) != 0);
+            final long declaredLength = compactLength + 16L;
+            assertTrue("declared length does not fit the Wire header", declaredLength <= LENGTH_MASK);
+            raf.seek(0L);
+            raf.writeInt(Integer.reverseBytes((header & ~LENGTH_MASK) | (int) declaredLength));
+            raf.setLength(compactLength);
+        }
+        final byte[] before = Files.readAllBytes(file.toPath());
+
+        final CorruptTableStoreException thrown = assertThrows(CorruptTableStoreException.class,
+                () -> SingleTableBuilder.builder(file, WireType.READ_ANY, Metadata.NoMeta.INSTANCE)
+                        .readOnly(true)
+                        .build());
+
+        assertTrue("physical-bound guard was not the failing decision: " + thrown,
+                thrown.getMessage().contains("extends beyond the physical file"));
+        assertEquals("failed read-only open changed the file length", compactLength, Files.size(file.toPath()));
+        assertArrayEquals("failed read-only open changed the compact file", before, Files.readAllBytes(file.toPath()));
         assertFileCanBeDeleted(file);
     }
 
@@ -289,6 +911,30 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
         return result;
     }
 
+    private Throwable findInChain(Throwable failure, Throwable expected) {
+        for (Throwable current = failure; current != null && current != current.getCause(); current = current.getCause()) {
+            if (current == expected)
+                return current;
+        }
+        return null;
+    }
+
+    private void assertThrowableChainOmits(Throwable failure, String forbidden) {
+        final Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        final ArrayDeque<Throwable> pending = new ArrayDeque<>();
+        pending.add(failure);
+        while (!pending.isEmpty()) {
+            final Throwable current = pending.removeFirst();
+            if (!seen.add(current))
+                continue;
+            assertFalse("throwable exposed persisted content: " + current,
+                    String.valueOf(current).contains(forbidden));
+            if (current.getCause() != null)
+                pending.add(current.getCause());
+            Collections.addAll(pending, current.getSuppressed());
+        }
+    }
+
     public static final class WrongHeaderValue extends SelfDescribingMarshallable {
         private static final String SECRET = "header-secret-must-not-appear";
 
@@ -296,7 +942,12 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
     }
 
     public static final class CloseableWrongHeaderValue extends SelfDescribingMarshallable implements java.io.Closeable {
+        private static final AtomicInteger CONSTRUCT_COUNT = new AtomicInteger();
         private static final AtomicInteger CLOSE_COUNT = new AtomicInteger();
+
+        public CloseableWrongHeaderValue() {
+            CONSTRUCT_COUNT.incrementAndGet();
+        }
 
         @Override
         public void close() {
@@ -318,9 +969,9 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
     }
 
     public static final class OverrideFailingMetadata implements Metadata {
-        private final transient BufferUnderflowException failure;
+        private final transient RuntimeException failure;
 
-        private OverrideFailingMetadata(BufferUnderflowException failure) {
+        private OverrideFailingMetadata(RuntimeException failure) {
             this.failure = failure;
         }
 
@@ -341,8 +992,48 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
         }
     }
 
+    public static final class SecretMetadata implements Metadata {
+        private static final String SECRET = "nested-metadata-secret-must-not-appear";
+        private static final AtomicInteger READ_COUNT = new AtomicInteger();
+        private String payload = SECRET;
+
+        public SecretMetadata() {
+        }
+
+        @SuppressWarnings("unused")
+        public SecretMetadata(@NotNull WireIn wire) {
+            READ_COUNT.incrementAndGet();
+            payload = wire.read("payload").text();
+        }
+
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            wire.write("payload").text(payload);
+        }
+    }
+
+    public static final class PaddingMetadata implements Metadata {
+        private final String payload;
+
+        PaddingMetadata(int payloadLength) {
+            final char[] chars = new char[payloadLength];
+            java.util.Arrays.fill(chars, 'p');
+            payload = new String(chars);
+        }
+
+        @SuppressWarnings("unused")
+        public PaddingMetadata(@NotNull WireIn wire) {
+            payload = wire.read("payload").text();
+        }
+
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            wire.write("payload").text(payload);
+        }
+    }
+
     public static final class ReadFailingMetadata implements Metadata {
-        private static RuntimeException FAILURE;
+        private static Throwable FAILURE;
 
         public ReadFailingMetadata() {
         }
@@ -350,12 +1041,38 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
         @SuppressWarnings("unused")
         public ReadFailingMetadata(@NotNull WireIn wire) {
             if (FAILURE != null)
-                throw FAILURE;
+                throw Jvm.rethrow(FAILURE);
         }
 
         @Override
         public void writeMarshallable(@NotNull WireOut wire) {
             // no persisted fields are needed for this classification test
+        }
+    }
+
+    public static final class ForeignTableStore extends ReadonlyTableStore<Metadata.NoMeta> {
+        private static final AtomicInteger CONSTRUCT_COUNT = new AtomicInteger();
+        private static final AtomicInteger CLOSE_COUNT = new AtomicInteger();
+
+        public ForeignTableStore() {
+            super(Metadata.NoMeta.INSTANCE);
+            CONSTRUCT_COUNT.incrementAndGet();
+        }
+
+        @SuppressWarnings("unused")
+        public ForeignTableStore(@NotNull WireIn wire) {
+            super(Metadata.NoMeta.INSTANCE);
+            CONSTRUCT_COUNT.incrementAndGet();
+        }
+
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            // This foreign schema deliberately retains no reference to the builder's mapped bytes.
+        }
+
+        @Override
+        protected void performClose() {
+            CLOSE_COUNT.incrementAndGet();
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreCorruptRecordTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreCorruptRecordTest.java
@@ -3,9 +3,14 @@
  */
 package net.openhft.chronicle.queue.impl.table;
 
+import net.openhft.chronicle.bytes.MappedBytes;
+import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.values.LongValue;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.TableStore;
+import net.openhft.chronicle.wire.BinaryWireCode;
+import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireType;
 import net.openhft.chronicle.wire.Wires;
 import org.junit.Test;
 
@@ -14,16 +19,22 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * QUEUE-148. A record in a table store declares its own length. If that length does not fit inside
- * the file, {@link SingleTableStore#acquireValueFor} must report the corruption. It must not walk
- * past the end of the mapped region.
+ * QUEUE-148. A record in a table store declares its own length. Both acquisition and iteration must
+ * bound every read by that declaration, then verify that the key, value and explicit Wire padding
+ * consume it exactly.
  */
 public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
 
@@ -45,44 +56,371 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
             try (LongValue value = store.acquireValueFor("key.199", -1L)) {
                 assertEquals(199, value.getValue());
             }
+
+            Map<String, Long> entries = new LinkedHashMap<>();
+            store.forEachKey(entries, (result, key, value) -> result.put(key.toString(), value.int64()));
+            assertEquals(200, entries.size());
+            assertEquals(Long.valueOf(0), entries.get("key.0"));
+            assertEquals(Long.valueOf(199), entries.get("key.199"));
+
+            List<Long> selectivelyReadValues = new ArrayList<>();
+            store.forEachKey(selectivelyReadValues, (result, key, value) -> {
+                if ("key.0".contentEquals(key) || "key.199".contentEquals(key))
+                    result.add(value.int64());
+            });
+            assertEquals(2, selectivelyReadValues.size());
+            assertEquals(Long.valueOf(0), selectivelyReadValues.get(0));
+            assertEquals(Long.valueOf(199), selectivelyReadValues.get(1));
+
+            List<String> keysSeenWithoutReadingValues = new ArrayList<>();
+            store.forEachKey(keysSeenWithoutReadingValues, (result, key, value) -> result.add(key.toString()));
+            assertEquals(200, keysSeenWithoutReadingValues.size());
+            assertEquals("key.0", keysSeenWithoutReadingValues.get(0));
+            assertEquals("key.199", keysSeenWithoutReadingValues.get(199));
         }
     }
 
     /**
-     * A record whose declared length runs past the read limit must be reported as corruption.
+     * A positive length that cuts through the key/value cannot borrow bytes beyond its boundary.
      */
     @Test
-    public void aRecordLengthThatDoesNotFitIsReportedAsCorruption() throws IOException {
-        File file = newTableStoreFile();
-        try (TableStore<Metadata.NoMeta> store = build(file)) {
-            try (LongValue value = store.acquireValueFor("key.one", 1L)) {
-                assertNotNull(value);
-            }
-        }
-        overstateLengthOfFirstRecord(file);
-
-        try (TableStore<Metadata.NoMeta> store = build(file)) {
-            try (LongValue value = store.acquireValueFor("key.one", 1L)) {
-                fail("a record that runs past the read limit was accepted: " + value);
-            }
-        } catch (CorruptTableStoreException expected) {
-            assertTrue("message was " + expected.getMessage(),
-                    expected.getMessage().contains("does not fit inside the read limit"));
-        }
+    public void shorterPositiveRecordIsRejected() throws IOException {
+        assertEveryTraversalRejects(LengthMutation.SHORTER_POSITIVE);
     }
 
     /**
-     * Overstates the declared length of the first record that follows the first header. The flag
-     * bits of the header keep their value, so the record still reads as a complete data record.
+     * A length can fit in the mapping and still be corrupt when it includes bytes after the value.
      */
-    private void overstateLengthOfFirstRecord(File file) throws IOException {
+    @Test
+    public void longerInRangeRecordIsRejected() throws IOException {
+        assertEveryTraversalRejects(LengthMutation.LONGER_IN_RANGE);
+    }
+
+    /**
+     * A declared end outside the readable mapping must be rejected before any record parsing.
+     */
+    @Test
+    public void recordBeyondTheReadLimitIsRejected() throws IOException {
+        assertEveryTraversalRejects(LengthMutation.BEYOND_READ_LIMIT,
+                "does not fit inside the read limit");
+    }
+
+    @Test
+    public void laterCorruptRecordIsRejectedWhenVisited() throws IOException {
+        File file = tableStoreWithTwoKeys();
+        mutateRecordLength(file, 1, LengthMutation.SHORTER_POSITIVE);
+
+        assertAcquireReads(file, "key.one", 1L);
+        assertAcquireRejects(file, "key.two");
+        assertAcquireRejects(file, "missing.key");
+        assertForEachKeyRejects(file);
+    }
+
+    @Test
+    public void laterMetadataHeaderIsRejected() throws IOException {
+        File file = tableStoreWithTwoKeys();
+        markRecordAsMetadata(file, 1);
+
+        assertAcquireReads(file, "key.one", 1L);
+        assertAcquireRejects(file, "key.two");
+        assertAcquireRejects(file, "missing.key");
+        assertForEachKeyRejects(file);
+    }
+
+    @Test
+    public void nonLongValueCodeIsRejectedByEveryTraversal() throws IOException {
+        File file = tableStoreWithTwoKeys();
+        replaceFirstValueCode(file, BinaryWireCode.FLOAT64);
+
+        assertAcquireRejects(file, "key.one");
+        assertAcquireRejects(file, "key.two");
+        assertForEachKeyRejects(file);
+    }
+
+    @Test
+    public void malformedBinaryPaddingIsRejected() throws IOException {
+        File truncated = tableStoreWithTwoKeys();
+        final long truncatedValueCodeAt = replaceFirstValueCode(truncated, BinaryWireCode.PADDING32);
+        truncateFirstRecordAfterValueCode(truncated, truncatedValueCodeAt);
+        assertAcquireRejects(truncated, "key.one", "ends inside a padding header");
+        assertForEachKeyRejects(truncated, "ends inside a padding header");
+
+        File oversized = tableStoreWithTwoKeys();
+        final long oversizedValueCodeAt = replaceFirstValueCode(oversized, BinaryWireCode.PADDING32);
+        overwriteAfterValueCode(oversized, oversizedValueCodeAt, LENGTH_MASK);
+        assertAcquireRejects(oversized, "key.one", "padding bytes with only");
+        assertForEachKeyRejects(oversized, "padding bytes with only");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void supportedBinaryWireTypesRoundTripBoundValues() {
+        final WireType[] supported = {
+                WireType.BINARY,
+                WireType.BINARY_LIGHT,
+                WireType.FIELDLESS_BINARY,
+                WireType.COMPRESSED_BINARY
+        };
+        for (WireType wireType : supported)
+            assertWireTypeRoundTripsBoundValues(wireType);
+    }
+
+    @Test
+    public void rawTableStoreStillScansValuesWrittenDuringItsInitialOpen() {
+        File file = newTableStoreFile("supported-raw");
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
+                .builder(file, WireType.RAW, Metadata.NoMeta.INSTANCE)
+                .build();
+             LongValue one = store.acquireValueFor("raw.one", 1L);
+             LongValue two = store.acquireValueFor("raw.two", 2L);
+             LongValue oneAgain = store.acquireValueFor("raw.one", -1L)) {
+            assertEquals(1L, one.getValue());
+            assertEquals(2L, two.getValue());
+            assertEquals(1L, oneAgain.getValue());
+        }
+    }
+
+    @Test
+    public void rawRecordLengthsAreBoundedDuringTheInitialOpen() throws IOException {
+        assertRawMutationRejected(LengthMutation.SHORTER_POSITIVE);
+        assertRawMutationRejected(LengthMutation.LONGER_IN_RANGE);
+    }
+
+    @Test
+    public void unsupportedWireTypesAreRejectedBeforeCreatingAFile() {
+        final WireType[] unsupported = {
+                WireType.TEXT,
+                WireType.JSON,
+                WireType.JSON_ONLY,
+                WireType.JSONL,
+                WireType.YAML,
+                WireType.YAML_ONLY,
+                WireType.CSV,
+                WireType.READ_ANY
+        };
+        for (WireType wireType : unsupported) {
+            final File file = newTableStoreFile("unsupported-" + wireType.name().toLowerCase());
+            final IllegalArgumentException thrown = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+                    () -> SingleTableBuilder.builder(file, wireType, Metadata.NoMeta.INSTANCE).build());
+            assertTrue("message was " + thrown.getMessage(), thrown.getMessage().contains(wireType.name()));
+            assertFalse("unsupported wire type created " + file, file.exists());
+        }
+    }
+
+    private void assertWireTypeRoundTripsBoundValues(WireType wireType) {
+        File file = newTableStoreFile("supported-" + wireType.name().toLowerCase());
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
+                .builder(file, wireType, Metadata.NoMeta.INSTANCE)
+                .build();
+             LongValue one = store.acquireValueFor("bound.one", 1L);
+             LongValue two = store.acquireValueFor("bound.two", 2L)) {
+            assertEquals(1L, one.getValue());
+            assertEquals(2L, two.getValue());
+        }
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
+                .builder(file, wireType, Metadata.NoMeta.INSTANCE)
+                .build();
+             LongValue one = store.acquireValueFor("bound.one", -1L);
+             LongValue two = store.acquireValueFor("bound.two", -1L)) {
+            assertEquals(1L, one.getValue());
+            assertEquals(2L, two.getValue());
+        }
+    }
+
+    private void assertRawMutationRejected(LengthMutation mutation) throws IOException {
+        File file = newTableStoreFile("raw-" + mutation.name().toLowerCase());
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
+                .builder(file, WireType.RAW, Metadata.NoMeta.INSTANCE)
+                .build()) {
+            try (LongValue one = store.acquireValueFor("raw.one", 1L);
+                 LongValue two = store.acquireValueFor("raw.two", 2L)) {
+                assertNotNull(one);
+                assertNotNull(two);
+            }
+            mutateRecordLength(file, 0, mutation);
+            final byte[] before = Files.readAllBytes(file.toPath());
+
+            assertAcquireRejects(store, "raw.one");
+            assertForEachKeyRejects(store);
+
+            assertEquals("rejecting a malformed RAW record changed the file length",
+                    before.length, Files.size(file.toPath()));
+            org.junit.Assert.assertArrayEquals("rejecting a malformed RAW record changed its bytes",
+                    before, Files.readAllBytes(file.toPath()));
+        }
+    }
+
+    private void assertEveryTraversalRejects(LengthMutation mutation) throws IOException {
+        assertEveryTraversalRejects(mutation, "the record at");
+    }
+
+    private void assertEveryTraversalRejects(LengthMutation mutation, String expectedMessage) throws IOException {
+        File file = tableStoreWithTwoKeys();
+        mutateRecordLength(file, 0, mutation);
+
+        assertAcquireRejects(file, "key.one", expectedMessage);
+        assertAcquireRejects(file, "key.two", expectedMessage);
+        assertAcquireRejects(file, "missing.key", expectedMessage);
+        assertForEachKeyRejects(file, expectedMessage);
+    }
+
+    private void assertAcquireReads(File file, String key, long expected) {
+        try (TableStore<Metadata.NoMeta> store = build(file);
+             LongValue value = store.acquireValueFor(key, -1L)) {
+            assertEquals(expected, value.getValue());
+        }
+    }
+
+    private void assertAcquireRejects(File file, String key) {
+        assertAcquireRejects(file, key, "the record at");
+    }
+
+    private void assertAcquireRejects(File file, String key, String expectedMessage) {
+        try (TableStore<Metadata.NoMeta> store = build(file);
+             LongValue value = store.acquireValueFor(key, -1L)) {
+            fail("acquireValueFor(" + key + ") accepted a corrupt record and returned " + value);
+        } catch (CorruptTableStoreException expected) {
+            assertTrue("message was " + expected.getMessage(), expected.getMessage().contains(expectedMessage));
+        }
+    }
+
+    private void assertAcquireRejects(TableStore<Metadata.NoMeta> store, String key) {
+        try (LongValue value = store.acquireValueFor(key, -1L)) {
+            fail("acquireValueFor(" + key + ") accepted a corrupt record and returned " + value);
+        } catch (CorruptTableStoreException expected) {
+            assertTrue("message was " + expected.getMessage(), expected.getMessage().contains("record at"));
+        }
+    }
+
+    private void assertForEachKeyRejects(File file) {
+        assertForEachKeyRejects(file, "the record at");
+    }
+
+    private void assertForEachKeyRejects(File file, String expectedMessage) {
+        try (TableStore<Metadata.NoMeta> store = build(file)) {
+            assertForEachKeyRejects(store, expectedMessage);
+        }
+    }
+
+    private void assertForEachKeyRejects(TableStore<Metadata.NoMeta> store) {
+        assertForEachKeyRejects(store, "record at");
+    }
+
+    private void assertForEachKeyRejects(TableStore<Metadata.NoMeta> store, String expectedMessage) {
+        try {
+            store.forEachKey(new ArrayList<>(), (keys, key, value) -> keys.add(key.toString()));
+            fail("forEachKey accepted a corrupt record");
+        } catch (CorruptTableStoreException expected) {
+            assertTrue("message was " + expected.getMessage(), expected.getMessage().contains(expectedMessage));
+        }
+    }
+
+    private File tableStoreWithTwoKeys() {
+        File file = newTableStoreFile();
+        try (TableStore<Metadata.NoMeta> store = build(file);
+             LongValue one = store.acquireValueFor("key.one", 1L);
+             LongValue two = store.acquireValueFor("key.two", 2L)) {
+            assertNotNull(one);
+            assertNotNull(two);
+        }
+        return file;
+    }
+
+    private void mutateRecordLength(File file, int ordinal, LengthMutation mutation) throws IOException {
         try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
-            final long recordAt = Integer.BYTES + Wires.lengthOf(readIntAt(raf, 0));
+            final long recordAt = recordAt(raf, ordinal);
             final int header = readIntAt(raf, recordAt);
             assertTrue("the record at " + recordAt + " is not a complete data record",
                     Wires.isReady(header) && Wires.isData(header));
-            writeIntAt(raf, recordAt, (header & ~LENGTH_MASK) | LENGTH_MASK);
+            final int originalLength = Wires.lengthOf(header);
+            final int replacementLength;
+            switch (mutation) {
+                case SHORTER_POSITIVE:
+                    assertTrue("record is too short to shorten positively: " + originalLength, originalLength > 1);
+                    replacementLength = 1;
+                    break;
+                case LONGER_IN_RANGE:
+                    replacementLength = originalLength + 1;
+                    assertTrue("the longer record would exceed the file", recordAt + Integer.BYTES + replacementLength <= raf.length());
+                    break;
+                case BEYOND_READ_LIMIT:
+                    replacementLength = LENGTH_MASK;
+                    break;
+                default:
+                    throw new AssertionError(mutation);
+            }
+            writeIntAt(raf, recordAt, (header & ~LENGTH_MASK) | replacementLength);
         }
+    }
+
+    private void markRecordAsMetadata(File file, int ordinal) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            final long recordAt = recordAt(raf, ordinal);
+            final int header = readIntAt(raf, recordAt);
+            assertTrue("the record at " + recordAt + " is not a complete data record",
+                    Wires.isReady(header) && Wires.isData(header));
+            writeIntAt(raf, recordAt, header | Wires.META_DATA);
+        }
+    }
+
+    private long replaceFirstValueCode(File file, int replacementCode) throws IOException {
+        final long valueCodeAt = firstValueCodeAt(file);
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            raf.seek(valueCodeAt);
+            final int originalCode = raf.read();
+            assertTrue("the table-store value did not use a bound-long code: 0x"
+                            + Integer.toHexString(originalCode),
+                    originalCode == 0 || originalCode == BinaryWireCode.INT64);
+            raf.seek(valueCodeAt);
+            raf.write(replacementCode);
+        }
+        return valueCodeAt;
+    }
+
+    private void overwriteAfterValueCode(File file, long valueCodeAt, int value) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            writeIntAt(raf, valueCodeAt + 1, value);
+        }
+    }
+
+    private void truncateFirstRecordAfterValueCode(File file, long valueCodeAt) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            final long recordAt = recordAt(raf, 0);
+            final int header = readIntAt(raf, recordAt);
+            final int lengthThroughValueCode = Math.toIntExact(valueCodeAt - recordAt - Integer.BYTES + 1);
+            writeIntAt(raf, recordAt, (header & ~LENGTH_MASK) | lengthThroughValueCode);
+        }
+    }
+
+    private long firstValueCodeAt(File file) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+            final long recordAt = recordAt(raf, 0);
+            final int header = readIntAt(raf, recordAt);
+            try (MappedBytes bytes = MappedBytes.mappedBytes(
+                    file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, true)) {
+                bytes.singleThreadedCheckDisabled(true);
+                try {
+                    final Wire wire = WireType.BINARY_LIGHT.apply(bytes);
+                    bytes.readPositionRemaining(recordAt + Integer.BYTES, Wires.lengthOf(header));
+                    wire.readEventName(new StringBuilder());
+                    wire.consumePadding();
+                    return bytes.readPosition();
+                } finally {
+                    bytes.singleThreadedCheckReset();
+                }
+            }
+        }
+    }
+
+    private long recordAt(RandomAccessFile raf, int ordinal) throws IOException {
+        long recordAt = alignHeader(Integer.BYTES + Wires.lengthOf(readIntAt(raf, 0)));
+        for (int i = 0; i < ordinal; i++)
+            recordAt = alignHeader(recordAt + Integer.BYTES + Wires.lengthOf(readIntAt(raf, recordAt)));
+        return recordAt;
+    }
+
+    private long alignHeader(long position) {
+        return (position + Integer.BYTES - 1L) & -Integer.BYTES;
     }
 
     private int readIntAt(RandomAccessFile raf, long position) throws IOException {
@@ -98,12 +436,22 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
     }
 
     private File newTableStoreFile() {
+        return newTableStoreFile("corrupt-record");
+    }
+
+    private File newTableStoreFile(String stem) {
         File dir = getTmpDir();
         dir.mkdirs();
-        return new File(dir, "corrupt-record" + SingleTableStore.SUFFIX);
+        return new File(dir, stem + SingleTableStore.SUFFIX);
     }
 
     private TableStore<Metadata.NoMeta> build(File file) {
         return SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build();
+    }
+
+    private enum LengthMutation {
+        SHORTER_POSITIVE,
+        LONGER_IN_RANGE,
+        BEYOND_READ_LIMIT
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreCorruptRecordTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreCorruptRecordTest.java
@@ -10,8 +10,11 @@ import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.queue.impl.TableStore;
 import net.openhft.chronicle.wire.BinaryWireCode;
 import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireIn;
+import net.openhft.chronicle.wire.WireOut;
 import net.openhft.chronicle.wire.WireType;
 import net.openhft.chronicle.wire.Wires;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.io.File;
@@ -21,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,7 +97,7 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
      */
     @Test
     public void longerInRangeRecordIsRejected() throws IOException {
-        assertEveryTraversalRejects(LengthMutation.LONGER_IN_RANGE);
+        assertEveryTraversalRejects(LengthMutation.LONGER_IN_RANGE, "content ends at");
     }
 
     /**
@@ -128,13 +132,124 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
     }
 
     @Test
+    public void firstRecordMustBeMetadata() throws IOException {
+        final File file = newTableStoreFile("first-record-is-data");
+        try (TableStore<Metadata.NoMeta> store = build(file)) {
+            try (LongValue value = store.acquireValueFor("key.one", 1L)) {
+                assertEquals(1L, value.getValue());
+            }
+            markFirstHeaderAsData(file);
+
+            assertAcquireRejects(store, "key.one", "first record is not table-store metadata");
+            assertForEachKeyRejects(store, "first record is not table-store metadata");
+        }
+    }
+
+    @Test
+    public void firstMetadataLengthMustBePositive() throws IOException {
+        final File file = newTableStoreFile("zero-length-metadata");
+        try (TableStore<Metadata.NoMeta> store = build(file)) {
+            try (LongValue value = store.acquireValueFor("key.one", 1L)) {
+                assertEquals(1L, value.getValue());
+            }
+            rewriteFirstHeaderLength(file, 0);
+
+            assertAcquireRejects(store, "key.one", "metadata header has no body");
+            assertForEachKeyRejects(store, "metadata header has no body");
+        }
+    }
+
+    @Test
+    public void firstMetadataEndMustBeHeaderAligned() throws IOException {
+        final File file = newTableStoreFile("misaligned-metadata-end");
+        try (TableStore<Metadata.NoMeta> store = build(file)) {
+            try (LongValue value = store.acquireValueFor("key.one", 1L)) {
+                assertEquals(1L, value.getValue());
+            }
+            final int originalLength;
+            try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+                originalLength = Wires.lengthOf(readIntAt(raf, 0L));
+            }
+            rewriteFirstHeaderLength(file, originalLength + 1);
+
+            assertAcquireRejects(store, "key.one", "metadata header end is not aligned");
+            assertForEachKeyRejects(store, "metadata header end is not aligned");
+        }
+    }
+
+    @Test
+    public void missingEventNameIsRejectedByEveryTraversal() throws IOException {
+        for (WireType wireType : new WireType[]{WireType.BINARY_LIGHT, WireType.BINARY}) {
+            final File file = tableStoreWithTwoKeys(wireType);
+            eraseFirstEventName(file, wireType);
+
+            assertAcquireRejects(file, wireType, "key.one", "event-name token");
+            assertAcquireRejects(file, wireType, "key.two", "event-name token");
+            assertAcquireRejects(file, wireType, "missing.key", "event-name token");
+            assertForEachKeyRejectsBeforeCallback(file, wireType, "event-name token");
+        }
+    }
+
+    @Test
+    public void nonCanonicalFieldNameTokenIsRejectedByEveryTraversal() throws IOException {
+        for (WireType wireType : new WireType[]{WireType.BINARY_LIGHT, WireType.BINARY}) {
+            final File file = tableStoreWithTwoKeys(wireType);
+            replaceFirstEventToken(file, BinaryWireCode.FIELD_NAME_ANY);
+
+            assertAcquireRejects(file, wireType, "key.one", "event-name token");
+            assertAcquireRejects(file, wireType, "key.two", "event-name token");
+            assertAcquireRejects(file, wireType, "missing.key", "event-name token");
+            assertForEachKeyRejectsBeforeCallback(file, wireType, "event-name token");
+        }
+    }
+
+    @Test
+    public void explicitEmptyEventNameRemainsValid() {
+        for (WireType wireType : new WireType[]{WireType.BINARY_LIGHT, WireType.BINARY}) {
+            final File file = newTableStoreFile("empty-key-" + wireType.name().toLowerCase());
+            try (TableStore<Metadata.NoMeta> store = build(file, wireType);
+                 LongValue value = store.acquireValueFor("", 17L)) {
+                assertEquals(17L, value.getValue());
+            }
+
+            try (TableStore<Metadata.NoMeta> store = build(file, wireType);
+                 LongValue value = store.acquireValueFor("", -1L)) {
+                assertEquals(17L, value.getValue());
+                final Map<String, Long> entries = new LinkedHashMap<>();
+                store.forEachKey(entries, (result, key, valueIn) -> result.put(key.toString(), valueIn.int64()));
+                assertEquals(Long.valueOf(17L), entries.get(""));
+            }
+        }
+    }
+
+    @Test
+    public void misalignedBoundLongIsRejected() throws IOException {
+        final File file = tableStoreWithTwoKeys();
+        shiftFirstBoundLongOneByteEarlier(file);
+
+        assertAcquireRejects(file, "key.one", "unaligned address");
+        assertAcquireRejects(file, "key.two", "unaligned address");
+        assertForEachKeyRejects(file, "unaligned address");
+    }
+
+    @Test
+    public void recordEndMustBeHeaderAligned() throws IOException {
+        final File file = tableStoreWithOneKey();
+        extendFirstRecordWithPadding(file);
+
+        assertAcquireRejects(file, "key.one", "not aligned for the next header");
+        assertAcquireRejects(file, "missing.key", "not aligned for the next header");
+        assertForEachKeyRejects(file, "not aligned for the next header");
+    }
+
+    @Test
     public void nonLongValueCodeIsRejectedByEveryTraversal() throws IOException {
         File file = tableStoreWithTwoKeys();
         replaceFirstValueCode(file, BinaryWireCode.FLOAT64);
 
         assertAcquireRejects(file, "key.one");
         assertAcquireRejects(file, "key.two");
-        assertForEachKeyRejects(file);
+        assertForEachKeyRejectsBeforeCallback(file, WireType.BINARY_LIGHT, "the record at");
     }
 
     @Test
@@ -143,51 +258,31 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
         final long truncatedValueCodeAt = replaceFirstValueCode(truncated, BinaryWireCode.PADDING32);
         truncateFirstRecordAfterValueCode(truncated, truncatedValueCodeAt);
         assertAcquireRejects(truncated, "key.one", "ends inside a padding header");
-        assertForEachKeyRejects(truncated, "ends inside a padding header");
+        assertForEachKeyRejectsBeforeCallback(
+                truncated, WireType.BINARY_LIGHT, "ends inside a padding header");
 
         File oversized = tableStoreWithTwoKeys();
         final long oversizedValueCodeAt = replaceFirstValueCode(oversized, BinaryWireCode.PADDING32);
         overwriteAfterValueCode(oversized, oversizedValueCodeAt, LENGTH_MASK);
         assertAcquireRejects(oversized, "key.one", "padding bytes with only");
-        assertForEachKeyRejects(oversized, "padding bytes with only");
+        assertForEachKeyRejectsBeforeCallback(
+                oversized, WireType.BINARY_LIGHT, "padding bytes with only");
     }
 
     @Test
     @SuppressWarnings("deprecation")
-    public void supportedBinaryWireTypesRoundTripBoundValues() {
+    public void canonicalAndLegacyBinarySelectorsRoundTripTheCommonSubset() {
         final WireType[] supported = {
-                WireType.BINARY,
                 WireType.BINARY_LIGHT,
-                WireType.FIELDLESS_BINARY,
-                WireType.COMPRESSED_BINARY
+                WireType.BINARY
         };
         for (WireType wireType : supported)
             assertWireTypeRoundTripsBoundValues(wireType);
     }
 
     @Test
-    public void rawTableStoreStillScansValuesWrittenDuringItsInitialOpen() {
-        File file = newTableStoreFile("supported-raw");
-        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
-                .builder(file, WireType.RAW, Metadata.NoMeta.INSTANCE)
-                .build();
-             LongValue one = store.acquireValueFor("raw.one", 1L);
-             LongValue two = store.acquireValueFor("raw.two", 2L);
-             LongValue oneAgain = store.acquireValueFor("raw.one", -1L)) {
-            assertEquals(1L, one.getValue());
-            assertEquals(2L, two.getValue());
-            assertEquals(1L, oneAgain.getValue());
-        }
-    }
-
-    @Test
-    public void rawRecordLengthsAreBoundedDuringTheInitialOpen() throws IOException {
-        assertRawMutationRejected(LengthMutation.SHORTER_POSITIVE);
-        assertRawMutationRejected(LengthMutation.LONGER_IN_RANGE);
-    }
-
-    @Test
-    public void unsupportedWireTypesAreRejectedBeforeCreatingAFile() {
+    @SuppressWarnings("deprecation")
+    public void unsupportedWritableWireTypesFailBeforeCreatingAFile() {
         final WireType[] unsupported = {
                 WireType.TEXT,
                 WireType.JSON,
@@ -196,7 +291,10 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
                 WireType.YAML,
                 WireType.YAML_ONLY,
                 WireType.CSV,
-                WireType.READ_ANY
+                WireType.READ_ANY,
+                WireType.RAW,
+                WireType.FIELDLESS_BINARY,
+                WireType.COMPRESSED_BINARY
         };
         for (WireType wireType : unsupported) {
             final File file = newTableStoreFile("unsupported-" + wireType.name().toLowerCase());
@@ -204,6 +302,101 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
                     () -> SingleTableBuilder.builder(file, wireType, Metadata.NoMeta.INSTANCE).build());
             assertTrue("message was " + thrown.getMessage(), thrown.getMessage().contains(wireType.name()));
             assertFalse("unsupported wire type created " + file, file.exists());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void readAnyReopensExistingBinaryTableStore() {
+        final WireType[] readable = {
+                WireType.BINARY_LIGHT,
+                WireType.BINARY
+        };
+        for (WireType wireType : readable) {
+            final File file = newTableStoreFile("read-any-" + wireType.name().toLowerCase());
+            try (TableStore<Metadata.NoMeta> store = build(file, wireType);
+                 LongValue value = store.acquireValueFor("read.any", 23L)) {
+                assertEquals(23L, value.getValue());
+            }
+
+            try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
+                    .builder(file, WireType.READ_ANY, Metadata.NoMeta.INSTANCE)
+                    .readOnly(true)
+                    .build();
+                 LongValue value = store.acquireValueFor("read.any", -1L)) {
+                assertEquals(23L, value.getValue());
+            }
+        }
+    }
+
+    @Test
+    public void readOnlyStoreOpenedBeforeGrowthSeesLaterKeys() throws IOException {
+        final File file = newTableStoreFile("read-only-observes-growth");
+        try (TableStore<Metadata.NoMeta> writer = build(file, WireType.BINARY_LIGHT);
+             TableStore<Metadata.NoMeta> reader = SingleTableBuilder
+                     .builder(file, WireType.READ_ANY, Metadata.NoMeta.INSTANCE)
+                     .readOnly(true)
+                     .build()) {
+            final long initialLength = Files.size(file.toPath());
+            String lastKey = null;
+            long lastValue = -1L;
+            for (int i = 0; i < 20_000 && Files.size(file.toPath()) <= initialLength; i++) {
+                lastKey = "growth.key." + i;
+                lastValue = i;
+                try (LongValue appended = writer.acquireValueFor(lastKey, lastValue)) {
+                    assertEquals(lastValue, appended.getValue());
+                }
+            }
+            assertTrue("fixture did not grow beyond its initial mapping", Files.size(file.toPath()) > initialLength);
+            try (LongValue observed = reader.acquireValueFor(lastKey, -1L)) {
+                assertEquals("read-only mapping did not observe the post-open key", lastValue, observed.getValue());
+            }
+        }
+    }
+
+    @Test
+    public void readAnyIgnoresFieldCodeBytesInTheFirstHeader() throws IOException {
+        File selected = null;
+        for (int payloadLength = 0; payloadLength < 512 && selected == null; payloadLength++) {
+            final File candidate = newTableStoreFile("read-any-header-code-" + payloadLength);
+            try (TableStore<SizedMetadata> store = SingleTableBuilder
+                    .builder(candidate, WireType.BINARY_LIGHT, new SizedMetadata(payloadLength))
+                    .build();
+                 LongValue value = store.acquireValueFor("read.any.header", 53L)) {
+                assertEquals(53L, value.getValue());
+            }
+            try (RandomAccessFile raf = new RandomAccessFile(candidate, "r")) {
+                final int firstHeaderByte = readIntAt(raf, 0L) & 0xff;
+                if (BinaryWireCode.isFieldCode(firstHeaderByte))
+                    selected = candidate;
+            }
+        }
+        assertNotNull("could not generate a valid first-header length whose low byte is a field code", selected);
+
+        try (TableStore<SizedMetadata> store = SingleTableBuilder
+                .builder(selected, WireType.READ_ANY, new SizedMetadata(0))
+                .readOnly(true)
+                .build();
+             LongValue value = store.acquireValueFor("read.any.header", -1L)) {
+            assertEquals(53L, value.getValue());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void canonicalAndLegacySelectorsCrossOpenWritableAndReadOnlyStores() {
+        final WireType[] binaryFormats = {WireType.BINARY_LIGHT, WireType.BINARY};
+        for (WireType persisted : binaryFormats) {
+            final File file = newTableStoreFile("cross-open-" + persisted.name().toLowerCase());
+            try (TableStore<Metadata.NoMeta> store = build(file, persisted);
+                 LongValue value = store.acquireValueFor("cross.open", 31L)) {
+                assertEquals(31L, value.getValue());
+            }
+
+            for (WireType selector : binaryFormats) {
+                assertCrossOpenReads(file, selector, false);
+                assertCrossOpenReads(file, selector, true);
+            }
         }
     }
 
@@ -227,26 +420,13 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
         }
     }
 
-    private void assertRawMutationRejected(LengthMutation mutation) throws IOException {
-        File file = newTableStoreFile("raw-" + mutation.name().toLowerCase());
+    private void assertCrossOpenReads(File file, WireType selector, boolean readOnly) {
         try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
-                .builder(file, WireType.RAW, Metadata.NoMeta.INSTANCE)
-                .build()) {
-            try (LongValue one = store.acquireValueFor("raw.one", 1L);
-                 LongValue two = store.acquireValueFor("raw.two", 2L)) {
-                assertNotNull(one);
-                assertNotNull(two);
-            }
-            mutateRecordLength(file, 0, mutation);
-            final byte[] before = Files.readAllBytes(file.toPath());
-
-            assertAcquireRejects(store, "raw.one");
-            assertForEachKeyRejects(store);
-
-            assertEquals("rejecting a malformed RAW record changed the file length",
-                    before.length, Files.size(file.toPath()));
-            org.junit.Assert.assertArrayEquals("rejecting a malformed RAW record changed its bytes",
-                    before, Files.readAllBytes(file.toPath()));
+                .builder(file, selector, Metadata.NoMeta.INSTANCE)
+                .readOnly(readOnly)
+                .build();
+             LongValue value = store.acquireValueFor("cross.open", -1L)) {
+            assertEquals("selector=" + selector + ", readOnly=" + readOnly, 31L, value.getValue());
         }
     }
 
@@ -276,7 +456,11 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
     }
 
     private void assertAcquireRejects(File file, String key, String expectedMessage) {
-        try (TableStore<Metadata.NoMeta> store = build(file);
+        assertAcquireRejects(file, WireType.BINARY_LIGHT, key, expectedMessage);
+    }
+
+    private void assertAcquireRejects(File file, WireType wireType, String key, String expectedMessage) {
+        try (TableStore<Metadata.NoMeta> store = build(file, wireType);
              LongValue value = store.acquireValueFor(key, -1L)) {
             fail("acquireValueFor(" + key + ") accepted a corrupt record and returned " + value);
         } catch (CorruptTableStoreException expected) {
@@ -285,10 +469,14 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
     }
 
     private void assertAcquireRejects(TableStore<Metadata.NoMeta> store, String key) {
+        assertAcquireRejects(store, key, "record at");
+    }
+
+    private void assertAcquireRejects(TableStore<Metadata.NoMeta> store, String key, String expectedMessage) {
         try (LongValue value = store.acquireValueFor(key, -1L)) {
             fail("acquireValueFor(" + key + ") accepted a corrupt record and returned " + value);
         } catch (CorruptTableStoreException expected) {
-            assertTrue("message was " + expected.getMessage(), expected.getMessage().contains("record at"));
+            assertTrue("message was " + expected.getMessage(), expected.getMessage().contains(expectedMessage));
         }
     }
 
@@ -297,8 +485,29 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
     }
 
     private void assertForEachKeyRejects(File file, String expectedMessage) {
-        try (TableStore<Metadata.NoMeta> store = build(file)) {
+        assertForEachKeyRejects(file, WireType.BINARY_LIGHT, expectedMessage);
+    }
+
+    private void assertForEachKeyRejects(File file, WireType wireType, String expectedMessage) {
+        try (TableStore<Metadata.NoMeta> store = build(file, wireType)) {
             assertForEachKeyRejects(store, expectedMessage);
+        }
+    }
+
+    private void assertForEachKeyRejectsBeforeCallback(File file,
+                                                       WireType wireType,
+                                                       String expectedMessage) {
+        try (TableStore<Metadata.NoMeta> store = build(file, wireType)) {
+            final List<String> callbacks = new ArrayList<>();
+            try {
+                store.forEachKey(callbacks, (keys, key, value) -> keys.add(key.toString()));
+                fail("forEachKey accepted a corrupt record");
+            } catch (CorruptTableStoreException expected) {
+                assertTrue("message was " + expected.getMessage(),
+                        expected.getMessage().contains(expectedMessage));
+                assertTrue("callback ran before the first corrupt record was validated: " + callbacks,
+                        callbacks.isEmpty());
+            }
         }
     }
 
@@ -316,14 +525,99 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
     }
 
     private File tableStoreWithTwoKeys() {
-        File file = newTableStoreFile();
-        try (TableStore<Metadata.NoMeta> store = build(file);
+        return tableStoreWithTwoKeys(WireType.BINARY_LIGHT);
+    }
+
+    private File tableStoreWithTwoKeys(WireType wireType) {
+        File file = newTableStoreFile("two-keys-" + wireType.name().toLowerCase());
+        try (TableStore<Metadata.NoMeta> store = build(file, wireType);
              LongValue one = store.acquireValueFor("key.one", 1L);
              LongValue two = store.acquireValueFor("key.two", 2L)) {
             assertNotNull(one);
             assertNotNull(two);
         }
         return file;
+    }
+
+    private File tableStoreWithOneKey() {
+        File file = newTableStoreFile("one-key");
+        try (TableStore<Metadata.NoMeta> store = build(file);
+             LongValue one = store.acquireValueFor("key.one", 1L)) {
+            assertNotNull(one);
+        }
+        return file;
+    }
+
+    private void eraseFirstEventName(File file, WireType wireType) throws IOException {
+        final long valueCodeAt = firstValueCodeAt(file, wireType);
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            final long bodyStart = recordAt(raf, 0) + Integer.BYTES;
+            assertTrue("the first record has no event-name bytes", bodyStart < valueCodeAt);
+            raf.seek(bodyStart);
+            for (long position = bodyStart; position < valueCodeAt; position++)
+                raf.write(BinaryWireCode.PADDING);
+        }
+    }
+
+    private void replaceFirstEventToken(File file, int replacementCode) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            final long bodyStart = recordAt(raf, 0) + Integer.BYTES;
+            raf.seek(bodyStart);
+            assertEquals("the first record does not begin with EVENT_NAME",
+                    BinaryWireCode.EVENT_NAME, raf.read());
+            raf.seek(bodyStart);
+            raf.write(replacementCode);
+        }
+    }
+
+    private void shiftFirstBoundLongOneByteEarlier(File file) throws IOException {
+        final long valueCodeAt = firstValueCodeAt(file);
+        final long eventEnd = firstValuePosition(file, WireType.BINARY_LIGHT, false);
+        assertTrue("the test record has no padding before its bound long", eventEnd < valueCodeAt);
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            raf.seek(eventEnd);
+            for (long position = eventEnd; position < valueCodeAt; position++)
+                raf.write(BinaryWireCode.PADDING);
+            raf.seek(valueCodeAt - 1L);
+            assertEquals("the test requires one padding byte before the bound long",
+                    BinaryWireCode.PADDING, raf.read());
+            final byte[] codeAndValue = new byte[1 + Long.BYTES];
+            raf.readFully(codeAndValue);
+            assertTrue("the table-store value did not use a bound-long code",
+                    (codeAndValue[0] & 0xff) == 0 || (codeAndValue[0] & 0xff) == BinaryWireCode.INT64);
+            raf.seek(valueCodeAt - 1L);
+            raf.write(codeAndValue);
+            raf.write(BinaryWireCode.PADDING);
+        }
+    }
+
+    private void extendFirstRecordWithPadding(File file) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            final long recordAt = recordAt(raf, 0);
+            final int header = readIntAt(raf, recordAt);
+            final int originalLength = Wires.lengthOf(header);
+            raf.seek(recordAt + Integer.BYTES + originalLength);
+            raf.write(BinaryWireCode.PADDING);
+            writeIntAt(raf, recordAt, (header & ~LENGTH_MASK) | (originalLength + 1));
+        }
+    }
+
+    private void markFirstHeaderAsData(File file) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            final int header = readIntAt(raf, 0L);
+            assertTrue("the first record is not a ready metadata header",
+                    Wires.isReady(header) && (header & Wires.META_DATA) != 0);
+            writeIntAt(raf, 0L, header & ~Wires.META_DATA);
+        }
+    }
+
+    private void rewriteFirstHeaderLength(File file, int length) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            final int header = readIntAt(raf, 0L);
+            assertTrue("the first record is not a ready metadata header",
+                    Wires.isReady(header) && (header & Wires.META_DATA) != 0);
+            writeIntAt(raf, 0L, (header & ~LENGTH_MASK) | length);
+        }
     }
 
     private void mutateRecordLength(File file, int ordinal, LengthMutation mutation) throws IOException {
@@ -340,7 +634,8 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
                     replacementLength = 1;
                     break;
                 case LONGER_IN_RANGE:
-                    replacementLength = originalLength + 1;
+                    // Keep the end aligned so exact consumption, rather than header alignment, rejects the mutation.
+                    replacementLength = originalLength + Integer.BYTES;
                     assertTrue("the longer record would exceed the file", recordAt + Integer.BYTES + replacementLength <= raf.length());
                     break;
                 case BEYOND_READ_LIMIT:
@@ -393,6 +688,14 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
     }
 
     private long firstValueCodeAt(File file) throws IOException {
+        return firstValueCodeAt(file, WireType.BINARY_LIGHT);
+    }
+
+    private long firstValueCodeAt(File file, WireType wireType) throws IOException {
+        return firstValuePosition(file, wireType, true);
+    }
+
+    private long firstValuePosition(File file, WireType wireType, boolean consumePadding) throws IOException {
         try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
             final long recordAt = recordAt(raf, 0);
             final int header = readIntAt(raf, recordAt);
@@ -400,10 +703,11 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
                     file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, true)) {
                 bytes.singleThreadedCheckDisabled(true);
                 try {
-                    final Wire wire = WireType.BINARY_LIGHT.apply(bytes);
+                    final Wire wire = wireType.apply(bytes);
                     bytes.readPositionRemaining(recordAt + Integer.BYTES, Wires.lengthOf(header));
                     wire.readEventName(new StringBuilder());
-                    wire.consumePadding();
+                    if (consumePadding)
+                        wire.consumePadding();
                     return bytes.readPosition();
                 } finally {
                     bytes.singleThreadedCheckReset();
@@ -446,12 +750,36 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
     }
 
     private TableStore<Metadata.NoMeta> build(File file) {
-        return SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build();
+        return build(file, WireType.BINARY_LIGHT);
+    }
+
+    private TableStore<Metadata.NoMeta> build(File file, WireType wireType) {
+        return SingleTableBuilder.builder(file, wireType, Metadata.NoMeta.INSTANCE).build();
     }
 
     private enum LengthMutation {
         SHORTER_POSITIVE,
         LONGER_IN_RANGE,
         BEYOND_READ_LIMIT
+    }
+
+    public static final class SizedMetadata implements Metadata {
+        private final String payload;
+
+        SizedMetadata(int payloadLength) {
+            final char[] chars = new char[payloadLength];
+            Arrays.fill(chars, 'x');
+            payload = new String(chars);
+        }
+
+        @SuppressWarnings("unused")
+        public SizedMetadata(@NotNull WireIn wire) {
+            payload = wire.read("payload").text();
+        }
+
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            wire.write("payload").text(payload);
+        }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreLockTest.java
@@ -10,11 +10,14 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -22,10 +25,14 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import java.util.function.IntConsumer;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -58,6 +65,244 @@ public class SingleTableStoreLockTest extends QueueTestCommon {
     @Test
     public void sharedContentionIsRetriedBeforeBodyRunsOnce() throws Exception {
         assertContentionIsRetriedBeforeBodyRunsOnce(true);
+    }
+
+    @Test
+    public void subprocessContentionRetriesNullBeforeBody() throws Exception {
+        final File file = newLockFile();
+        final String java = new File(new File(System.getProperty("java.home"), "bin"), "java").getPath();
+        final Process holder = new ProcessBuilder(java, "-cp", System.getProperty("java.class.path"),
+                LockHolder.class.getName(), file.getAbsolutePath()).redirectError(ProcessBuilder.Redirect.INHERIT).start();
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final AtomicInteger bodyCalls = new AtomicInteger();
+        final AtomicInteger targetCalls = new AtomicInteger();
+        final BufferedReader output = new BufferedReader(new InputStreamReader(holder.getInputStream(), StandardCharsets.UTF_8));
+        try {
+            assertEquals("LOCKED", executor.submit(output::readLine).get(5, TimeUnit.SECONDS));
+            final ObservedFileLockRuntime runtime = new ObservedFileLockRuntime(file, false);
+            final Future<String> result = executor.submit(() -> withLock(file, false, target -> {
+                bodyCalls.incrementAndGet();
+                return target;
+            }, () -> {
+                targetCalls.incrementAndGet();
+                return "done";
+            }, TimeUnit.SECONDS.toNanos(5), runtime));
+
+            assertTrue("the real null-contention result was not observed", runtime.contention.await(5, TimeUnit.SECONDS));
+            assertTrue("same-JVM overlap was observed instead of null", runtime.nullResults.get() > 0);
+            assertEquals(0, bodyCalls.get());
+            assertEquals(0, targetCalls.get());
+            holder.getOutputStream().write(1);
+            holder.getOutputStream().flush();
+            assertTrue("lock-holder process did not finish", holder.waitFor(5, TimeUnit.SECONDS));
+            assertEquals(0, holder.exitValue());
+            assertEquals("done", result.get(5, TimeUnit.SECONDS));
+            assertEquals(1, bodyCalls.get());
+            assertEquals(1, targetCalls.get());
+        } finally {
+            holder.destroyForcibly();
+            try {
+                assertTrue("lock-holder process survived cleanup", holder.waitFor(5, TimeUnit.SECONDS));
+            } finally {
+                output.close();
+                ExecutorServiceUtil.shutdownForciblyAndWaitForTermination(executor);
+            }
+        }
+    }
+
+    @Test
+    public void scriptedNullContentionSignalsAttemptBeforeBodyAndThenSucceeds() throws Exception {
+        final File file = newLockFile();
+        final CountDownLatch attempted = new CountDownLatch(1);
+        final CountDownLatch releaseContention = new CountDownLatch(1);
+        final AtomicInteger scriptedAttempts = new AtomicInteger();
+        final AtomicLong now = new AtomicLong();
+        final AtomicInteger targetCalls = new AtomicInteger();
+        final AtomicInteger bodyCalls = new AtomicInteger();
+        final TestLockRuntime runtime = new TestLockRuntime(
+                () -> {
+                    attempted.countDown();
+                    return scriptedAttempts.getAndIncrement() > 0;
+                },
+                now::get,
+                ignored -> {
+                    await(releaseContention);
+                    now.incrementAndGet();
+                });
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try {
+            final Future<String> result = executor.submit(() -> withLock(file, false, target -> {
+                bodyCalls.incrementAndGet();
+                return target + "-done";
+            }, () -> {
+                targetCalls.incrementAndGet();
+                return "target";
+            }, 2L, runtime));
+
+            assertTrue("lock acquisition was not attempted", attempted.await(5, TimeUnit.SECONDS));
+            assertThrows("body ran before scripted contention was released", TimeoutException.class,
+                    () -> result.get(100, TimeUnit.MILLISECONDS));
+            assertEquals(0, targetCalls.get());
+            assertEquals(0, bodyCalls.get());
+
+            releaseContention.countDown();
+
+            assertEquals("target-done", result.get(5, TimeUnit.SECONDS));
+            assertEquals(2, runtime.attemptCalls.get());
+            assertEquals(1, runtime.pauseCalls.get());
+            assertEquals(1, runtime.closeLockCalls.get());
+            assertEquals(1, runtime.closeCalls.get());
+            assertEquals(1, targetCalls.get());
+            assertEquals(1, bodyCalls.get());
+        } finally {
+            releaseContention.countDown();
+            ExecutorServiceUtil.shutdownForciblyAndWaitForTermination(executor);
+        }
+    }
+
+    @Test
+    public void scriptedAcquisitionIOExceptionRetainsExactCauseAndSkipsBody() throws IOException {
+        final File file = newLockFile();
+        final IOException acquisitionFailure = new IOException("deliberate acquisition failure");
+        final AtomicInteger targetCalls = new AtomicInteger();
+        final AtomicInteger bodyCalls = new AtomicInteger();
+        final TestLockRuntime runtime = new TestLockRuntime(
+                () -> {
+                    throw acquisitionFailure;
+                },
+                () -> 0L,
+                ignored -> {
+                });
+
+        final IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> withLock(file, false, target -> {
+                    bodyCalls.incrementAndGet();
+                    return target;
+                }, () -> {
+                    targetCalls.incrementAndGet();
+                    return "target";
+                }, TimeUnit.SECONDS.toNanos(1), runtime));
+
+        assertSame(acquisitionFailure, actual.getCause());
+        assertEquals(1, runtime.attemptCalls.get());
+        assertEquals(0, runtime.closeLockCalls.get());
+        assertEquals(1, runtime.closeCalls.get());
+        assertEquals(0, targetCalls.get());
+        assertEquals(0, bodyCalls.get());
+    }
+
+    @Test
+    public void scriptedTimeoutRetainsOverlapCause() throws IOException {
+        final OverlappingFileLockException overlap = new OverlappingFileLockException();
+        final IllegalStateException actual = assertScriptedTimeout(() -> {
+            throw overlap;
+        });
+
+        assertSame(overlap, actual.getCause());
+    }
+
+    @Test
+    public void scriptedNullContentionTimesOutWithoutInventingACause() throws IOException {
+        final IllegalStateException actual = assertScriptedTimeout(() -> false);
+
+        assertNull(actual.getCause());
+    }
+
+    @Test
+    public void timeoutRetainsChannelCloseFailureAsSuppressed() throws IOException {
+        final File file = newLockFile();
+        final AtomicLong now = new AtomicLong();
+        final long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(1);
+        final IOException channelCloseFailure = new IOException("deliberate channel close failure");
+        final TestLockRuntime runtime = new TestLockRuntime(
+                () -> false,
+                now::get,
+                ignored -> now.set(timeoutNanos),
+                null,
+                channelCloseFailure);
+
+        final IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> withLock(file, false, target -> target, () -> "target", timeoutNanos, runtime));
+
+        assertTrue(actual.getMessage().contains("Unable to claim the exclusive lock"));
+        assertNull(actual.getCause());
+        assertEquals(1, actual.getSuppressed().length);
+        assertSame(channelCloseFailure, actual.getSuppressed()[0]);
+        assertEquals(0, runtime.closeLockCalls.get());
+        assertEquals(1, runtime.closeCalls.get());
+    }
+
+    @Test
+    public void bodyFailureRetainsLockAndChannelCleanupFailures() throws IOException {
+        final File file = newLockFile();
+        final RuntimeException bodyFailure = new RuntimeException("deliberate body failure");
+        final IOException lockCloseFailure = new IOException("deliberate lock close failure");
+        final IOException channelCloseFailure = new IOException("deliberate channel close failure");
+        final TestLockRuntime runtime = new TestLockRuntime(
+                () -> true,
+                () -> 0L,
+                ignored -> {
+                },
+                lockCloseFailure,
+                channelCloseFailure);
+
+        final RuntimeException actual = assertThrows(RuntimeException.class,
+                () -> withLock(file, false, ignored -> {
+                    throw bodyFailure;
+                }, () -> "target", TimeUnit.SECONDS.toNanos(1), runtime));
+
+        assertSame(bodyFailure, actual);
+        assertEquals(2, actual.getSuppressed().length);
+        assertSame(lockCloseFailure, actual.getSuppressed()[0]);
+        assertSame(channelCloseFailure, actual.getSuppressed()[1]);
+        assertEquals(1, runtime.closeLockCalls.get());
+        assertEquals(1, runtime.closeCalls.get());
+    }
+
+    @Test
+    public void successfulBodyReportsLockCloseFailureWithChannelCloseSuppressed() throws IOException {
+        final File file = newLockFile();
+        final IOException lockCloseFailure = new IOException("deliberate lock close failure");
+        final IOException channelCloseFailure = new IOException("deliberate channel close failure");
+        final TestLockRuntime runtime = new TestLockRuntime(
+                () -> true,
+                () -> 0L,
+                ignored -> {
+                },
+                lockCloseFailure,
+                channelCloseFailure);
+
+        final IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> withLock(file, false, target -> target, () -> "target",
+                        TimeUnit.SECONDS.toNanos(1), runtime));
+
+        assertSame(lockCloseFailure, actual.getCause());
+        assertEquals(1, lockCloseFailure.getSuppressed().length);
+        assertSame(channelCloseFailure, lockCloseFailure.getSuppressed()[0]);
+        assertEquals(1, runtime.closeLockCalls.get());
+        assertEquals(1, runtime.closeCalls.get());
+    }
+
+    @Test
+    public void successfulBodyReportsChannelCloseFailure() throws IOException {
+        final File file = newLockFile();
+        final IOException channelCloseFailure = new IOException("deliberate channel close failure");
+        final TestLockRuntime runtime = new TestLockRuntime(
+                () -> true,
+                () -> 0L,
+                ignored -> {
+                },
+                null,
+                channelCloseFailure);
+
+        final IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> withLock(file, false, target -> target, () -> "target",
+                        TimeUnit.SECONDS.toNanos(1), runtime));
+
+        assertSame(channelCloseFailure, actual.getCause());
+        assertEquals(1, runtime.closeLockCalls.get());
+        assertEquals(1, runtime.closeCalls.get());
     }
 
     private void assertBodyRunsOnceAndPreservesFailureIdentity(boolean shared) throws IOException {
@@ -102,24 +347,23 @@ public class SingleTableStoreLockTest extends QueueTestCommon {
         final File file = newLockFile();
         final AtomicInteger targetCalls = new AtomicInteger();
         final AtomicInteger bodyCalls = new AtomicInteger();
-        final CountDownLatch workerStarted = new CountDownLatch(1);
         final ExecutorService executor = Executors.newSingleThreadExecutor();
 
         try (FileChannel blockerChannel = FileChannel.open(file.toPath(), StandardOpenOption.WRITE)) {
             final FileLock blocker = blockerChannel.lock(LOCK_START, LOCK_SIZE, false);
             try {
+                final ObservedFileLockRuntime runtime = new ObservedFileLockRuntime(file, shared);
                 final Future<String> result = executor.submit(() -> {
-                    workerStarted.countDown();
                     return withLock(file, shared, target -> {
                         bodyCalls.incrementAndGet();
                         return target + "-done";
                     }, () -> {
                         targetCalls.incrementAndGet();
                         return "target";
-                    });
+                    }, TimeUnit.SECONDS.toNanos(5), runtime);
                 });
 
-                assertTrue("lock worker did not start", workerStarted.await(5, TimeUnit.SECONDS));
+                assertTrue("lock contention was not observed", runtime.contention.await(5, TimeUnit.SECONDS));
                 assertThrows("body ran while the conflicting lock was still held", TimeoutException.class,
                         () -> result.get(100, TimeUnit.MILLISECONDS));
                 assertEquals(0, targetCalls.get());
@@ -139,6 +383,36 @@ public class SingleTableStoreLockTest extends QueueTestCommon {
         }
     }
 
+    private IllegalStateException assertScriptedTimeout(LockAttempt attempt) throws IOException {
+        final File file = newLockFile();
+        final AtomicLong now = new AtomicLong();
+        final long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(1);
+        final AtomicInteger targetCalls = new AtomicInteger();
+        final AtomicInteger bodyCalls = new AtomicInteger();
+        final TestLockRuntime runtime = new TestLockRuntime(
+                attempt,
+                now::get,
+                ignored -> now.set(timeoutNanos));
+
+        final IllegalStateException actual = assertThrows(IllegalStateException.class,
+                () -> withLock(file, false, target -> {
+                    bodyCalls.incrementAndGet();
+                    return target;
+                }, () -> {
+                    targetCalls.incrementAndGet();
+                    return "target";
+                }, timeoutNanos, runtime));
+
+        assertTrue(actual.getMessage().contains("Unable to claim the exclusive lock"));
+        assertEquals(1, runtime.attemptCalls.get());
+        assertEquals(1, runtime.pauseCalls.get());
+        assertEquals(0, runtime.closeLockCalls.get());
+        assertEquals(1, runtime.closeCalls.get());
+        assertEquals(0, targetCalls.get());
+        assertEquals(0, bodyCalls.get());
+        return actual;
+    }
+
     private File newLockFile() throws IOException {
         final File directory = getTmpDir();
         assertTrue(directory.mkdirs() || directory.isDirectory());
@@ -152,5 +426,149 @@ public class SingleTableStoreLockTest extends QueueTestCommon {
         if (shared)
             return SingleTableStore.doWithSharedLock(file, code, target);
         return SingleTableStore.doWithExclusiveLock(file, code, target);
+    }
+
+    private <T, R> R withLock(File file,
+                              boolean shared,
+                              Function<T, ? extends R> code,
+                              Supplier<T> target,
+                              long timeoutNanos,
+                              SingleTableStore.LockRuntime lockRuntime) {
+        return SingleTableStore.doWithLock(file, code, target, shared, timeoutNanos, lockRuntime);
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS))
+                throw new AssertionError("timed out waiting for scripted contention release");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("interrupted while waiting for scripted contention release", e);
+        }
+    }
+
+    public static final class LockHolder {
+        public static void main(String[] args) throws IOException {
+            try (FileChannel channel = FileChannel.open(new File(args[0]).toPath(), StandardOpenOption.WRITE);
+                 FileLock lock = channel.lock(LOCK_START, LOCK_SIZE, false)) {
+                if (!lock.isValid())
+                    throw new IOException("lock acquisition did not return a valid lock");
+                System.out.println("LOCKED");
+                System.out.flush();
+                System.in.read();
+            }
+        }
+    }
+
+    private static final class ObservedFileLockRuntime implements SingleTableStore.LockRuntime {
+        private final SingleTableStore.FileChannelLockRuntime delegate;
+        private final CountDownLatch contention = new CountDownLatch(1);
+        private final AtomicInteger nullResults = new AtomicInteger();
+
+        ObservedFileLockRuntime(File file, boolean shared) throws IOException {
+            delegate = new SingleTableStore.FileChannelLockRuntime(file,
+                    shared ? StandardOpenOption.READ : StandardOpenOption.WRITE, shared);
+        }
+
+        @Override
+        public boolean tryLock() throws IOException {
+            try {
+                final boolean locked = delegate.tryLock();
+                if (!locked) {
+                    nullResults.incrementAndGet();
+                    contention.countDown();
+                }
+                return locked;
+            } catch (OverlappingFileLockException e) {
+                contention.countDown();
+                throw e;
+            }
+        }
+
+        @Override
+        public long nanoTime() {
+            return delegate.nanoTime();
+        }
+
+        @Override
+        public void pause(int millis) {
+            delegate.pause(millis);
+        }
+
+        @Override
+        public void closeLock() throws IOException {
+            delegate.closeLock();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+
+    @FunctionalInterface
+    private interface LockAttempt {
+        boolean tryLock() throws IOException;
+    }
+
+    private static final class TestLockRuntime implements SingleTableStore.LockRuntime {
+        private final LockAttempt attempt;
+        private final LongSupplier nanoTime;
+        private final IntConsumer pause;
+        private final IOException lockCloseFailure;
+        private final IOException channelCloseFailure;
+        private final AtomicInteger attemptCalls = new AtomicInteger();
+        private final AtomicInteger pauseCalls = new AtomicInteger();
+        private final AtomicInteger closeLockCalls = new AtomicInteger();
+        private final AtomicInteger closeCalls = new AtomicInteger();
+
+        private TestLockRuntime(LockAttempt attempt,
+                                LongSupplier nanoTime,
+                                IntConsumer pause) {
+            this(attempt, nanoTime, pause, null, null);
+        }
+
+        private TestLockRuntime(LockAttempt attempt,
+                                LongSupplier nanoTime,
+                                IntConsumer pause,
+                                IOException lockCloseFailure,
+                                IOException channelCloseFailure) {
+            this.attempt = attempt;
+            this.nanoTime = nanoTime;
+            this.pause = pause;
+            this.lockCloseFailure = lockCloseFailure;
+            this.channelCloseFailure = channelCloseFailure;
+        }
+
+        @Override
+        public long nanoTime() {
+            return nanoTime.getAsLong();
+        }
+
+        @Override
+        public boolean tryLock() throws IOException {
+            attemptCalls.incrementAndGet();
+            return attempt.tryLock();
+        }
+
+        @Override
+        public void closeLock() throws IOException {
+            closeLockCalls.incrementAndGet();
+            if (lockCloseFailure != null)
+                throw lockCloseFailure;
+        }
+
+        @Override
+        public void pause(int millis) {
+            pauseCalls.incrementAndGet();
+            pause.accept(millis);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCalls.incrementAndGet();
+            if (channelCloseFailure != null)
+                throw channelCloseFailure;
+        }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreLockTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.queue.impl.table;
+
+import net.openhft.chronicle.queue.QueueTestCommon;
+import net.openhft.chronicle.testframework.ExecutorServiceUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class SingleTableStoreLockTest extends QueueTestCommon {
+
+    private static final int LOCK_SIZE = 1;
+    private static final long LOCK_START = Long.MAX_VALUE - LOCK_SIZE;
+
+    @Before
+    public void trackTestThreads() {
+        threadDump();
+    }
+
+    @Test
+    public void exclusiveBodyRunsOnceAndPreservesRuntimeExceptionAndErrorIdentity() throws IOException {
+        assertBodyRunsOnceAndPreservesFailureIdentity(false);
+    }
+
+    @Test
+    public void sharedBodyRunsOnceAndPreservesRuntimeExceptionAndErrorIdentity() throws IOException {
+        assertBodyRunsOnceAndPreservesFailureIdentity(true);
+    }
+
+    @Test
+    public void exclusiveContentionIsRetriedBeforeBodyRunsOnce() throws Exception {
+        assertContentionIsRetriedBeforeBodyRunsOnce(false);
+    }
+
+    @Test
+    public void sharedContentionIsRetriedBeforeBodyRunsOnce() throws Exception {
+        assertContentionIsRetriedBeforeBodyRunsOnce(true);
+    }
+
+    private void assertBodyRunsOnceAndPreservesFailureIdentity(boolean shared) throws IOException {
+        final File file = newLockFile();
+        final AtomicInteger targetCalls = new AtomicInteger();
+        final AtomicInteger bodyCalls = new AtomicInteger();
+        final OverlappingFileLockException expectedRuntimeException = new OverlappingFileLockException();
+
+        final OverlappingFileLockException actualRuntimeException = assertThrows(
+                OverlappingFileLockException.class,
+                () -> withLock(file, shared, target -> {
+                    bodyCalls.incrementAndGet();
+                    throw expectedRuntimeException;
+                }, () -> {
+                    targetCalls.incrementAndGet();
+                    return "target";
+                }));
+
+        assertSame(expectedRuntimeException, actualRuntimeException);
+        assertEquals(1, targetCalls.get());
+        assertEquals(1, bodyCalls.get());
+
+        targetCalls.set(0);
+        bodyCalls.set(0);
+        final AssertionError expectedError = new AssertionError("deliberate body failure");
+
+        final AssertionError actualError = assertThrows(AssertionError.class,
+                () -> withLock(file, shared, target -> {
+                    bodyCalls.incrementAndGet();
+                    throw expectedError;
+                }, () -> {
+                    targetCalls.incrementAndGet();
+                    return "target";
+                }));
+
+        assertSame(expectedError, actualError);
+        assertEquals(1, targetCalls.get());
+        assertEquals(1, bodyCalls.get());
+    }
+
+    private void assertContentionIsRetriedBeforeBodyRunsOnce(boolean shared) throws Exception {
+        final File file = newLockFile();
+        final AtomicInteger targetCalls = new AtomicInteger();
+        final AtomicInteger bodyCalls = new AtomicInteger();
+        final CountDownLatch workerStarted = new CountDownLatch(1);
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try (FileChannel blockerChannel = FileChannel.open(file.toPath(), StandardOpenOption.WRITE)) {
+            final FileLock blocker = blockerChannel.lock(LOCK_START, LOCK_SIZE, false);
+            try {
+                final Future<String> result = executor.submit(() -> {
+                    workerStarted.countDown();
+                    return withLock(file, shared, target -> {
+                        bodyCalls.incrementAndGet();
+                        return target + "-done";
+                    }, () -> {
+                        targetCalls.incrementAndGet();
+                        return "target";
+                    });
+                });
+
+                assertTrue("lock worker did not start", workerStarted.await(5, TimeUnit.SECONDS));
+                assertThrows("body ran while the conflicting lock was still held", TimeoutException.class,
+                        () -> result.get(100, TimeUnit.MILLISECONDS));
+                assertEquals(0, targetCalls.get());
+                assertEquals(0, bodyCalls.get());
+
+                blocker.release();
+
+                assertEquals("target-done", result.get(5, TimeUnit.SECONDS));
+                assertEquals(1, targetCalls.get());
+                assertEquals(1, bodyCalls.get());
+            } finally {
+                if (blocker.isValid())
+                    blocker.release();
+            }
+        } finally {
+            ExecutorServiceUtil.shutdownForciblyAndWaitForTermination(executor);
+        }
+    }
+
+    private File newLockFile() throws IOException {
+        final File directory = getTmpDir();
+        assertTrue(directory.mkdirs() || directory.isDirectory());
+        return Files.createFile(new File(directory, "table-lock" + SingleTableStore.SUFFIX).toPath()).toFile();
+    }
+
+    private <T, R> R withLock(File file,
+                              boolean shared,
+                              Function<T, ? extends R> code,
+                              Supplier<T> target) {
+        if (shared)
+            return SingleTableStore.doWithSharedLock(file, code, target);
+        return SingleTableStore.doWithExclusiveLock(file, code, target);
+    }
+}


### PR DESCRIPTION
## Scope and status

Draft remediation stacked on #1748, with a second correctness pass after `2309982159afe38fef0efc7b1c4bee84fce98e26`. The base remains `feature/QUEUE-148-safe-queue-instantiation-broken-metadata`. Integrate this work into that branch before delivering #1748 to `develop`; this is not a separate exception-hierarchy transition intended for release.

Latest remediation commit: `7438e297dc9ecf7c776f5eec790cc1db2ebdac3b`.

The latest pass addresses the supplied #1752 review and the maintainer's clarification that BINARY_LIGHT is the supported encoding. Platform and released-fixture evidence remain open; this is not a cross-platform approval claim.

## Correctness changes

- Both record traversals require an actual EVENT_NAME token and a present event, while preserving explicitly empty keys. They validate the bound-long representation before callbacks, including callbacks which ignore ValueIn. Validation covers the declared body, aligned eight-byte binding address, four-byte next-header boundary, bounded explicit padding, and exact body consumption.
- The first header accepts only the trusted STStore schema (short alias or its full class name), constructing SingleTableStore directly. A foreign TableStore or a mutable global alias cannot receive the mapping or run its constructor in place of that schema.
- Queue-owned fields are read sequentially and checked for name, order and representation. Unknown/skipped fields, comments and trailing values in the STStore body are rejected; current-writer final alignment padding is accepted. Nested application metadata remains extensible rather than acquiring the same closed-schema rule.
- Both read and write bounds constrain nested Wire marshallable framing before constructors run. Physical first-header bounds are established before READ_ANY format detection. Writable opening observes the mapped file's physical size under the lock, avoiding a stale observation when another creator publishes first.
- A dedicated TableStoreUnavailableException originates at the open/wait boundary. Queue fallback no longer uses message matching or walks arbitrary causes for FileNotFoundException. Constructor failures cannot promote a public corruption/availability exception into a Queue diagnosis. The reserved availability signal is also isolated when thrown by metadata override; ordinary override failures retain identity. Post-open queue metadata access is outside the fallback catch.
- Queue's first-header corruption diagnostics retain bounded reasons and decoder-class context without persisted event names, aliases or byte dumps in their cause chain. Application-constructor failures retain their application context and are not represented as sanitized Queue parser failures.
- Failed construction, metadata override and post-open metadata access release the mapping, including Error and sneaky checked-exception exits. Short files with missing/incomplete first headers or a declared first body past physical EOF are rejected before writable preallocation.
- Lock acquisition has a testable runtime seam. Tests cover null contention, same-JVM overlap, terminal acquisition I/O, monotonic timeout, exact body/target invocation counts, RuntimeException and Error identity, and lock/channel cleanup suppression. A real subprocess holds the lock to exercise FileChannel.tryLock() returning null. Same-JVM tests synchronize after an observed failed acquisition attempt, not merely after starting a worker.

The one-shot protected-body behavior, IORuntimeException compatibility of CorruptTableStoreException, and explicit corruption bypass of read-only fallback from the first pass are retained.

## Supported table-store formats

| Selector | Policy |
| --- | --- |
| BINARY_LIGHT | Canonical create, append and read encoding. |
| BINARY | Retained legacy selector/persisted label; the implementation uses the BINARY_LIGHT codec and common subset, with no BINARY-specific features. |
| READ_ANY | Detection selector for opening an existing supported store read-only; not a writable or persisted encoding. |
| RAW, FIELDLESS_BINARY, COMPRESSED_BINARY, text/JSON/YAML/CSV and other formats | Unsupported for table stores; rejected before creating a file. |

This pass does not change the general queue-data WireType API. Current-encoding tests cover canonical/legacy cross-opening, read-only reopening, READ_ANY detection, and read-only readers observing later growth of normally preallocated stores.

Intentional compatibility boundaries are explicit: arbitrary TableStore implementations and aliases, out-of-order/unknown Queue-owned header fields, non-event record keys, unaligned bindings and previously tolerated malformed padding are not accepted. No released-file fixture claim is made for those boundaries.

## Local validation

Final command (Linux amd64, Ubuntu OpenJDK 21.0.12, offline resolved dependency cache):

```sh
mvn -o -B -Dorg.slf4j.simpleLogger.defaultLogLevel=warn \
  -l /tmp/queue-148-remediation-2-final-clean-verify-2026-09-05.log clean verify
```

Passed, exit 0. Maven aggregate: **1,188 tests, 0 failures, 0 errors, 52 skipped**. The four focused corruption/locking suites are included. Raw XML includes four duplicate ignored DAILY parameter entries, so summing all XML suite attributes yields 1,192 tests and 56 skips; the Maven aggregate above is not that raw sum.

The new metadata-override availability test was executed before its production guard and failed at the intended assertion; its fixed result is included in the final run. This is a focused red/green control, not a claim that a complete mutation campaign was run.

Production `//!` notes name concrete tests and distinguish current-encoding integration evidence from historical or platform evidence. All 74 test methods in the four changed test files have production rationale references. Mechanical checks passed for those references, no `//!` in tests, `git diff --check`, and the 144-character added-Java-line limit.

Key resolved dependency identities (SHA-256 of the actual JAR, not a source-equivalence claim):

| JAR | SHA-256 |
| --- | --- |
| chronicle-wire-2026.10-SNAPSHOT.jar | `49fd03ac07e36d7289f70beb77f217c32c992b4c4ed6416259a65c0d3b7c0b3f` |
| chronicle-bytes-2026.4.jar | `68d04e970009c12e61eaabd8be68a00ac18adb9285c9ed406557e3e23a348a5e` |
| chronicle-core-2026.6.jar | `e69b0644406c7bbd53a2745fa069b90e7df7e3efd79a7170153c42d820aad41c` |
| chronicle-threads-2026.3.jar | `529b609341a062e9a43f6159ac00b4f29ab08a0ea107b962e3c0b5968abafa6c` |

## Supplied Mac build 1828 log

This log is for the earlier `2309982` head, not this new commit. It reports 1 failure, 10 errors and 12 flakes, with persistent timeout-related failures across TestBinarySearch, TestMethodWriterWithThreads and BackwardsTailerBoundaryTest. It used Java 11.0.24, four Surefire forks and three reruns.

Sampled stacks include Core 2026.6 CleaningThreadLocal cleanup and ordinary queue-indexing paths; they do not establish that the changed table-store decoder/scanner caused the timeouts. Two builder cleanup tests initially observed unrelated StoreAppender threads and passed on rerun. This is useful failure localization, not proof that macOS is healthy or that the failures are unrelated.

Needed next platform evidence: base/head A/B on the same Mac and dependency closure, initially one fork with reruns disabled and thread dumps captured on timeout; then the supported CI topology. Windows logs were not supplied. Neither platform is cleared by this Linux run.

## Remaining evidence and scope limits

- Released .cq4t fixtures are still needed for supported header aliases, optional metadata, legacy zero long markers and historical padding. Current-writer round trips are not a substitute.
- The short-file probe preserves the covered missing/incomplete/physically truncated first-header cases. It does not promise that every compact file with a complete outer header but malformed contents remains unchanged before decode; writable mapping may still preallocate that file. Universal forensic no-mutation behavior is not claimed.
- Normal read-only mappings retain growth behavior. The narrowly handled compact page-aligned read-only file uses a fixed opening snapshot; lock-ignoring external truncation is not made safe by these checks.
- Binary grammar checks remain in Queue and need coordinated Wire compatibility review. Extensible metadata constructors are trusted application code, not sandboxed hostile code.
- No local Windows/macOS, alternate-JDK matrix or released-binary API compatibility run was performed in this pass. Maven shading warnings are not represented as a warning-free build.
