### PR TITLE
QUEUE-149: Strengthen access-after-close rejection test

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/TableDirectoryListingTest.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class TableDirectoryListingTest extends QueueTestCommon {
     private DirectoryListing listing;
@@ -58,10 +59,11 @@ public class TableDirectoryListingTest extends QueueTestCommon {
         Closeable.closeQuietly(tablestore, tablestoreReadOnly, listing, listingReadOnly);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldBlowUpIfClosed() {
         listing.close();
-        listing.getMaxCreatedCycle();
+        assertThrows("Reading the maximum cycle must be rejected after the listing is closed",
+                IllegalStateException.class, listing::getMaxCreatedCycle);
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Extract the closed-directory-listing test improvement from #1702, independently of the JUnit migration.

Previously, `@Test(expected = IllegalStateException.class)` covered both `listing.close()` and the later getter. A close failure could satisfy a test intended to prove that access after closing is rejected.

## Change

One method in one file, based on develop `d1cc3c87a04539ee1d3aedb7696f39bc2261f68e`:

- Require `listing.close()` to complete normally.
- Assert rejection only from `getMaxCreatedCycle()`.
- Include a descriptive assertion failure message.

JUnit 4, public visibility, setup/cleanup, the shared timeout, POMs and production sources are unchanged. This is a test-quality extraction, not a completed Jupiter migration.

## Local validation

Pinned head: `d82cb54417afdd6cbc59b79cea33f6ce15390ac0`.

Linux x86_64, Maven 3.9.11, Ubuntu OpenJDK 21.0.12:

- `mvn -B -ntp -nsu clean verify -l <unique-log>`: **1,114 tests reported, zero failures/errors, 52 skipped; BUILD SUCCESS**.
- Compatibility enforcer against Queue 2026.0 passed (production-library report only).
- `mvn -B -ntp -nsu -Dtest=TableDirectoryListingTest test -l <unique-log>`: **four tests passed** on Java 21.0.12 and Java 8u502.

Six supplemental before/after copies of the actual test ran through JUnit 4 and the existing fixture; all six expected outcomes matched:

| Controlled condition | Old test | Strengthened test |
| --- | --- | --- |
| Actual close followed by rejected getter | Pass | Pass |
| Inject matching exception in place of close | False pass | Fail |
| Replace getter rejection with a non-throwing operation | Fail | Fail |

These are derived test-body probes, not production mutations or six newly committed tests.

<details>
<summary>Run receipt and resolved snapshot identities</summary>

```text
Tests run: 1114, Failures: 0, Errors: 0, Skipped: 52
BINARY COMPATIBILITY ENFORCER - SUCCESSFUL - chronicle-queue
BUILD SUCCESS
Total time: 02:33 min
Finished at: 2026-09-08T10:29:01+01:00
```

Parent/third-party BOM remain 2026.0; Chronicle BOM remains 2026.0-SNAPSHOT.
Resolved Core 2026.6, Bytes 2026.4, Wire 2026.10-SNAPSHOT and Threads 2026.3;
JUnit 4.13.2, Vintage 5.10.0, Surefire 3.1.2.

SHA-256:
- Chronicle BOM POM: `5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0`.
- Wire JAR: `77afd5d4236c738c25980c268858879b6c929e70486b829b5e4a434dd6b31c87`.

Locally installed snapshots; no immutable source provenance is claimed.
All 92 recorded dependency/selected-POM input hashes were unchanged across verification.
Per-run XML, logs, effective POM, dependencies, snapshot copies and probe sources/output
are retained locally, not publicly attached here.

</details>

No full-suite tests were newly disabled or excluded. The 52 existing skips include unavailable huge-page coverage; existing warnings remain. No local Windows/macOS/ARM execution or successful remote-CI claim is made.
