### PR TITLE
QUEUE-148: address follow-up table-store review

### DIFF
--- a/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilder.java
@@ -19,7 +19,6 @@ import net.openhft.chronicle.core.util.ObjectUtils;
 import net.openhft.chronicle.core.util.Updater;
 import net.openhft.chronicle.queue.*;
 import net.openhft.chronicle.queue.impl.*;
-import net.openhft.chronicle.queue.impl.table.CorruptTableStoreException;
 import net.openhft.chronicle.queue.impl.table.ReadonlyTableStore;
 import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
 import net.openhft.chronicle.queue.impl.table.TableStoreUnavailableException;
@@ -571,23 +570,21 @@ public class SingleChronicleQueueBuilder extends SelfDescribingMarshallable impl
         final boolean readOnly = readOnly();
         try {
             metaStore = SingleTableBuilder.binary(metapath, metadata).readOnly(readOnly).build();
-        //! Corruption remains an IORuntimeException for caller compatibility but must never enter the legacy read-only fallback:
-        //! a synthetic store would hide the damaged metadata rather than make it readable. The
-        //! SingleChronicleQueueCorruptMetadataTest#corruptMetadataBypassesReadonlyFallbackAndRemainsAnIORuntimeException test
-        //! fails if this catch is removed or reordered.
-        } catch (CorruptTableStoreException ex) {
-            throw ex;
         } catch (TableStoreUnavailableException ex) {
             //! Fall back only on non-Windows for the dedicated availability failure emitted while opening or awaiting the
-            //! metadata file. A writable request whose existing metadata is not writable deliberately becomes read-only.
-            //! Walking arbitrary decoder causes for FileNotFoundException lets persisted constructors disguise malformed
-            //! content as absence. SingleChronicleQueueCorruptMetadataTest
+            //! metadata file. Corruption is a sibling IORuntimeException, so it cannot enter this exact-type catch and be
+            //! hidden by a synthetic store. Walking arbitrary causes for FileNotFoundException lets persisted constructors
+            //! disguise malformed content as absence. SingleChronicleQueueCorruptMetadataTest
+            //! #corruptMetadataBypassesReadonlyFallbackAndRemainsAnIORuntimeException and
             //! #nestedFileNotFoundFromMetadataDoesNotActivateReadonlyFallback and
             //! ReadWriteTest#testNonWriteableFilesSetToReadOnly discriminate the provenance boundary.
             if (OS.isWindows())
                 throw ex;
 
-            Jvm.warn().on(getClass(), "Failback to readonly tablestore " + ex);
+            if (ex.getCause() == null)
+                Jvm.warn().on(getClass(), "Failback to readonly tablestore " + ex);
+            else
+                Jvm.warn().on(getClass(), "Failback to readonly tablestore", ex);
 
             // Fallback to read-only table store if metadata file is not found
             metaStore = new ReadonlyTableStore<>(metadata);

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilder.java
@@ -15,8 +15,10 @@ import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import net.openhft.chronicle.core.util.StringUtils;
 import net.openhft.chronicle.queue.impl.TableStore;
 import net.openhft.chronicle.queue.impl.single.MetaDataKeys;
+import net.openhft.chronicle.queue.impl.single.SCQMeta;
 import net.openhft.chronicle.threads.Pauser;
 import net.openhft.chronicle.threads.TimingPauser;
+import net.openhft.chronicle.wire.BinaryWireCode;
 import net.openhft.chronicle.wire.ValueIn;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
@@ -34,6 +36,7 @@ import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static net.openhft.chronicle.core.pool.ClassAliasPool.CLASS_ALIASES;
 
@@ -125,35 +128,31 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         //! SingleTableStoreCorruptRecordTest#readAnyReopensExistingBinaryTableStore and
         //! #unsupportedWritableWireTypesFailBeforeCreatingAFile discriminate the two capabilities.
         SingleTableStore.requireSelectedWireType(wireType, readOnly);
-        if (readOnly) {
-            if (!file.exists())
-                throw new TableStoreUnavailableException(file, "Metadata file not found in readOnly mode");
-
-            // Wait a short time for the file to be initialized
-            TimingPauser pauser = Pauser.balanced();
-            try {
-                while (file.length() < OS.mapAlignment()) {
-                    pauser.pause(1, TimeUnit.SECONDS);
-                }
-            } catch (TimeoutException e) {
-                throw new TableStoreUnavailableException(file,
-                        "Metadata file found in readOnly mode, but not initialized yet", e);
-            }
-        }
+        if (readOnly)
+            awaitReadOnlyFirstHeader();
 
         MappedBytes bytes = null;
         //! The builder owns this mapping until a complete TableStore is returned; every earlier failure must close it.
         //! SingleTableBuilderCorruptMetadataTest#failedHeaderDecodePreservesTheFileAndReleasesTheMapping fails if this
         //! ownership guard is removed, because the failed mapping keeps the table-store file open on affected platforms.
         boolean handedOver = false;
+        final AtomicReference<TableStore<T>> provisionalStore = new AtomicReference<>();
         try {
             final int mappingPageSize = PageUtil.getPageSize(file.getAbsolutePath());
             final long mappedChunkSize = OS.mapAlign(OS.SAFE_PAGE_SIZE, mappingPageSize);
             final long firstWritableMappingSize = 2L * mappedChunkSize;
             if (!readOnly) {
-                final boolean created = file.createNewFile();
+                final boolean created;
+                try {
+                    created = file.createNewFile();
+                } catch (IOException e) {
+                    //! File creation is part of the availability boundary. A writable queue request against an unwritable
+                    //! directory historically falls back to a synthetic read-only table store on non-Windows platforms.
+                    //! ReadWriteTest#testNonWriteableDirectoryWithoutMetadataSetsQueueReadOnly loses this translation.
+                    throw new TableStoreUnavailableException(file, "Metadata file cannot be created", e);
+                }
                 if (created && !file.canWrite())
-                    throw new IllegalStateException("Cannot write to tablestore file " + file);
+                    throw new TableStoreUnavailableException(file, "Metadata file cannot be opened for writing");
 
                 //! A writable mapping grows a short file while acquiring its first chunk. Reject a ready first header whose
                 //! declared body is physically truncated before mapping, while retaining compact files whose header is whole.
@@ -172,20 +171,16 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
                     //! SingleTableBuilderCorruptMetadataTest#readOnlyOpenRejectsHeaderBeyondPhysicalFileWithoutMutation
                     //! exercises the pre-mapping boundary and verifies that the original file is unchanged.
                     validateFirstHeaderBeforeMapping(physicalLength);
-                    //! A page-aligned compact store can use an exact single read-only mapping without mapping beyond EOF; it
-                    //! is an opening snapshot. Normal preallocated stores retain chunked mappings so long-lived readers can
-                    //! observe later appends and growth.
-                    //! SingleTableBuilderCorruptMetadataTest#readOnlyOpenRejectsHeaderBeyondPhysicalFileWithoutMutation
-                    //! exercises the pre-map bound; #compactCompleteTableStoreReopensReadOnly covers the compact snapshot and
-                    //! SingleTableStoreCorruptRecordTest#readOnlyStoreOpenedBeforeGrowthSeesLaterKeys protects normal growth.
-                    final boolean compactSnapshot = physicalLength < firstWritableMappingSize
+                    //! Released table stores can be page-aligned and only 64 KiB. Use exact, zero-overlap chunks for compact
+                    //! files so opening never maps beyond EOF but later file growth remains visible; a single mapping freezes
+                    //! the old capacity and misreports a healthy boundary-crossing record as corruption.
+                    //! SingleTableBuilderCorruptMetadataTest#compactReadOnlyTableStoreObservesLaterGrowth discriminates the
+                    //! growable mapping; #compactCompleteTableStoreReopensReadOnly retains the static positive control.
+                    final boolean compact = physicalLength < firstWritableMappingSize
                             && physicalLength % mappingPageSize == 0L;
-                    bytes = compactSnapshot
-                            ? MappedBytes.singleMappedBytes(file, physicalLength, true)
-                            : MappedBytes.mappedBytes(
-                                    file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, mappingPageSize, true);
-                    if (compactSnapshot)
-                        bytes.writeLimit(physicalLength);
+                    bytes = compact
+                            ? MappedBytes.mappedBytes(file, physicalLength, 0L, mappingPageSize, true)
+                            : MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, mappingPageSize, true);
                     bytes.readLimit(physicalLength);
                     readBound = physicalLength;
                 } else {
@@ -228,7 +223,9 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
                         //! against the old limit and touch stale mapped bytes before this bound takes effect.
                         readOnlyBytes.readPosition(0L);
                         readOnlyBytes.readLimit(lockedReadBound);
-                        return readTableStore(readOnlyBytes, wire, lockedReadBound);
+                        final TableStore<T> opened = readTableStore(readOnlyBytes, wire, lockedReadBound);
+                        provisionalStore.set(opened);
+                        return opened;
                     } catch (IOException ex) {
                         throw Jvm.rethrow(ex);
                     }
@@ -238,13 +235,17 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
                 store = SingleTableStore.doWithExclusiveLock(file, v -> {
                     try {
                         if (wire.writeFirstHeader()) {
-                            return writeTableStore(finalBytes, wire);
+                            final TableStore<T> opened = writeTableStore(finalBytes, wire);
+                            provisionalStore.set(opened);
+                            return opened;
                         } else {
                             //! A builder can observe the file before a concurrent creator publishes its first header, then
                             //! acquire the lock afterwards. Read the mapped channel's size under that lock rather than reusing
                             //! the pre-lock observation. RollCycleMultiThreadStressTest#stress exercises that publication race.
                             final long lockedReadBound = finalBytes.mappedFile().actualSize();
-                            return readTableStore(finalBytes, wire, lockedReadBound);
+                            final TableStore<T> opened = readTableStore(finalBytes, wire, lockedReadBound);
+                            provisionalStore.set(opened);
+                            return opened;
                         }
                     } catch (IOException ex) {
                         throw Jvm.rethrow(ex);
@@ -260,6 +261,12 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         } catch (IOException e) {
             throw new IORuntimeException("file=" + file.getAbsolutePath(), e);
         } finally {
+            //! A body can finish constructing a store before lock or channel cleanup fails. Keep that provisional owner
+            //! reachable until the lock helper returns, and close it if no caller receives it. The scripted cleanup tests in
+            //! SingleTableStoreLockTest cover propagation; no public FileChannel seam deterministically injects this exact
+            //! post-construction builder edge, so the ownership guard currently has static rather than losing-test evidence.
+            if (!handedOver)
+                Closeable.closeQuietly(provisionalStore.get());
             if (bytes != null) {
                 // A provisional store closes the same mapping when construction fails after deserialisation.
                 if (!bytes.isClosed()) {
@@ -333,6 +340,10 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
 
                 final ValueIn valueIn = readTableStoreValue(wire);
                 preflightTableStoreType(valueIn);
+                //! The trusted type prefix must be followed by BinaryWire's explicit marshallable framing. Permissive scalar,
+                //! null, padding-only or absent framing can otherwise invoke the STStore constructor on malformed input.
+                //! SingleTableBuilderCorruptMetadataTest#outerSchemaRequiresMarshallableFraming covers each rejected form.
+                requireMarshallableFrame(valueIn, "the first header does not hold a readable table store");
                 //! Only the trusted mapping-owning SingleTableStore schema may receive this builder mapping. Accepting any
                 //! TableStore can return an object that neither retains nor closes these MappedBytes. Consume the allowlisted
                 //! prefix and construct SingleTableStore directly so a mutable global alias cannot substitute a foreign class.
@@ -360,7 +371,7 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
                         } catch (SingleTableStore.SchemaCorruptionException e) {
                             throw e;
                         } catch (SingleTableStore.MetadataConstructorFailed e) {
-                            throw new TableStoreConstructorFailed(e.getCause());
+                            throw new TableStoreConstructorFailed(e.getCause(), e.metadataType());
                         } catch (RuntimeException e) {
                             throw new SingleTableStore.SchemaCorruptionException(
                                     "the first header does not hold a readable table store", e);
@@ -390,8 +401,13 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
             throw new CorruptTableStoreException(file, e.getMessage(), e);
         } catch (TableStoreConstructorFailed e) {
             final Throwable constructorFailure = e.getCause();
-            if (constructorFailure instanceof Error)
-                throw (Error) constructorFailure;
+            if (e.metadataType() == SCQMeta.class) {
+                //! SCQMeta and its nested SCQRoll are Queue-owned persisted schema, not application constructor hooks. A
+                //! decode failure inside that body is corruption just like a damaged STStore envelope, with redacted detail.
+                //! SingleChronicleQueueCorruptMetadataTest#queueOwnedMetadataBodyDamageIsCorruption discriminates the scope.
+                throw new CorruptTableStoreException(file, "the queue metadata body cannot be decoded",
+                        redactedDecodeCause(constructorFailure));
+            }
             if (constructorFailure instanceof IORuntimeException
                     && !(constructorFailure instanceof CorruptTableStoreException)
                     && !(constructorFailure instanceof TableStoreUnavailableException))
@@ -401,13 +417,6 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
             //! SingleChronicleQueueCorruptMetadataTest#constructorAvailabilitySignalDoesNotActivateReadonlyFallback
             //! discriminates this boundary.
             throw new IORuntimeException("Persisted table-store constructor failed", constructorFailure);
-        } catch (CorruptTableStoreException e) {
-            //! CorruptTableStoreException is public, so extensible metadata code can throw it too. Queue-generated failures
-            //! use the package-owned marker above; preserve an application-created instance as constructor failure context
-            //! rather than promoting it as Queue's disk diagnosis.
-            //! SingleTableBuilderCorruptMetadataTest#applicationCorruptionExceptionIsNotPromoted covers direct and wrapped
-            //! application failures.
-            throw new IORuntimeException("Persisted table-store constructor threw a corruption exception", e);
         } catch (StreamCorruptedException | BufferUnderflowException | BufferOverflowException | ClassNotFoundRuntimeException |
                  OverlappingFileLockException e) {
             //! Event-name, type-alias and bounded-underflow failures arise before any caller policy hook and identify an
@@ -441,6 +450,46 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         //! Preserve the decoder's failure class as bounded diagnostic context without retaining its data-bearing message.
         //! SingleTableBuilderCorruptMetadataTest#corruptionCauseChainDoesNotExposeStoredContent covers event and alias input.
         return new IORuntimeException("First-header decoding failed with " + failure.getClass().getName());
+    }
+
+    private void awaitReadOnlyFirstHeader() {
+        if (!file.exists())
+            throw new TableStoreUnavailableException(file, "Metadata file not found in readOnly mode");
+
+        //! A creator grows the file before taking the table-store lock and publishing its first header. Zero and
+        //! NOT_COMPLETE therefore mean "not published yet", not corruption; wait before acquiring the shared lock.
+        //! SingleTableBuilderCorruptMetadataTest#readOnlyOpenWaitsForFirstHeaderPublication loses this distinction.
+        final TimingPauser shortFilePauser = Pauser.balanced();
+        final TimingPauser publicationPauser = Pauser.balanced();
+        try {
+            while (true) {
+                boolean preallocated = false;
+                try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+                    final long physicalLength = raf.length();
+                    preallocated = physicalLength >= OS.mapAlignment();
+                    if (physicalLength >= Integer.BYTES) {
+                        final int header = Integer.reverseBytes(raf.readInt());
+                        if (Wires.isReady(header)) {
+                            if (Wires.lengthOf(header) > physicalLength - Integer.BYTES)
+                                throw new CorruptTableStoreException(file,
+                                        "the first header extends beyond the physical file");
+                            return;
+                        }
+                    }
+                } catch (FileNotFoundException e) {
+                    throw new TableStoreUnavailableException(file, "Metadata file is unavailable", e);
+                } catch (IOException e) {
+                    throw new TableStoreUnavailableException(file, "Metadata file cannot be inspected", e);
+                }
+                if (preallocated)
+                    publicationPauser.pause(SingleTableStore.lockTimeoutMillis(), TimeUnit.MILLISECONDS);
+                else
+                    shortFilePauser.pause(1L, TimeUnit.SECONDS);
+            }
+        } catch (TimeoutException e) {
+            throw new TableStoreUnavailableException(file,
+                    "Metadata file found in readOnly mode, but not initialized yet", e);
+        }
     }
 
     private void validateFirstHeaderPhysicalBound(MappedBytes mappedBytes, long readBound) {
@@ -507,11 +556,41 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         }
     }
 
+    static void requireMarshallableFrame(ValueIn valueIn, String failureMessage) {
+        if (valueIn.wireIn().bytes().readRemaining() == 0L)
+            throw new SingleTableStore.SchemaCorruptionException(failureMessage);
+        final int code = valueIn.wireIn().bytes().peekUnsignedByte();
+        if (code != BinaryWireCode.BYTES_LENGTH8
+                && code != BinaryWireCode.BYTES_LENGTH16
+                && code != BinaryWireCode.BYTES_LENGTH32)
+            throw new SingleTableStore.SchemaCorruptionException(failureMessage);
+
+        final long start = valueIn.wireIn().bytes().readPosition();
+        final long length;
+        try {
+            length = valueIn.readLength();
+        } catch (RuntimeException e) {
+            throw new SingleTableStore.SchemaCorruptionException(failureMessage, e);
+        } finally {
+            valueIn.wireIn().bytes().readPosition(start);
+        }
+        final int prefixLength = code == BinaryWireCode.BYTES_LENGTH8 ? 2
+                : code == BinaryWireCode.BYTES_LENGTH16 ? 3 : 5;
+        if (length < 0L || length > valueIn.wireIn().bytes().readRemaining() - prefixLength)
+            throw new SingleTableStore.SchemaCorruptionException(failureMessage);
+    }
+
     private static final class TableStoreConstructorFailed extends RuntimeException {
         private static final long serialVersionUID = 0L;
+        private final Class<? extends Metadata> metadataType;
 
-        TableStoreConstructorFailed(Throwable cause) {
+        TableStoreConstructorFailed(Throwable cause, Class<? extends Metadata> metadataType) {
             super(cause);
+            this.metadataType = metadataType;
+        }
+
+        Class<? extends Metadata> metadataType() {
+            return metadataType;
         }
     }
 
@@ -536,7 +615,17 @@ public class SingleTableBuilder<T extends Metadata> implements Builder<TableStor
         final TableStore<T> store = new SingleTableStore<>(wireType, bytes, metadata);
         boolean handedOver = false;
         try {
-            wire.writeEventName("header").object(store);
+            try {
+                //! Persist Queue's fixed outer alias instead of consulting the mutable global class-to-name mapping. A custom
+                //! alias registered before this builder initializes must not make its own healthy output unreadable.
+                //! SingleTableBuilderCorruptMetadataTest#writerAlwaysUsesCanonicalTableStoreAlias discriminates this choice.
+                wire.writeEventName("header").typedMarshallable("STStore", store);
+            } catch (CorruptTableStoreException | TableStoreUnavailableException e) {
+                //! Public Queue diagnosis types thrown by application metadata do not acquire file-open provenance merely
+                //! because they occur during initial serialization. Preserve them as causes of an ordinary write failure.
+                //! SingleTableBuilderCorruptMetadataTest#metadataWriteCannotOriginateReservedTableStoreSignals covers both.
+                throw new IORuntimeException("Initial table-store metadata serialization failed", e);
+            }
             wire.updateFirstHeader();
             handedOver = true;
             return store;

--- a/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
+++ b/src/main/java/net/openhft/chronicle/queue/impl/table/SingleTableStore.java
@@ -54,6 +54,10 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
     private static final long timeoutMS = Jvm.getLong("chronicle.table.store.timeoutMS", 10_000L);
 
+    static long lockTimeoutMillis() {
+        return timeoutMS;
+    }
+
     //! Use a package-owned marker for Queue-established schema failures during reflective construction. Searching for the
     //! public corruption API in arbitrary constructor causes lets application code relabel its own failure as disk corruption.
     //! SingleTableBuilderCorruptMetadataTest#applicationCorruptionExceptionIsNotPromoted protects that origin boundary.
@@ -71,9 +75,19 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
     static final class MetadataConstructorFailed extends RuntimeException {
         private static final long serialVersionUID = 0L;
+        private final Class<? extends Metadata> metadataType;
 
         MetadataConstructorFailed(Throwable cause) {
+            this(cause, null);
+        }
+
+        MetadataConstructorFailed(Throwable cause, Class<? extends Metadata> metadataType) {
             super(cause);
+            this.metadataType = metadataType;
+        }
+
+        Class<? extends Metadata> metadataType() {
+            return metadataType;
         }
     }
 
@@ -105,6 +119,8 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                 decodedWireType = Objects.requireNonNull(
                         readTableStoreField(wire, MetaDataField.wireType).object(WireType.class),
                         "the table-store header has no wire type");
+            } catch (SchemaCorruptionException e) {
+                throw e;
             } catch (RuntimeException e) {
                 //! The wire type is Queue-owned schema, not an extensible constructor hook. A missing or unreadable value
                 //! proves that this header cannot describe a table store; retrying the file lock cannot repair it.
@@ -120,10 +136,9 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
             final ValueIn metadataValue;
             try {
-                consumeTableStorePadding(wire);
-                metadataValue = wire.bytes().readRemaining() > 0
-                        ? readTableStoreField(wire, MetaDataField.metadata)
-                        : null;
+                metadataValue = readTableStoreMetadata(wire);
+            } catch (SchemaCorruptionException e) {
+                throw e;
             } catch (RuntimeException e) {
                 //! Padding and the metadata field token belong to Queue's persisted schema, before any extensible constructor
                 //! is entered. SingleTableBuilderCorruptMetadataTest
@@ -133,6 +148,11 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             }
             if (metadataValue != null) {
                 final Class<? extends Metadata> metadataType = preflightMetadataType(metadataValue);
+                //! A typed value must still contain one of BinaryWire's explicit marshallable length prefixes. Its permissive
+                //! applyToMarshallable path also accepts scalars and missing frames, which can invoke a constructor on corrupt
+                //! Queue framing. SingleTableBuilderCorruptMetadataTest#metadataRequiresMarshallableFraming discriminates it.
+                SingleTableBuilder.requireMarshallableFrame(
+                        metadataValue, "the first header does not hold readable metadata");
                 final Object decodedMetadata;
                 try {
                     decodedMetadata = metadataValue.applyToMarshallable(nestedWire -> {
@@ -144,12 +164,14 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                             mappedBytes.writeLimit(mappedBytes.readLimit());
                             return Demarshallable.newInstance(metadataType, nestedWire);
                         } catch (Throwable e) {
-                            throw new MetadataConstructorFailed(e);
+                            throw new MetadataConstructorFailed(e, metadataType);
                         } finally {
                             mappedBytes.writeLimit(containingWriteLimit);
                         }
                     });
                 } catch (MetadataConstructorFailed e) {
+                    throw e;
+                } catch (SchemaCorruptionException e) {
                     throw e;
                 } catch (RuntimeException e) {
                     //! Framing around the nested marshallable is persisted Queue schema, while only the callback invokes
@@ -180,6 +202,8 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                 //! #writerProducedFinalPaddingAcrossAllAlignmentsReopens covers the current writer's four alignment outcomes;
                 //! it is current-encoding compatibility evidence, not a claim about released historical fixtures.
                 consumeTableStorePadding(wire);
+            } catch (SchemaCorruptionException e) {
+                throw e;
             } catch (RuntimeException e) {
                 throw new SchemaCorruptionException("the table-store body has unreadable trailing padding", e);
             }
@@ -246,21 +270,52 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         }
     }
 
+    private static ValueIn readTableStoreMetadata(WireIn wire) {
+        consumeTableStorePadding(wire);
+        if (wire.bytes().readRemaining() == 0)
+            return null;
+
+        try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
+            final StringBuilder fieldName = stlSb.get();
+            ValueIn value = readTableStoreField(wire, fieldName);
+            if (StringUtils.isEqual(fieldName, MetaDataField.recovery.name())) {
+                //! Queue releases 5.16.9 through 5.17.9 wrote one recovery value between wireType and metadata. Skip that
+                //! bounded legacy value without resolving its alias, then resume the modern ordered schema. The older
+                //! recovery-only shape remains outside the readable contract because develop already required metadata.
+                //! SingleTableBuilderCorruptMetadataTest#legacyRecoveryFieldBeforeMetadataStillOpens discriminates this
+                //! released-file compatibility path; other unknown fields remain corruption.
+                value.skipValue();
+                consumeTableStorePadding(wire);
+                if (wire.bytes().readRemaining() == 0)
+                    throw new SchemaCorruptionException("the table-store body has recovery but no metadata field");
+                fieldName.setLength(0);
+                value = readTableStoreField(wire, fieldName);
+            }
+            if (!StringUtils.isEqual(fieldName, MetaDataField.metadata.name()))
+                throw new SchemaCorruptionException("the table-store body does not contain the expected field");
+            return value;
+        }
+    }
+
     private static ValueIn readTableStoreField(WireIn wire, MetaDataField expected) {
         //! STStore is a closed, ordered Queue-owned schema: general WireKey lookup scans over unknown fields and makes their
         //! acceptance depend on where they occur. Read the immediate field and validate its name instead.
         //! SingleTableBuilderCorruptMetadataTest#unknownTableStoreFieldsAreRejectedAtEveryPosition loses this boundary.
-        final int code = wire.bytes().peekUnsignedByte();
-        if (code != BinaryWireCode.FIELD_NAME_ANY
-                && (code < BinaryWireCode.FIELD_NAME0 || code > BinaryWireCode.FIELD_NAME31))
-            throw new SchemaCorruptionException("the table-store body does not contain the expected field");
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
             final StringBuilder actual = stlSb.get();
-            final ValueIn value = wire.read(actual);
+            final ValueIn value = readTableStoreField(wire, actual);
             if (!StringUtils.isEqual(actual, expected.name()))
                 throw new SchemaCorruptionException("the table-store body does not contain the expected field");
             return value;
         }
+    }
+
+    private static ValueIn readTableStoreField(WireIn wire, StringBuilder actual) {
+        final int code = wire.bytes().peekUnsignedByte();
+        if (code != BinaryWireCode.FIELD_NAME_ANY
+                && (code < BinaryWireCode.FIELD_NAME0 || code > BinaryWireCode.FIELD_NAME31))
+            throw new SchemaCorruptionException("the table-store body does not contain the expected field");
+        return wire.read(actual);
     }
 
     /**
@@ -373,12 +428,16 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         final String type = shared ? "shared" : "exclusive";
         final StandardOpenOption readOrWrite = shared ? StandardOpenOption.READ : StandardOpenOption.WRITE;
 
+        final LockRuntime runtime;
         try {
-            return doWithLock(file, code, target, shared, TimeUnit.MILLISECONDS.toNanos(timeoutMS),
-                    new FileChannelLockRuntime(file, readOrWrite, shared));
+            runtime = new FileChannelLockRuntime(file, readOrWrite, shared);
         } catch (IOException e) {
-            throw new IllegalStateException("I/O failure while using the " + type + " file lock on " + file, e);
+            throw lockIOException(file, type, e);
         }
+        //! Restrict the checked opening catch to channel construction. A supplier or body can sneaky-throw IOException; once
+        //! the channel is open that failure must pass through as the original object rather than becoming a lock I/O failure.
+        //! SingleTableStoreLockTest#publicLockMethodsPreserveCheckedSupplierAndBodyFailures discriminates all four paths.
+        return doWithLock(file, code, target, shared, TimeUnit.MILLISECONDS.toNanos(timeoutMS), runtime);
     }
 
     static <T, R> R doWithLock(@NotNull final File file,
@@ -395,7 +454,10 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         //! #scriptedNullContentionTimesOutWithoutInventingACause exercise the Queue-owned deadline branches; the
         //! real-lock contention tests retain integration evidence without claiming control of the operating-system clock.
         Throwable lastAcquisitionFailure = null;
-        try (LockRuntime runtime = lockRuntime) {
+        Throwable operationFailure = null;
+        Throwable cleanupSuppressionTarget = null;
+        try {
+            final LockRuntime runtime = lockRuntime;
             final long startNanos = runtime.nanoTime();
             for (int count = 1; runtime.nanoTime() - startNanos < timeoutNanos; count++) {
                 boolean locked = false;
@@ -410,9 +472,11 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                     //! exclusiveContentionIsRetriedBeforeBodyRunsOnce prove the same-JVM signal waits
                     //! and then runs the body exactly once with a real FileChannel. #subprocessContentionRetriesNullBeforeBody
                     //! observes the null result while a separate JVM holds the range, then releases it before body execution.
-                    //! In contrast, IOException is the API's terminal "other I/O error" signal; the
-                    //! scriptedAcquisitionIOExceptionRetainsExactCauseAndSkipsBody test proves Queue propagates
-                    //! the exact cause without invoking either the target or body.
+                    //! In contrast, IOException is the API's terminal "other I/O error" signal; develop retried that broad
+                    //! category, but no supported-platform evidence identifies it as contention. The supplied Mac build 1828
+                    //! log contains no tryLock IOException and predates this branch. The
+                    //! scriptedAcquisitionIOExceptionRetainsExactCauseAndSkipsBody test proves Queue propagates the exact
+                    //! cause without invoking either the target or body; platform evidence remains an explicit open item.
                     lastAcquisitionFailure = e;
                     // failed to acquire the lock, wait until other operation completes
                     if (count > 9) {
@@ -447,7 +511,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                             runtime.closeLock();
                         } catch (Throwable closeFailure) {
                             if (bodyFailed != null)
-                                bodyFailed.addSuppressed(closeFailure);
+                                addSuppressedIfDistinct(bodyFailed.getCause(), closeFailure);
                             else
                                 throw Jvm.rethrow(closeFailure);
                         }
@@ -469,20 +533,54 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                 timeout.initCause(lastAcquisitionFailure);
             throw timeout;
         } catch (BodyFailed e) {
-            //! Lock and channel cleanup run while BodyFailed is primary, so Java attaches their failures
-            //! to the wrapper. Move those suppressed failures onto the original body Throwable before
-            //! rethrowing it; otherwise unwrapping would silently discard cleanup evidence.
+            //! Preserve the body Throwable itself and attach only distinct cleanup failures. Reusing the same Throwable for
+            //! the body and cleanup must not trigger Java's self-suppression guard and replace the primary failure.
+            //! SingleTableStoreLockTest#sameFailureObjectIsNeverSelfSuppressed discriminates this identity edge.
             final Throwable bodyFailure = e.getCause();
             for (Throwable suppressed : e.getSuppressed())
-                bodyFailure.addSuppressed(suppressed);
+                addSuppressedIfDistinct(bodyFailure, suppressed);
+            operationFailure = bodyFailure;
+            cleanupSuppressionTarget = bodyFailure;
             throw Jvm.rethrow(bodyFailure);
         } catch (IOException e) {
             //! Once cleanup failures are no longer discarded, IOException can come from opening,
             //! acquiring, releasing, or closing the lock channel. Report that honest common boundary
             //! and retain the concrete cause. SingleTableStoreLockTest's scripted acquisition and cleanup
             //! tests discriminate Queue's propagation and suppression rules without claiming a platform failure.
-            throw new IllegalStateException("I/O failure while using the " + type + " file lock on " + file, e);
+            operationFailure = lockIOException(file, type, e);
+            cleanupSuppressionTarget = e;
+            throw (IllegalStateException) operationFailure;
+        } catch (Throwable t) {
+            operationFailure = t;
+            cleanupSuppressionTarget = t;
+            throw Jvm.rethrow(t);
+        } finally {
+            try {
+                lockRuntime.close();
+            } catch (Throwable closeFailure) {
+                if (operationFailure != null) {
+                    addSuppressedIfDistinct(cleanupSuppressionTarget, closeFailure);
+                } else if (closeFailure instanceof IOException) {
+                    throw lockIOException(file, type, (IOException) closeFailure);
+                } else {
+                    throw Jvm.rethrow(closeFailure);
+                }
+            }
         }
+    }
+
+    private static IllegalStateException lockIOException(File file, String type, IOException cause) {
+        return new IllegalStateException("I/O failure while using the " + type + " file lock on " + file, cause);
+    }
+
+    private static void addSuppressedIfDistinct(Throwable primary, Throwable cleanup) {
+        if (primary == cleanup)
+            return;
+        for (Throwable suppressed : primary.getSuppressed()) {
+            if (suppressed == cleanup)
+                return;
+        }
+        primary.addSuppressed(cleanup);
     }
 
     interface LockRuntime extends java.io.Closeable {
@@ -680,11 +778,11 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             StringBuilder sb = stlSb.get();
 
             mappedBytes.readPosition(0);
-            // A read limit above writeLimit can fail while another TableStore is being written.
-            //! Capture one immutable scan bound no greater than either this Bytes view's write limit or mapped capacity.
-            //! This is a local bounds guarantee, not a durable logical EOF or a concurrent-publication barrier; the public
-            //! TableStore API does not expose the internal Bytes view needed for a direct losing test.
-            final long scanLimit = Math.min(mappedBytes.writeLimit(), mappedBytes.realCapacity());
+            //! Start from the current physical capacity, even when another writable view previously left this Bytes view's
+            //! logical write limit stale. Otherwise forEachKey can silently omit records already published by that writer.
+            //! The compact-growth compatibility test exercises post-open growth; a deterministic cross-writer publication
+            //! interleaving is not exposed by the public API, so the stale-limit refresh also has static evidence.
+            long scanLimit = currentScanLimit();
             mappedBytes.readLimit(scanLimit);
             positionAfterTableStoreHeader(scanLimit);
             while (true) {
@@ -711,9 +809,19 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
 
                 final long bodyStart = mappedBytes.readPosition();
                 final int length = Wires.lengthOf(header);
-                //! Subtraction avoids overflow while proving the declared end remains inside the snapshotted scan limit.
+                //! Subtraction avoids overflow while proving the declared end remains inside the scan limit. If a writer
+                //! publishes a record that straddles the initial physical boundary, refresh once before calling it corrupt.
+                //! SingleTableBuilderCorruptMetadataTest#compactReadOnlyTableStoreObservesLaterGrowth covers completed growth;
+                //! the narrower mid-scan publication race currently has static evidence because no callback precedes it.
                 //! SingleTableStoreCorruptRecordTest#recordBeyondTheReadLimitIsRejected checks this exact diagnostic,
                 //! before Wire can turn the invalid boundary into an unrelated parsing failure.
+                if (length > scanLimit - bodyStart) {
+                    final long refreshedLimit = currentScanLimit();
+                    if (refreshedLimit > scanLimit) {
+                        scanLimit = refreshedLimit;
+                        mappedBytes.readLimit(scanLimit);
+                    }
+                }
                 if (length > scanLimit - bodyStart)
                     throw new CorruptTableStoreException(file(), "the record at " + recordStart
                             + " declares a length of " + length + ", which does not fit inside the read limit of " + scanLimit);
@@ -738,10 +846,7 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
                     //! and field-number tokens as present identifiers, so ValueIn presence alone cannot enforce this schema.
                     //! SingleTableStoreCorruptRecordTest#missingEventNameIsRejectedByEveryTraversal covers a value-only body;
                     //! #nonCanonicalFieldNameTokenIsRejectedByEveryTraversal loses the exact-token guard; and
-                    //! #explicitEmptyEventNameRemainsValid proves presence, rather than key length, is the schema boundary.
-                    if (!valueIn.isPresent())
-                        throw new CorruptTableStoreException(file(), "the record at " + recordStart
-                                + " has no present event name");
+                    //! #explicitEmptyEventNameRemainsValid proves token presence, rather than key length, is the boundary.
                     valueStart = mappedBytes.readPosition();
                     validateRecordConsumption(recordStart, recordEnd);
                 } catch (CorruptTableStoreException e) {
@@ -772,6 +877,13 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
             }
             return null;
         }
+    }
+
+    private long currentScanLimit() {
+        final long physicalCapacity = mappedBytes.realCapacity();
+        if (mappedBytes.writeLimit() < physicalCapacity)
+            mappedBytes.writeLimit(mappedBytes.capacity());
+        return physicalCapacity;
     }
 
     private void positionAfterTableStoreHeader(long scanLimit) throws EOFException {
@@ -818,7 +930,11 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         //! FLOAT64 without changing the record length and fails if generic skipValue validation is restored.
         final long valueCodeAt = mappedBytes.readPosition();
         final int valueCode = mappedBytes.peekUnsignedByte();
-        if (valueCode != 0 && valueCode != BinaryWireCode.INT64)
+        //! Queue's table-store writer has emitted INT64 for bound longs since the format was introduced. BinaryWire's
+        //! binding API also accepts zero, but scalar iteration reads that same marker as the number zero and ignores its
+        //! payload. Reject the ambiguous representation instead of returning different values through the two traversals.
+        //! SingleTableStoreCorruptRecordTest#zeroValueCodeIsRejectedByEveryTraversal discriminates this consistency rule.
+        if (valueCode != BinaryWireCode.INT64)
             throw new CorruptTableStoreException(file(), "the record at " + recordStart
                     + " holds Wire type 0x" + Integer.toHexString(valueCode) + " instead of a bound long");
 
@@ -832,7 +948,6 @@ public class SingleTableStore<T extends Metadata> extends AbstractCloseable impl
         if (mappedBytes.readRemaining() < 1L + Long.BYTES)
             throw new CorruptTableStoreException(file(), "the record at " + recordStart
                     + " ends inside its bound long");
-        // BinaryWire's binding reader accepts zero as a legacy long marker and consumes its following eight bytes.
         mappedBytes.readSkip(1L + Long.BYTES);
         consumeExplicitBinaryPadding(recordStart);
 

--- a/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -205,6 +206,31 @@ public class ReadWriteTest extends QueueTestCommon {
             tailer.toEnd();
             long index = tailer.index();
             assertNotEquals(0, index);
+        }
+    }
+
+    @Test
+    public void testNonWriteableDirectoryWithoutMetadataSetsQueueReadOnly() {
+        assumeFalse(OS.isWindows());
+        final File metadata = new File(chroniclePath, "metadata.cq4t");
+        BackgroundResourceReleaser.releasePendingResources();
+        assertTrue("metadata fixture was not removed", metadata.delete());
+        assertTrue("directory permissions could not be changed", chroniclePath.setWritable(false, false));
+        try {
+            assumeFalse("test process can still create files in the directory", Files.isWritable(chroniclePath.toPath()));
+            expectException("Failback to readonly tablestore");
+            expectException("Forcing queue to be readOnly");
+
+            try (ChronicleQueue out = SingleChronicleQueueBuilder
+                    .binary(chroniclePath)
+                    .testBlockSize()
+                    .readOnly(false)
+                    .build()) {
+                final ExcerptTailer tailer = out.createTailer();
+                assertEquals(STR1, tailer.readText());
+            }
+        } finally {
+            assertTrue("directory write permission was not restored", chroniclePath.setWritable(true, false));
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCorruptMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueCorruptMetadataTest.java
@@ -3,6 +3,7 @@
  */
 package net.openhft.chronicle.queue.impl.single;
 
+import net.openhft.chronicle.bytes.MappedBytes;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
@@ -14,8 +15,12 @@ import net.openhft.chronicle.queue.impl.table.CorruptTableStoreException;
 import net.openhft.chronicle.queue.impl.table.Metadata;
 import net.openhft.chronicle.queue.impl.table.SingleTableBuilder;
 import net.openhft.chronicle.queue.impl.table.TableStoreUnavailableException;
+import net.openhft.chronicle.wire.BinaryWireCode;
+import net.openhft.chronicle.wire.ValueIn;
+import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireIn;
 import net.openhft.chronicle.wire.WireOut;
+import net.openhft.chronicle.wire.WireType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assume;
 import org.junit.Test;
@@ -220,6 +225,28 @@ public class SingleChronicleQueueCorruptMetadataTest extends QueueTestCommon {
                 thrown.getMessage().contains("does not hold a readable table store"));
     }
 
