### PR TITLE
QUEUE-149: Strengthen configuration rejection tests

### DIFF
--- a/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/RollingResourcesCacheTest.java
@@ -246,11 +246,12 @@ public class RollingResourcesCacheTest extends QueueTestCommon {
         doTestCycleAndResourceNames(BIG_NEGATIVE_RELATIVE_EPOCH, WeeklyRollCycle.INSTANCE, 354, "1976287");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void parseIncorrectlyFormattedName() {
         final RollingResourcesCache cache =
                 new RollingResourcesCache(HOURLY, PM_EPOCH, File::new, File::getName);
-        cache.parseCount("foobar-qux");
+        assertThrows("Parsing a malformed roll filename must be rejected",
+                RuntimeException.class, () -> cache.parseCount("foobar-qux"));
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/impl/single/SingleChronicleQueueBuilderTest.java
@@ -70,12 +70,12 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
         assertTrue(new File(TEST_QUEUE_FILE).length() < (1 << 20));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfQueuePathIsFileWithIncorrectExtension() throws IOException {
         final File tempFile = File.createTempFile(SingleChronicleQueueBuilderTest.class.getSimpleName(), ".txt");
         tempFile.deleteOnExit();
-        SingleChronicleQueueBuilder.
-                binary(tempFile);
+        assertThrows("A queue path naming a file with a non-queue extension must be rejected",
+                IllegalArgumentException.class, () -> SingleChronicleQueueBuilder.binary(tempFile));
     }
 
     @Test
@@ -89,13 +89,14 @@ public class SingleChronicleQueueBuilderTest extends QueueTestCommon {
         assertEquals(98765, b2.bufferCapacity());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAllNullFieldsShouldFailWithDifferentHierarchy() {
         OneExtendedBuilder b1 = new OneExtendedBuilder();
         OtherExtendedBuilder b2 = new OtherExtendedBuilder();
         b2.bufferCapacity(98765);
         b1.blockSize(1234567);
-        b2.setAllNullFields(b1);
+        assertThrows("Copying builder fields between different subclass hierarchies must be rejected",
+                IllegalArgumentException.class, () -> b2.setAllNullFields(b1));
     }
 
     static class OneExtendedBuilder extends SingleChronicleQueueBuilder {

--- a/src/test/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpecTest.java
+++ b/src/test/java/net/openhft/chronicle/queue/internal/domestic/QueueOffsetSpecTest.java
@@ -72,9 +72,10 @@ public class QueueOffsetSpecTest {
         QueueOffsetSpec.parse("INVALID;foo");
     }
 
-    @Test(expected = java.time.DateTimeException.class)
+    @Test
     public void parseRollTimeWithInvalidZoneFailsValidation() {
         QueueOffsetSpec spec = QueueOffsetSpec.parse("ROLL_TIME;12:00;Invalid/Zone");
-        spec.validate();
+        assertThrows("An invalid roll-time zone must be rejected during validation",
+                java.time.DateTimeException.class, spec::validate);
     }
 }


### PR DESCRIPTION
## Purpose

Extract four configuration-test improvements from #1702 without migrating JUnit or shared fixtures. Each test must reject the intended operation, not pass because preparation threw the same exception.

## Scope

Four existing test methods in three files, based on develop
`d1cc3c87a04539ee1d3aedb7696f39bc2261f68e`:

| Test | What the narrowed assertion proves |
| --- | --- |
| QueueOffsetSpecTest: invalid roll-time zone | Parsing succeeds; `validate()` rejects the zone. |
| RollingResourcesCacheTest: malformed roll filename | Cache construction succeeds; `parseCount()` rejects the filename. |
| SingleChronicleQueueBuilderTest: wrong file extension | The temporary file is created; `binary(tempFile)` rejects the path. |
| SingleChronicleQueueBuilderTest: different builder hierarchy | Builder construction/configuration succeeds; `setAllNullFields()` rejects the incompatible hierarchy. |

Every `assertThrows` has a descriptive failure message. Expected exception types remain unchanged, including the existing broad RuntimeException expectation for the malformed filename.

No production, POM, dependency, engine, public-visibility, parameterisation, timeout or lifecycle changes. Other mechanical annotation conversions are deliberately excluded. This is preparatory test strengthening, not a completed Jupiter migration.

## Local validation

Pinned head: `ddd61753e3ddcd896a15fb371cfa165ca7a25a85`.

Linux x86_64, Maven 3.9.11, Ubuntu OpenJDK 21.0.12:

- `mvn -B -ntp -nsu clean verify -l <unique-log>`: **1,114 tests reported, zero failures/errors, 52 skipped; BUILD SUCCESS**.
- Compatibility enforcer against Queue 2026.0 passed (production-library report only).
- `mvn -B -ntp -nsu -Dtest=QueueOffsetSpecTest,RollingResourcesCacheTest,SingleChronicleQueueBuilderTest test -l <unique-log>`: **27 tests passed** on both Java 21.0.12 and Java 8u502.

Twenty-four supplemental derived before/after cases ran through JUnit 4; all expected outcomes matched. For each of the four methods:

| Controlled condition | Old test | Strengthened test |
| --- | --- | --- |
| Actual intended rejection | Pass | Pass |
| Inject matching exception in the preparation operation | False pass | Fail |
| Replace intended rejection with a non-throwing operation | Fail | Fail |

The probes derive copies from the real test sources and preserve their existing fixtures. These are test-body injections, not production mutations or 24 newly committed tests.

<details>
<summary>Run receipt and resolved snapshot identities</summary>

```text
Tests run: 1114, Failures: 0, Errors: 0, Skipped: 52
BINARY COMPATIBILITY ENFORCER - SUCCESSFUL - chronicle-queue
BUILD SUCCESS
Total time: 02:19 min
Finished at: 2026-09-08T10:32:19+01:00
```

Parent/third-party BOM remain 2026.0; Chronicle BOM remains 2026.0-SNAPSHOT.
Resolved Core 2026.6, Bytes 2026.4, Wire 2026.10-SNAPSHOT, Threads 2026.3;
JUnit 4.13.2, Vintage 5.10.0, Surefire 3.1.2.

SHA-256:
- Chronicle BOM POM: `5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0`.
- Wire JAR: `77afd5d4236c738c25980c268858879b6c929e70486b829b5e4a434dd6b31c87`.

Locally installed snapshots; no immutable source provenance is claimed.
All 92 recorded dependency/selected-POM inputs were unchanged across verification.
Logs, per-run XML, effective POM, dependency list, input hashes, snapshot copies
and probe sources/output are retained locally, not publicly attached here.

</details>

No full-suite tests were newly disabled or excluded. Existing skips include unavailable huge-page coverage; existing warnings remain. Local success does not establish supported-platform or remote-CI success.
