### PR TITLE
QUEUE-149: Require all legal cycle writes before asserting overflow

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
@@ -24,11 +24,12 @@ public class CycleOverflowTest extends QueueTestCommon {
         SetTimeProvider timeProvider = new SetTimeProvider();
         timeProvider.set(System.currentTimeMillis());
         try (SingleChronicleQueue queue = SingleChronicleQueueBuilder.builder().timeProvider(timeProvider).rollCycle(rollCycle).path(path).build(); ExcerptAppender appender = queue.createAppender();) {
-            assertThrows("Unable to index 64, the number of entries exceeds max number for the current rollcycle", IllegalStateException.class, () -> {
-                for (int i = 0; i < rollCycle.maxMessagesPerCycle() + 1; i++) {
-                    appender.writeText(Integer.toString(i));
-                }
-            });
+            for (int i = 0; i < rollCycle.maxMessagesPerCycle(); i++) {
+                appender.writeText(Integer.toString(i));
+            }
+
+            assertThrows(IllegalStateException.class,
+                    () -> appender.writeText(Long.toString(rollCycle.maxMessagesPerCycle())));
         } finally {
             IOTools.deleteDirWithFiles(path);
         }

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/CycleOverflowTest.java
@@ -28,7 +28,8 @@ public class CycleOverflowTest extends QueueTestCommon {
                 appender.writeText(Integer.toString(i));
             }
 
-            assertThrows(IllegalStateException.class,
+            assertThrows("Writing beyond the cycle's maximum message count must be rejected",
+                    IllegalStateException.class,
                     () -> appender.writeText(Long.toString(rollCycle.maxMessagesPerCycle())));
         } finally {
             IOTools.deleteDirWithFiles(path);


### PR DESCRIPTION
## Purpose

Extract the cycle-overflow boundary improvement from #1702, independently of the JUnit 5 migration.

Previously, `assertThrows` enclosed both the legal writes and the overflowing write. An `IllegalStateException` on the first or last legal write could satisfy the test.

## Change

One method in one file, based on develop `d1cc3c87a04539ee1d3aedb7696f39bc2261f68e`:

1. Complete every legal write outside `assertThrows`.
2. Assert rejection only for the next entry.

The old string supplied to `assertThrows` was a failure message, not an assertion about exception text; no exception-message contract is removed.

No POM, production code, JUnit version/engine, shared fixture, timeout, cleanup or public-visibility changes. This is preparatory test strengthening, not a completed Jupiter migration. Companion read-only improvement: #1757.

## Validation

Executed locally on Linux x86_64, Maven 3.9.11, at `7d00d21a3ac2142e2951c12651532f4ec1cf1ceb`:

| Check | Result |
| --- | --- |
| Java 21.0.12, fresh checkout: `mvn -B -ntp clean verify -l <log>` | 1,114 tests reported; zero failures/errors; 52 skipped |
| `mvn -B -ntp -Dtest=CycleOverflowTest test -l <log>` | One test passed on Java 21.0.12 and Java 8u502 |
| Compatibility enforcer against 2026.0 | 100% binary and source; production-library report only |

Eight derived before/after copies of the actual test were also executed through JUnit 4 and the unchanged shared fixture. Queue writes were real, with controlled exceptions inserted into the test body; no production classes were modified.

| Condition | Old test | New test |
| --- | --- | --- |
| Correct queue boundary | Pass | Pass |
| Inject an exception at legal write 0 | False pass | Fails |
| Inject an exception at legal write 63 | False pass | Fails |
| Suppress the overflowing operation so it cannot throw | Fails | Fails |

The last row is an assertion-scope probe, not a Queue implementation that accepted a 65th write.

## Full-run limitations and follow-up

The first full run in the main workspace failed the unchanged `TestBinarySearch` disk-space diagnostic (2.79 GiB filesystem free-space decrease). A repeat hit that diagnostic in `StoreAppenderInternalWriteBytesTest` and `TestBinarySearch` (5.55 and 4.16 GiB). The changed overflow test passed in both runs.

The unchanged binary-search class then passed all 42 cases in isolation. Inspection confirmed that `QueueTestCommon.checkSpaceUsed()` measures free space for the whole filesystem, not directory-owned usage.

A fresh detached checkout of the same commit on the separate `/tmp` filesystem passed the complete normal `clean verify`. No checks were disabled, tests excluded, source changed, or fork settings altered. All failed and successful logs/XML were retained. This supports an environmental/disk-accounting explanation but does not establish exactly which other allocations caused the failures.

Full-suite skips include unavailable huge-page coverage. Local results are not an attestation of remote platform CI. Existing shaded-resource warnings remain.

<details>
<summary>Successful full-run receipt and resolved snapshot identities</summary>

```text
Tests run: 1114, Failures: 0, Errors: 0, Skipped: 52
BINARY COMPATIBILITY ENFORCER - SUCCESSFUL - chronicle-queue
BUILD SUCCESS
Total time: 01:51 min
Finished at: 2026-09-08T07:10:49+01:00
```

Selected resolved dependencies: Core 2026.6, Bytes 2026.4, Wire 2026.10-SNAPSHOT, Threads 2026.3; JUnit 4.13.2 and Vintage 5.10.0. Parent and third-party BOM remain 2026.0; Chronicle BOM remains 2026.0-SNAPSHOT.

SHA-256 of the actual local snapshot inputs:

- Chronicle BOM POM: `5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0`.
- Wire JAR: `77afd5d4236c738c25980c268858879b6c929e70486b829b5e4a434dd6b31c87`.

Both were locally installed snapshots; no remote timestamped identity is claimed. Resolved-input hashes were rechecked after verification. XML reports were archived separately before subsequent test runs.

</details>