+    @Test
+    public void queueOwnedMetadataBodyDamageIsCorruption() {
+        final File queueDir = getTmpDir();
+        try (ChronicleQueue queue = SingleChronicleQueueBuilder.binary(queueDir).build()) {
+            queue.createAppender().writeText("hello");
+        }
+        final File metadataFile = new File(queueDir, SingleChronicleQueue.QUEUE_METADATA_FILE);
+        final long sourceIdCodeAt = sourceIdValueCodeAt(metadataFile);
+        try (RandomAccessFile raf = new RandomAccessFile(metadataFile, "rw")) {
+            raf.seek(sourceIdCodeAt);
+            raf.write(BinaryWireCode.TYPE_PREFIX);
+        } catch (IOException e) {
+            throw new AssertionError("could not damage SCQMeta", e);
+        }
+
+        final Throwable thrown = buildAndCaptureFailure(queueDir);
+
+        assertEquals("thrown was " + chainOf(thrown), CorruptTableStoreException.class, thrown.getClass());
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("queue metadata body cannot be decoded"));
+    }
+
     /**
      * The check must not reject a healthy queue.
      */
@@ -288,6 +315,38 @@ public class SingleChronicleQueueCorruptMetadataTest extends QueueTestCommon {
         } catch (IOException e) {
             throw new AssertionError("could not corrupt " + metadataFile, e);
         }
