### PR TITLE
QUEUE-149: Strengthen empty-appender index rejection tests

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueTest.java
@@ -1246,23 +1246,23 @@ public class SingleChronicleQueueTest extends QueueTestCommon {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testLastWrittenIndexPerAppenderNoData() {
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = chronicle.createAppender()) {
-            appender.lastIndexAppended();
-            fail();
+            assertThrows("lastIndexAppended() must reject an appender with no written messages",
+                    IllegalStateException.class, appender::lastIndexAppended);
         }
     }
 
-    @Test(expected = IllegalStateException.class) //: no messages written
+    @Test //: no messages written
     public void testNoMessagesWritten() {
         try (final ChronicleQueue chronicle = builder(getTmpDir(), this.wireType)
                 .build();
              final ExcerptAppender appender = chronicle.createAppender()) {
-
-            appender.lastIndexAppended();
+            assertThrows("A new appender must not report a last-written index",
+                    IllegalStateException.class, appender::lastIndexAppended);
         }
     }
 


### PR DESCRIPTION
## Purpose

Extract the empty-appender assertion-scope improvement from #1702 without migrating shared test infrastructure.

The old whole-method expected exception could pass when queue opening or appender acquisition failed. It also accepted a cleanup failure suppressed behind the expected index-query exception.

## Scope

Two methods in one file, based on develop `d1cc3c87a04539ee1d3aedb7696f39bc2261f68e`:

- Only `lastIndexAppended()` can satisfy the expected `IllegalStateException`.
- Queue opening and appender acquisition must succeed; cleanup failures fail the test.
- Both assertions have descriptive failure messages.
- Both existing methods retain all three constructor/provider rows: BINARY_LIGHT/named, BINARY/unnamed, BINARY_LIGHT/unnamed.

JUnit 4, public test visibility, the existing provider, shared lifecycle and timeout remain unchanged. No production, POM, dependency or engine changes. This does not import #1702's missed parameterisation or claim Jupiter migration is complete.

## Local validation

Pinned head: `8496f154607eceacdaafd8fe236a1249d759b693`.

Linux x86_64, Maven 3.9.11, Ubuntu OpenJDK 21.0.12:

- `mvn -B -ntp -nsu clean verify -l <unique-log>`: **1,114 tests reported, zero failures/errors, 52 skipped; BUILD SUCCESS**.
- Compatibility enforcer against Queue 2026.0 passed. This is the production-library check, not a downstream test-JAR consumer run.
- `mvn -B -ntp -nsu '-Dtest=SingleChronicleQueueTest#testLastWrittenIndexPerAppenderNoData+testNoMessagesWritten' test -l <unique-log>`: **six tests passed**, with all six method/parameter names present in XML.
- The same focused command passed on Ubuntu OpenJDK 8u502.

Twenty supplemental before/after derived test cases ran through JUnit 4 and the existing fixture/provider: **60 actual invocations**, all expected outcomes matched.

| Controlled condition | Old tests | Strengthened tests |
| --- | --- | --- |
| Actual empty-appender query | Pass | Pass |
| Queue-opening exception | False pass | Fail |
| Appender-acquisition exception | False pass | Fail |
| Real appender closes, then injected close exception | Pass despite cleanup failure | Fail; appender closed once per invocation |
| Replace the required rejection with a non-throwing operation | Fail | Fail |

These probes use extracted/overridden test bodies; controlled replacements and a delegating appender proxy are test-harness injections, not production-library mutations. They are supplemental evidence, not 60 newly committed tests.

<details>
<summary>Build receipt and snapshot inputs</summary>

```text
Tests run: 1114, Failures: 0, Errors: 0, Skipped: 52
BINARY COMPATIBILITY ENFORCER - SUCCESSFUL - chronicle-queue
BUILD SUCCESS
Total time: 02:21 min
Finished at: 2026-09-08T10:25:31+01:00
```

Parent/third-party BOM: 2026.0; Chronicle BOM: 2026.0-SNAPSHOT.
Resolved Core 2026.6, Bytes 2026.4, Wire 2026.10-SNAPSHOT, Threads 2026.3;
JUnit 4.13.2, Vintage 5.10.0, Surefire 3.1.2.

SHA-256:
- Chronicle BOM POM: `5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0`.
- Wire JAR: `77afd5d4236c738c25980c268858879b6c929e70486b829b5e4a434dd6b31c87`.

These are locally installed snapshot identities, not immutable source provenance.
All 92 recorded dependency/selected-POM inputs were unchanged across the full run.
Raw logs, per-run XML, effective POM, dependency list, input hashes, snapshot copies
and probe sources/output are retained in the local evidence bundle, not publicly attached here.

</details>

The full build ran from a clean build directory in a separate /tmp worktree. No tests were newly disabled or excluded from full verification. Existing skips include unavailable huge-page coverage; existing warnings remain. These are local results, not a claim that remote platform CI has passed.
