### PR TITLE
QUEUE-149: Strengthen read-only appender rejection test

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/ReadWriteTest.java
@@ -153,21 +153,24 @@ public class ReadWriteTest extends QueueTestCommon {
     }
 
     // Can't append to a read-only chronicle
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testWriteToReadOnlyChronicle() {
-        if (OS.isWindows()) {
-            System.err.println("#460 Cannot test read only mode on windows");
-            throw new IllegalStateException("not run");
-        }
+        assumeFalse("#460 Cannot test read only mode on Windows", OS.isWindows());
 
         try (ChronicleQueue out = SingleChronicleQueueBuilder
                 .binary(chroniclePath)
                 .testBlockSize()
                 .readOnly(true)
-                .build();
-             final ExcerptAppender appender = out.createAppender()) {
-            assumeNotNull(appender);
-            // Do nothing
+                .build()) {
+            ExcerptAppender unexpectedAppender;
+            try {
+                unexpectedAppender = out.createAppender();
+            } catch (IllegalStateException expected) {
+                return;
+            }
+            try (ExcerptAppender appender = unexpectedAppender) {
+                fail("Read-only queue unexpectedly created an appender: " + appender);
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose

Extract the read-only test-quality improvement from #1702 without importing the bulk JUnit 5 migration.

The old whole-method expected exception could pass when opening the queue failed. Its Windows branch manufactured the expected exception and reported a pass without testing rejection.

## Change

One method in one file, based on develop `d1cc3c87a04539ee1d3aedb7696f39bc2261f68e`:

- Report the unsupported Windows path as an assumption skip.
- Build the read-only queue outside the expected-rejection scope.
- Catch `IllegalStateException` only from `createAppender()`.
- Fail if acquisition returns. Close any unexpectedly returned appender using try-with-resources; a close failure is suppressed on the assertion failure, not accepted as rejection.

JUnit 4, the inherited timeout and lifecycle, public test visibility, the test JAR, POMs and production sources remain unchanged. This is preparatory strengthening, not a claim that Jupiter migration is complete. #1702's shared-fixture migration still needs independent review.

## Validation

Executed locally on Linux x86_64, Maven 3.9.11; these are local results, not an attestation of remote CI:

| Check | Result |
| --- | --- |
| Java 21.0.12: `mvn -B -ntp clean verify -l <log>` at `6b19d66dc4389e61660ddbd3f57a8075e975f5b5` | 1,114 tests reported; zero failures/errors; 52 skipped |
| `mvn -B -ntp -Dtest=ReadWriteTest test -l <log>` | Six tests passed on both Java 21.0.12 and Java 8u502 |
| Compatibility enforcer against 2026.0 | 100% binary and source; production-library report only |
| `javap -public` comparison of `ReadWriteTest` | Public signatures unchanged |

Also executed ten derived before/after copies of the actual test through JUnit 4 and the unchanged shared fixture. Controlled queue/appender proxies were substituted only in the target method; real setup/teardown still ran:

| Injected condition | Old test | New test |
| --- | --- | --- |
| Appender acquisition rejects | Pass | Pass |
| Queue opening throws | False pass | Fails |
| Acquisition returns; close succeeds | Fails | Fails; appender closed once |
| Acquisition returns; close throws | False pass | Assertion fails; close exception retained as suppressed; closed once |
| Windows branch selected | Manufactured pass | Assumption skip |

The Windows row is a controlled branch probe on Linux, not native Windows execution. No production classes were modified or runtime bug claimed. Full-suite skips include unavailable huge-page coverage; platform CI remains a separate check.

<details>
<summary>Run receipt and resolved snapshot identities</summary>

Full verification log excerpt:

```text
Tests run: 1114, Failures: 0, Errors: 0, Skipped: 52
BINARY COMPATIBILITY ENFORCER - SUCCESSFUL - chronicle-queue
BUILD SUCCESS
Total time: 02:49 min
Finished at: 2026-09-08T06:55:14+01:00
```

Selected resolved dependencies: Core 2026.6, Bytes 2026.4, Wire 2026.10-SNAPSHOT, Threads 2026.3; JUnit 4.13.2 and Vintage 5.10.0. Parent and third-party BOM remain 2026.0; Chronicle BOM remains 2026.0-SNAPSHOT.

SHA-256 of the actual local snapshot inputs:
- Chronicle BOM POM: `5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0`.
- Wire JAR: `77afd5d4236c738c25980c268858879b6c929e70486b829b5e4a434dd6b31c87`.

Both were locally installed snapshots; no remote timestamped identity is claimed. XML reports were archived separately before later test runs could overwrite them. Existing expected read-only fallback logs and shaded-resource warnings remain; this is not a warning-free build claim.

</details>

## CI status snapshot (2026-09-08 06:19 UTC)

Exact-head statuses: seven successful, one failed (Zing 11), four pending. The [failed Zing 11 job](https://teamcity.chronicle.software/buildConfiguration/Chronicle_ChronicleQueue_SnapshotZing11/1349159) remains uninvestigated: the unauthenticated TeamCity guest REST request returned HTTP 401. The cause is not attributed to this patch, the baseline or infrastructure. Local successful verification does not resolve that CI failure.