+    }
+
+    private long sourceIdValueCodeAt(File metadataFile) {
+        final long[] result = {-1L};
+        try (MappedBytes bytes = MappedBytes.mappedBytes(
+                metadataFile, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, true)) {
+            bytes.singleThreadedCheckDisabled(true);
+            try {
+                final Wire wire = WireType.BINARY_LIGHT.apply(bytes);
+                wire.readFirstHeader();
+                final ValueIn storeValue = wire.read(MetaDataKeys.header);
+                storeValue.typePrefix(new StringBuilder(), StringBuilder::append);
+                storeValue.applyToMarshallable(storeWire -> {
+                    storeWire.read(MetaDataField.wireType).object(WireType.class);
+                    final ValueIn metadataValue = storeWire.read(MetaDataField.metadata);
+                    metadataValue.typePrefix(new StringBuilder(), StringBuilder::append);
+                    metadataValue.applyToMarshallable(metadataWire -> {
+                        metadataWire.read(MetaDataField.roll).skipValue();
+                        metadataWire.read(MetaDataField.sourceId);
+                        result[0] = metadataWire.bytes().readPosition();
+                        return null;
+                    });
+                    return null;
+                });
+            } finally {
+                bytes.singleThreadedCheckReset();
+            }
+        } catch (IOException e) {
+            throw new AssertionError("could not locate SCQMeta sourceId", e);
+        }
+        assertTrue("SCQMeta sourceId value was not located", result[0] >= 0L);
+        return result[0];
     }
 
     private String chainOf(Throwable thrown) {

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilderCorruptMetadataTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableBuilderCorruptMetadataTest.java
@@ -36,7 +36,9 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static net.openhft.chronicle.core.pool.ClassAliasPool.CLASS_ALIASES;
@@ -314,6 +316,27 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
     }
 
     @Test
+    public void metadataRequiresMarshallableFraming() throws IOException {
+        final File file = newTableStoreFile("metadata-missing-frame");
+        try (TableStore<SecretMetadata> store = SingleTableBuilder.binary(file, new SecretMetadata()).build()) {
+            assertNotNull(store);
+        }
+        replaceLengthPrefixWithPadding(file, nestedMetadataLengthCodeAt(file));
+        SecretMetadata.READ_COUNT.set(0);
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("does not hold readable metadata"));
+        assertEquals("metadata without marshallable framing invoked its constructor", 0, SecretMetadata.READ_COUNT.get());
+        assertFileCanBeDeleted(file);
+
+        assertUnframedMetadataIsRejected("metadata-scalar-frame", value -> value.int32(17));
+        assertUnframedMetadataIsRejected("metadata-null-frame", ValueOut::nu11);
+        assertUnframedMetadataIsRejected("metadata-absent-frame", value -> { });
+    }
+
+    @Test
     public void outerTableStoreFramingFailureIsCorruptionWithoutConstruction() throws IOException {
         final File file = newTableStoreFile("outer-table-store-framing");
         try (TableStore<SecretMetadata> store = SingleTableBuilder.binary(file, new SecretMetadata()).build()) {
@@ -331,6 +354,27 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
         assertEquals("failed outer framing decode grew the file", corruptedLength, Files.size(file.toPath()));
         assertThrowableChainOmits(thrown, SecretMetadata.SECRET);
         assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void outerSchemaRequiresMarshallableFraming() throws IOException {
+        final File file = newTableStoreFile("outer-missing-frame");
+        try (TableStore<SecretMetadata> store = SingleTableBuilder.binary(file, new SecretMetadata()).build()) {
+            assertNotNull(store);
+        }
+        replaceLengthPrefixWithPadding(file, outerTableStoreLengthCodeAt(file));
+        SecretMetadata.READ_COUNT.set(0);
+
+        final CorruptTableStoreException thrown = assertCorruption(file, false);
+
+        assertTrue("message was " + thrown.getMessage(),
+                thrown.getMessage().contains("does not hold a readable table store"));
+        assertEquals("STStore without marshallable framing invoked metadata", 0, SecretMetadata.READ_COUNT.get());
+        assertFileCanBeDeleted(file);
+
+        assertUnframedOuterStoreIsRejected("outer-scalar-frame", value -> value.int32(17));
+        assertUnframedOuterStoreIsRejected("outer-null-frame", ValueOut::nu11);
+        assertUnframedOuterStoreIsRejected("outer-absent-frame", value -> { });
     }
 
     @Test
@@ -408,6 +452,35 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
 
         assertFileCanBeDeleted(beforeWireType);
         assertFileCanBeDeleted(beforeMetadata);
+    }
+
+    @Test
+    public void legacyRecoveryFieldBeforeMetadataStillOpens() throws IOException {
+        final File file = writeFirstHeader("legacy-recovery", "header",
+                value -> value.typedMarshallable("STStore", wire -> {
+                    wire.write(MetaDataField.wireType).object(WireType.BINARY);
+                    wire.write(MetaDataField.recovery).typedMarshallable("LegacyTimedStoreRecovery",
+                            recovery -> recovery.write("timeStamp").int64(0L));
+                    wire.write(MetaDataField.metadata).typedMarshallable(new SecretMetadata());
+                    wire.writeAlignTo(Integer.BYTES, 0);
+                }));
+
+        try (TableStore<SecretMetadata> store = SingleTableBuilder
+                .builder(file, WireType.BINARY_LIGHT, new SecretMetadata())
+                .build();
+             LongValue value = store.acquireValueFor("legacy.recovery", 73L)) {
+            assertEquals(SecretMetadata.SECRET, store.metadata().payload);
+            assertEquals(73L, value.getValue());
+        }
+        try (TableStore<SecretMetadata> store = SingleTableBuilder
+                .builder(file, WireType.READ_ANY, new SecretMetadata())
+                .readOnly(true)
+                .build();
+             LongValue value = store.acquireValueFor("legacy.recovery", -1L)) {
+            assertEquals(SecretMetadata.SECRET, store.metadata().payload);
+            assertEquals(73L, value.getValue());
+        }
+        assertFileCanBeDeleted(file);
     }
 
     @Test
@@ -499,6 +572,38 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
     }
 
     @Test
+    public void writerAlwaysUsesCanonicalTableStoreAlias() throws Exception {
+        final File file = newTableStoreFile("canonical-writer-alias");
+        final String javaExecutable = new File(new File(System.getProperty("java.home"), "bin"), "java").getPath();
+        final java.util.List<String> command = new java.util.ArrayList<>();
+        command.add(javaExecutable);
+        command.addAll(java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments());
+        command.add("-cp");
+        command.add(System.getProperty("java.class.path"));
+        command.add(AliasFirstWriter.class.getName());
+        command.add(file.getAbsolutePath());
+        final Process writer = new ProcessBuilder(command)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start();
+
+        try {
+            assertTrue("alias-first writer did not terminate", writer.waitFor(15L, TimeUnit.SECONDS));
+            assertEquals("alias-first writer failed", 0, writer.exitValue());
+        } finally {
+            if (writer.isAlive()) {
+                writer.destroyForcibly();
+                writer.waitFor(15L, TimeUnit.SECONDS);
+            }
+        }
+        assertEquals("STStore", persistedOuterAlias(file));
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build();
+             LongValue value = store.acquireValueFor("alias.first", -1L)) {
+            assertEquals(47L, value.getValue());
+        }
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
     public void applicationCorruptionExceptionIsNotPromoted() throws IOException {
         final File file = tableStoreWithReadFailingMetadata("application-corruption");
         final CorruptTableStoreException direct =
@@ -566,6 +671,43 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
         assertSame("application constructor failure lost its identity", expected, findInChain(thrown, expected));
     }
 
+    private void assertReservedWriteFailureIsIsolated(String stem, RuntimeException expected) throws IOException {
+        final File file = newTableStoreFile(stem);
+        final IORuntimeException actual = assertThrows(IORuntimeException.class,
+                () -> SingleTableBuilder.binary(file, new ReservedSignalWriteMetadata(expected)).build());
+        assertFalse("application write failure became corruption", actual instanceof CorruptTableStoreException);
+        assertFalse("application write failure became availability", actual instanceof TableStoreUnavailableException);
+        assertSame(expected, actual.getCause());
+        assertFileCanBeDeleted(file);
+    }
+
+    private void assertUnframedMetadataIsRejected(String stem, Consumer<ValueOut> frameWriter) throws IOException {
+        final File file = writeFirstHeader(stem, "header", value -> value.typedMarshallable("STStore", wire -> {
+            wire.write(MetaDataField.wireType).object(WireType.BINARY_LIGHT);
+            final ValueOut metadataValue = wire.write(MetaDataField.metadata);
+            metadataValue.typePrefix(SecretMetadata.class);
+            frameWriter.accept(metadataValue);
+            wire.writeAlignTo(Integer.BYTES, 0);
+        }));
+        SecretMetadata.READ_COUNT.set(0);
+
+        assertCorruption(file, false);
+
+        assertEquals("unframed metadata invoked its constructor", 0, SecretMetadata.READ_COUNT.get());
+        assertFileCanBeDeleted(file);
+    }
+
+    private void assertUnframedOuterStoreIsRejected(String stem, Consumer<ValueOut> frameWriter) throws IOException {
+        final File file = writeFirstHeader(stem, "header", value -> {
+            value.typePrefix("STStore");
+            frameWriter.accept(value);
+        });
+
+        assertCorruption(file, false);
+
+        assertFileCanBeDeleted(file);
+    }
+
     private File tableStoreWithReadFailingMetadata(String stem) throws IOException {
         final File file = newTableStoreFile(stem);
         ReadFailingMetadata.FAILURE = null;
@@ -611,6 +753,22 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
                 final net.openhft.chronicle.wire.ValueIn storeValue = wire.read("header");
                 storeValue.typePrefix(new StringBuilder(), StringBuilder::append);
                 return wire.bytes().readPosition();
+            } finally {
+                bytes.singleThreadedCheckReset();
+            }
+        }
+    }
+
+    private String persistedOuterAlias(File file) throws IOException {
+        try (MappedBytes bytes = MappedBytes.mappedBytes(file, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, true)) {
+            bytes.singleThreadedCheckDisabled(true);
+            try {
+                final Wire wire = WireType.BINARY_LIGHT.apply(bytes);
+                wire.readFirstHeader();
+                final net.openhft.chronicle.wire.ValueIn storeValue = wire.read("header");
+                final StringBuilder alias = new StringBuilder();
+                storeValue.typePrefix(alias, StringBuilder::append);
+                return alias.toString();
             } finally {
                 bytes.singleThreadedCheckReset();
             }
@@ -700,6 +858,25 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
             raf.seek(lengthCodeAt);
             raf.write(BinaryWireCode.BYTES_LENGTH32);
             raf.writeInt(Integer.reverseBytes(LENGTH_MASK));
+        }
+    }
+
+    private void replaceLengthPrefixWithPadding(File file, long lengthCodeAt) throws IOException {
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            raf.seek(lengthCodeAt);
+            final int code = raf.readUnsignedByte();
+            final int prefixWidth;
+            if (code == BinaryWireCode.BYTES_LENGTH8)
+                prefixWidth = 2;
+            else if (code == BinaryWireCode.BYTES_LENGTH16)
+                prefixWidth = 3;
+            else if (code == BinaryWireCode.BYTES_LENGTH32)
+                prefixWidth = 5;
+            else
+                throw new AssertionError("expected a marshallable length prefix, found 0x" + Integer.toHexString(code));
+            raf.seek(lengthCodeAt);
+            for (int i = 0; i < prefixWidth; i++)
+                raf.write(BinaryWireCode.PADDING);
         }
     }
 
@@ -796,6 +973,76 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
     }
 
     @Test
+    public void compactReadOnlyTableStoreObservesLaterGrowth() throws IOException {
+        final File file = newTableStoreFile("compact-growth");
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build();
+             LongValue value = store.acquireValueFor("compact.initial", 1L)) {
+            assertEquals(1L, value.getValue());
+        }
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            raf.setLength(64L * 1024L);
+        }
+
+        try (TableStore<Metadata.NoMeta> reader = SingleTableBuilder
+                .builder(file, WireType.READ_ANY, Metadata.NoMeta.INSTANCE)
+                .readOnly(true)
+                .build();
+             TableStore<Metadata.NoMeta> writer = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build()) {
+            final char[] keyChars = new char[180];
+            java.util.Arrays.fill(keyChars, 'k');
+            final String keyPrefix = new String(keyChars);
+            String lastKey = null;
+            for (int i = 0; i < 400; i++) {
+                lastKey = keyPrefix + i;
+                try (LongValue appended = writer.acquireValueFor(lastKey, i)) {
+                    assertEquals(i, appended.getValue());
+                }
+            }
+            try (LongValue value = reader.acquireValueFor(lastKey, -1L)) {
+                assertEquals(399L, value.getValue());
+            }
+            final AtomicInteger keyCount = new AtomicInteger();
+            reader.forEachKey(keyCount, (count, key, valueIn) -> count.incrementAndGet());
+            assertEquals(401, keyCount.get());
+        }
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void readOnlyOpenWaitsForFirstHeaderPublication() throws Exception {
+        final File file = newTableStoreFile("publication-window");
+        final int mappingPageSize = PageUtil.getPageSize(file.getAbsolutePath());
+        try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
+            raf.setLength(2L * OS.mapAlign(OS.SAFE_PAGE_SIZE, mappingPageSize));
+        }
+        final AtomicReference<Throwable> creatorFailure = new AtomicReference<>();
+        final Thread creator = new Thread(() -> {
+            // Exceed the historical one-second short-file wait: a preallocated zero header uses the lock timeout instead.
+            Jvm.pause(1_500L);
+            try (TableStore<Metadata.NoMeta> created = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build()) {
+                if (created.metadata() != Metadata.NoMeta.INSTANCE)
+                    throw new AssertionError("creator published unexpected metadata");
+            } catch (Throwable t) {
+                creatorFailure.set(t);
+            }
+        }, "table-store-header-publisher");
+        creator.start();
+
+        try (TableStore<Metadata.NoMeta> store = SingleTableBuilder
+                .builder(file, WireType.READ_ANY, Metadata.NoMeta.INSTANCE)
+                .readOnly(true)
+                .build()) {
+            assertEquals(Metadata.NoMeta.INSTANCE, store.metadata());
+        } finally {
+            creator.join(5_000L);
+        }
+        assertFalse("creator did not terminate", creator.isAlive());
+        if (creatorFailure.get() != null)
+            throw new AssertionError("creator failed", creatorFailure.get());
+        assertFileCanBeDeleted(file);
+    }
+
+    @Test
     public void failedWritableOpenDoesNotGrowAnIncompleteFirstHeader() throws IOException {
         final File file = newTableStoreFile("incomplete-first-header");
         try (java.io.RandomAccessFile raf = new java.io.RandomAccessFile(file, "rw")) {
@@ -852,6 +1099,20 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
 
         assertSame("the metadata failure was replaced", expected, thrown);
         assertFileCanBeDeleted(file);
+    }
+
+    @Test
+    public void metadataWriteCannotOriginateReservedTableStoreSignals() throws IOException {
+        final File unavailableFile = newTableStoreFile("reserved-unavailable");
+        assertTrue(unavailableFile.delete());
+        final TableStoreUnavailableException unavailable = new TableStoreUnavailableException(
+                unavailableFile, "application-owned availability signal");
+        assertReservedWriteFailureIsIsolated("write-unavailable", unavailable);
+
+        final File corruptFile = newTableStoreFile("reserved-corrupt");
+        final CorruptTableStoreException corrupt = new CorruptTableStoreException(
+                corruptFile, "application-owned corruption signal");
+        assertReservedWriteFailureIsIsolated("write-corrupt", corrupt);
     }
 
     private CorruptTableStoreException assertCorruption(File file, boolean readOnly) {
@@ -968,6 +1229,19 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
         }
     }
 
+    public static final class ReservedSignalWriteMetadata implements Metadata {
+        private final transient RuntimeException failure;
+
+        private ReservedSignalWriteMetadata(RuntimeException failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            throw failure;
+        }
+    }
+
     public static final class OverrideFailingMetadata implements Metadata {
         private final transient RuntimeException failure;
 
@@ -1073,6 +1347,18 @@ public class SingleTableBuilderCorruptMetadataTest extends QueueTestCommon {
         @Override
         protected void performClose() {
             CLOSE_COUNT.incrementAndGet();
+        }
+    }
+
+    public static final class AliasFirstWriter {
+        public static void main(String[] args) {
+            CLASS_ALIASES.addAlias(SingleTableStore.class, "AliasRegisteredBeforeBuilder");
+            final File file = new File(args[0]);
+            try (TableStore<Metadata.NoMeta> store = SingleTableBuilder.binary(file, Metadata.NoMeta.INSTANCE).build();
+                 LongValue value = store.acquireValueFor("alias.first", 47L)) {
+                if (value.getValue() != 47L)
+                    throw new AssertionError("unexpected stored value " + value.getValue());
+            }
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreCorruptRecordTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreCorruptRecordTest.java
@@ -253,6 +253,16 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
     }
 
     @Test
+    public void zeroValueCodeIsRejectedByEveryTraversal() throws IOException {
+        final File file = tableStoreWithTwoKeys();
+        replaceFirstValueCode(file, 0);
+
+        assertAcquireRejects(file, "key.one", "instead of a bound long");
+        assertAcquireRejects(file, "key.two", "instead of a bound long");
+        assertForEachKeyRejectsBeforeCallback(file, WireType.BINARY_LIGHT, "instead of a bound long");
+    }
+
+    @Test
     public void malformedBinaryPaddingIsRejected() throws IOException {
         File truncated = tableStoreWithTwoKeys();
         final long truncatedValueCodeAt = replaceFirstValueCode(truncated, BinaryWireCode.PADDING32);
@@ -584,7 +594,7 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
             final byte[] codeAndValue = new byte[1 + Long.BYTES];
             raf.readFully(codeAndValue);
             assertTrue("the table-store value did not use a bound-long code",
-                    (codeAndValue[0] & 0xff) == 0 || (codeAndValue[0] & 0xff) == BinaryWireCode.INT64);
+                    (codeAndValue[0] & 0xff) == BinaryWireCode.INT64);
             raf.seek(valueCodeAt - 1L);
             raf.write(codeAndValue);
             raf.write(BinaryWireCode.PADDING);
@@ -630,8 +640,9 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
             final int replacementLength;
             switch (mutation) {
                 case SHORTER_POSITIVE:
-                    assertTrue("record is too short to shorten positively: " + originalLength, originalLength > 1);
-                    replacementLength = 1;
+                    assertTrue("record is too short to shorten positively: " + originalLength,
+                            originalLength > Integer.BYTES);
+                    replacementLength = Integer.BYTES;
                     break;
                 case LONGER_IN_RANGE:
                     // Keep the end aligned so exact consumption, rather than header alignment, rejects the mutation.
@@ -665,7 +676,7 @@ public class SingleTableStoreCorruptRecordTest extends QueueTestCommon {
             final int originalCode = raf.read();
             assertTrue("the table-store value did not use a bound-long code: 0x"
                             + Integer.toHexString(originalCode),
-                    originalCode == 0 || originalCode == BinaryWireCode.INT64);
+                    originalCode == BinaryWireCode.INT64);
             raf.seek(valueCodeAt);
             raf.write(replacementCode);
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreLockTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/table/SingleTableStoreLockTest.java
@@ -3,6 +3,7 @@
  */
 package net.openhft.chronicle.queue.impl.table;
 
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.queue.QueueTestCommon;
 import net.openhft.chronicle.testframework.ExecutorServiceUtil;
 import org.junit.Before;
@@ -78,7 +79,7 @@ public class SingleTableStoreLockTest extends QueueTestCommon {
         final AtomicInteger targetCalls = new AtomicInteger();
         final BufferedReader output = new BufferedReader(new InputStreamReader(holder.getInputStream(), StandardCharsets.UTF_8));
         try {
-            assertEquals("LOCKED", executor.submit(output::readLine).get(5, TimeUnit.SECONDS));
+            assertEquals("LOCKED", executor.submit(output::readLine).get(15, TimeUnit.SECONDS));
             final ObservedFileLockRuntime runtime = new ObservedFileLockRuntime(file, false);
             final Future<String> result = executor.submit(() -> withLock(file, false, target -> {
                 bodyCalls.incrementAndGet();
@@ -88,21 +89,21 @@ public class SingleTableStoreLockTest extends QueueTestCommon {
                 return "done";
             }, TimeUnit.SECONDS.toNanos(5), runtime));
 
-            assertTrue("the real null-contention result was not observed", runtime.contention.await(5, TimeUnit.SECONDS));
+            assertTrue("the real null-contention result was not observed", runtime.contention.await(15, TimeUnit.SECONDS));
             assertTrue("same-JVM overlap was observed instead of null", runtime.nullResults.get() > 0);
             assertEquals(0, bodyCalls.get());
             assertEquals(0, targetCalls.get());
             holder.getOutputStream().write(1);
             holder.getOutputStream().flush();
-            assertTrue("lock-holder process did not finish", holder.waitFor(5, TimeUnit.SECONDS));
+            assertTrue("lock-holder process did not finish", holder.waitFor(15, TimeUnit.SECONDS));
             assertEquals(0, holder.exitValue());
-            assertEquals("done", result.get(5, TimeUnit.SECONDS));
+            assertEquals("done", result.get(15, TimeUnit.SECONDS));
             assertEquals(1, bodyCalls.get());
             assertEquals(1, targetCalls.get());
         } finally {
             holder.destroyForcibly();
             try {
-                assertTrue("lock-holder process survived cleanup", holder.waitFor(5, TimeUnit.SECONDS));
+                assertTrue("lock-holder process survived cleanup", holder.waitFor(15, TimeUnit.SECONDS));
             } finally {
                 output.close();
                 ExecutorServiceUtil.shutdownForciblyAndWaitForTermination(executor);
@@ -305,6 +306,80 @@ public class SingleTableStoreLockTest extends QueueTestCommon {
         assertEquals(1, runtime.closeCalls.get());
     }
 
+    @Test
+    public void publicLockMethodsPreserveCheckedSupplierAndBodyFailures() throws IOException {
+        final File file = newLockFile();
+        for (boolean shared : new boolean[]{false, true}) {
+            final AtomicInteger supplierCalls = new AtomicInteger();
+            final AtomicInteger bodyCalls = new AtomicInteger();
+            final IOException supplierFailure = new IOException("checked supplier failure, shared=" + shared);
+
+            final IOException actualSupplierFailure = assertThrows(IOException.class,
+                    () -> withPublicLock(file, shared, ignored -> {
+                        bodyCalls.incrementAndGet();
+                        return "unused";
+                    }, () -> {
+                        supplierCalls.incrementAndGet();
+                        throw Jvm.rethrow(supplierFailure);
+                    }));
+            assertSame(supplierFailure, actualSupplierFailure);
+            assertEquals(1, supplierCalls.get());
+            assertEquals(0, bodyCalls.get());
+
+            supplierCalls.set(0);
+            final IOException bodyFailure = new IOException("checked body failure, shared=" + shared);
+            final IOException actualBodyFailure = assertThrows(IOException.class,
+                    () -> withPublicLock(file, shared, ignored -> {
+                        bodyCalls.incrementAndGet();
+                        throw Jvm.rethrow(bodyFailure);
+                    }, () -> {
+                        supplierCalls.incrementAndGet();
+                        return "target";
+                    }));
+            assertSame(bodyFailure, actualBodyFailure);
+            assertEquals(1, supplierCalls.get());
+            assertEquals(1, bodyCalls.get());
+            assertEquals("reacquired", withPublicLock(file, shared, ignored -> "reacquired", () -> "target"));
+        }
+    }
+
+    @Test
+    public void sameFailureObjectIsNeverSelfSuppressed() throws IOException {
+        final File file = newLockFile();
+        final IOException bodyAndLockFailure = new IOException("same body and lock failure");
+        final TestLockRuntime bodyRuntime = new TestLockRuntime(
+                () -> true, () -> 0L, ignored -> {
+                }, bodyAndLockFailure, null);
+
+        final IOException actualBodyFailure = assertThrows(IOException.class,
+                () -> withLock(file, false, ignored -> {
+                    throw Jvm.rethrow(bodyAndLockFailure);
+                }, () -> "target", TimeUnit.SECONDS.toNanos(1), bodyRuntime));
+        assertSame(bodyAndLockFailure, actualBodyFailure);
+        assertEquals(0, actualBodyFailure.getSuppressed().length);
+
+        final IOException bodyAndChannelFailure = new IOException("same body and channel failure");
+        final TestLockRuntime channelRuntime = new TestLockRuntime(
+                () -> true, () -> 0L, ignored -> {
+                }, null, bodyAndChannelFailure);
+        final IOException actualChannelFailure = assertThrows(IOException.class,
+                () -> withLock(file, false, ignored -> {
+                    throw Jvm.rethrow(bodyAndChannelFailure);
+                }, () -> "target", TimeUnit.SECONDS.toNanos(1), channelRuntime));
+        assertSame(bodyAndChannelFailure, actualChannelFailure);
+        assertEquals(0, actualChannelFailure.getSuppressed().length);
+
+        final IOException lockAndChannelFailure = new IOException("same lock and channel failure");
+        final TestLockRuntime cleanupRuntime = new TestLockRuntime(
+                () -> true, () -> 0L, ignored -> {
+                }, lockAndChannelFailure, lockAndChannelFailure);
+        final IllegalStateException actualCleanupFailure = assertThrows(IllegalStateException.class,
+                () -> withLock(file, false, ignored -> "done", () -> "target",
+                        TimeUnit.SECONDS.toNanos(1), cleanupRuntime));
+        assertSame(lockAndChannelFailure, actualCleanupFailure.getCause());
+        assertEquals(0, lockAndChannelFailure.getSuppressed().length);
+    }
+
     private void assertBodyRunsOnceAndPreservesFailureIdentity(boolean shared) throws IOException {
         final File file = newLockFile();
         final AtomicInteger targetCalls = new AtomicInteger();
@@ -435,6 +510,15 @@ public class SingleTableStoreLockTest extends QueueTestCommon {
                               long timeoutNanos,
                               SingleTableStore.LockRuntime lockRuntime) {
         return SingleTableStore.doWithLock(file, code, target, shared, timeoutNanos, lockRuntime);
+    }
+
+    private <T, R> R withPublicLock(File file,
+                                    boolean shared,
+                                    Function<T, ? extends R> code,
+                                    Supplier<T> target) {
+        return shared
+                ? SingleTableStore.doWithSharedLock(file, code, target)
+                : SingleTableStore.doWithExclusiveLock(file, code, target);
     }
 
     private static void await(CountDownLatch latch) {


### PR DESCRIPTION
## Summary

- wait for a preallocated but unpublished first header instead of reporting corruption
- preserve read-only fallback for an unwritable directory with no metadata file
- retain released recovery-field headers and make legacy 64 KiB read-only mappings observe growth
- emit the canonical STStore alias and require explicit marshallable framing before construction
- classify failures inside persisted SCQMeta as Queue metadata corruption while preserving application metadata failures
- preserve public lock callback Throwable identity and make cleanup suppression identity-safe
- reject the ambiguous zero value marker and refresh record scan bounds after growth
- keep provisional stores reachable until lock cleanup completes

## Wire format policy

BINARY_LIGHT is the supported table-store encoding. BINARY remains a legacy selector for the common subset and is decoded with BINARY_LIGHT. READ_ANY is read-only detection only. RAW, fieldless, compressed, and text formats remain unsupported.

Security-focused concerns are explicitly outside this follow-up scope.

## Mac build 1828

The supplied log built commit 2309982, not this branch. Its two remediation-test failures were global resource-tracing collisions with a concurrently running test and both passed on rerun. The broader failures were timeouts, disk use, and leaked resources across unrelated tests. The log contains no tryLock IOException evidence, so generic acquisition IOException remains terminal pending supported-platform evidence.

## Verification

- 92 focused tests: 0 failures, 0 errors, 0 skipped
- mvn clean verify: 1204 tests, 0 failures, 0 errors, 56 skipped
- git diff --check
- no changed Java line exceeds 144 characters
- every added test method is referenced by a production rationale note; no //! appears in tests

## Deliberately deferred

- the pre-existing per-key file-growth behavior
- direct deterministic injection of the post-construction builder cleanup edge
- supported-platform evidence for FileChannel.tryLock IOException classification
- security-focused findings